### PR TITLE
chore(lint): suppress benign golangci findings on dev-seed / stubs / factory

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -63,6 +63,21 @@ linters-settings:
     enable:
       - nilness
 
+  misspell:
+    # Some openZro files (BACEN compliance docs, cluster/nats comments,
+    # brand notes) are intentionally written in Portuguese. misspell's
+    # English dictionary flags them as typos — `momento` → `memento`,
+    # `ser` → `set`, etc. Whitelist the PT words we ship deliberately.
+    # codespell already has the equivalent ignore_words_list in
+    # .github/workflows/golangci-lint.yml; keep the two in sync if
+    # adding new entries.
+    locale: US
+    ignore-words:
+      - momento
+      - ser
+      - vai
+      - controles
+
   revive:
     rules:
       - name: exported
@@ -119,12 +134,32 @@ issues:
     - path: signal/cmd/root\.go
       linters:
         - forbidigo
+    # CLI dev tool — fmt.Print* is the user-facing output, not log spam.
+    - path: scripts/dev-seed-flow-events/main\.go
+      linters:
+        - forbidigo
     - path: sharedsock/filter\.go
       linters:
       - unused
     - path: client/firewall/iptables/rule\.go
       linters:
       - unused
+    # Stubs under a no-cgo build tag — intentionally unused outside
+    # the CGO build path. The real implementations live in
+    # flow/store/archive/duckdb.go (cgo build tag).
+    - path: flow/store/archive/duckdb_stub\.go
+      linters:
+      - unused
+    # Constants like `tokenAuth`, `bucketSecret`, `archivePass` that
+    # gosec flags as G101 hardcoded-credentials. None are credentials —
+    # they're identifier suffixes that happen to match gosec's
+    # heuristic. The actual secrets come from environment / config.
+    - path: flow/store/archive/factory\.go
+      linters:
+      - gosec
+    - path: flow/sinks/factory\.go
+      linters:
+      - gosec
     - path: test\.go
       linters:
       - mirror


### PR DESCRIPTION
## Summary

Trims the easy / clearly-benign chunk of the ~30+ golangci-lint findings that surfaced once #19 unblocked the Lint workflow. All entries here are documented false-positives or intentional-but-flagged patterns; the linter stays strict on everything else.

Partial close of #20.

## What's excluded + why

| Path | Linter | Why benign |
|---|---|---|
| \`scripts/dev-seed-flow-events/main.go\` | \`forbidigo\` | CLI dev tool — \`fmt.Print*\` is the user-facing output. Mirrors existing exclusion for \`management/cmd/root.go\` and \`signal/cmd/root.go\`. |
| \`flow/store/archive/duckdb_stub.go\` | \`unused\` | Stubs under a no-cgo build tag, intentionally unused outside the CGO build path. Real impl in \`duckdb.go\`. |
| \`flow/store/archive/factory.go\` | \`gosec\` | Constants named \`tokenAuth\` / \`bucketSecret\` / \`archivePass\` — G101 heuristic on suffix, not actual credentials. |
| \`flow/sinks/factory.go\` | \`gosec\` | Same pattern as above. |

## Misspell ignore-words for PT-BR

Extends \`linters-settings.misspell.ignore-words\` with \`momento\`, \`ser\`, \`vai\`, \`controles\` — Portuguese words we use deliberately in BACEN compliance docs and cluster/nats comments. Mirrors the codespell ignore_words_list already configured in \`.github/workflows/golangci-lint.yml\`.

## What's NOT in this PR (separate follow-ups)

The \"real findings worth fixing\" from #20:

- **\`exitAfterDefer\`** at \`scripts/dev-seed-flow-events/main.go:159\` — real bug (\`log.Fatalf\` after \`defer s.Close()\` skips the close). One-line fix; separate PR keeps blame clean.
- **\`mdm.MDMProvider\` → \`mdm.Provider\`** rename (revive). Public-API identifier change; ripple to callers needs a focused PR.

## Test plan

- [ ] CI run on this PR — Lint workflow's golangci-lint step shows fewer findings (the 4 paths above + the misspell hits drop out)
- [ ] No regression on the wider lint coverage — the strict ruleset stays applied to everything else
- [ ] Once findings are at zero, future PR can drop the \`continue-on-error: true\` from \`.github/workflows/golangci-lint.yml\` and move Lint back to a hard gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)