### PR TITLE
fix(ci/windows): drop test-out.txt redirect — output goes to job log

### DIFF
--- a/.github/workflows/golang-test-windows.yml
+++ b/.github/workflows/golang-test-windows.yml
@@ -76,7 +76,16 @@ jobs:
       - run: echo "files=$(go list ./... | ForEach-Object { $_ } | Where-Object { $_ -notmatch '/management' })" >> $env:GITHUB_ENV
 
       - name: test
-        run: PsExec64 -s -w ${{ github.workspace }} cmd.exe /c "${{ env.goexe }} test -tags=devcert -timeout 10m -p 1 ${{ env.files }} > test-out.txt 2>&1"
-      - name: test output
-        if: ${{ always() }}
-        run: Get-Content test-out.txt
+        # Direct PsExec64 → go.exe, without the cmd.exe /c "..."
+        # wrapper. The previous form redirected to test-out.txt and
+        # the next step tried to Get-Content it back, but the file
+        # was either never created (cmd.exe command-line length
+        # limit truncating the huge package list before the redirect
+        # parsed) or was SYSTEM-owned and unreadable to the runner
+        # user — either way every Windows run failed with
+        # "test-out.txt does not exist" and the underlying go test
+        # error stayed invisible. PsExec64 forwards the remote
+        # process stdout/stderr to its own stdout, which Actions
+        # captures into the job log natively — no intermediate file
+        # needed.
+        run: PsExec64 -s -nobanner -w ${{ github.workspace }} ${{ env.goexe }} test -tags=devcert -timeout 10m -p 1 ${{ env.files }}


### PR DESCRIPTION
## Summary

Closes the visibility gap from #21. Windows \`Client / Unit\` has been failing on every commit for ~10 days with the same misleading error:

\`\`\`
Get-Content: Cannot find path 'D:\a\openzro\openzro\test-out.txt' because it does not exist.
\`\`\`

The actual \`go test\` failure was hidden behind the redirect-then-read-back pattern. Removing the indirection makes the real error visible — that's the prerequisite for fixing whatever the underlying test issue is.

## What changed

\`\`\`diff
- run: PsExec64 -s -w ... cmd.exe /c \"... go test ... > test-out.txt 2>&1\"
- # ... and a separate step that does Get-Content test-out.txt
+ run: PsExec64 -s -nobanner -w ... go.exe test ...
\`\`\`

PsExec64 already forwards the remote process's stdout/stderr to its own stdout. GitHub Actions captures that into the job log natively. No intermediate file, no SYSTEM ACL on a file the runner user can't read, no cmd.exe command-line length limit chopping off the redirect.

## What this PR does NOT fix

Whatever the underlying \`go test\` failure is. With this change merged, the next Windows run will surface the actual error, and we can diagnose it from there. Likely candidates given the package list:

- A package with \`//go:build !windows\` constraints missing somewhere it should be present
- A test using \`netlink\` or platform-specific APIs without the right build tag
- A vendored dependency drift since the last green Windows run (the previous green from before this regression hit would tell us)

## Test plan

- [ ] CI runs on this PR — Windows step output is now visible in the job log (replaces the misleading \"file does not exist\" with the actual go test error)
- [ ] Root cause of the underlying Windows test failure follows in a separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)