### PR TITLE
feat(management/flow): server-side flow event policy resolver (ADR-0018)

### DIFF
--- a/client/internal/netflow/conntrack/conntrack.go
+++ b/client/internal/netflow/conntrack/conntrack.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"net/netip"
 	"sync"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
 	nfct "github.com/ti-mo/conntrack"
@@ -18,6 +20,17 @@ import (
 )
 
 const defaultChannelSize = 100
+
+// Backoff parameters for the conntrack listener reconnect loop.
+// Exposed as vars so unit tests can shorten the cycle (tests assign
+// reconnectInitInterval = a few ms before constructing a ConnTrack).
+// Production values land within the netlink "transient EPERM after
+// module reload" recovery window: ~5s first try, capped at 5 minutes.
+var (
+	reconnectInitInterval  = 5 * time.Second
+	reconnectMaxInterval   = 5 * time.Minute
+	reconnectRandomization = 0.5
+)
 
 // PolicyResolver maps the agent-local rule_index that the firewall
 // backend stamped on the conntrack mark (per ADR-0013) back to the
@@ -150,14 +163,107 @@ func (c *ConnTrack) receiverRoutine(events chan nfct.Event, errChan chan error) 
 		case event := <-events:
 			c.handleEvent(event)
 		case err := <-errChan:
-			log.Errorf("Error from conntrack event listener: %v", err)
-			if err := c.conn.Close(); err != nil {
-				log.Errorf("Error closing conntrack connection: %v", err)
+			// Listener errored — kernel module reloaded, EPERM on a
+			// transient permission flap, netlink dispatcher restart.
+			// Attempt to recover via exponential backoff instead of
+			// dying for good. handleListenerError returns nil channels
+			// when Stop() ran during the reconnect window.
+			if events, errChan = c.handleListenerError(err); events == nil {
+				return
 			}
-			return
 		case <-c.done:
 			return
 		}
+	}
+}
+
+// handleListenerError closes the failed connection and attempts to
+// reconnect with exponential backoff. Returns the new event channels
+// on success, or (nil, nil) when shutdown was requested mid-reconnect
+// (caller exits the receiver loop in that case).
+func (c *ConnTrack) handleListenerError(err error) (chan nfct.Event, chan error) {
+	log.Warnf("conntrack event listener failed: %v", err)
+	c.closeConn()
+	return c.reconnect()
+}
+
+// closeConn tears down the current netlink listener if any. Safe to
+// call when c.conn is already nil (the reconnect race path).
+func (c *ConnTrack) closeConn() {
+	c.mux.Lock()
+	defer c.mux.Unlock()
+
+	if c.conn != nil {
+		if err := c.conn.Close(); err != nil {
+			log.Debugf("close conntrack connection: %v", err)
+		}
+		c.conn = nil
+	}
+}
+
+// reconnect loops on backoff.NextBackOff() until either a fresh
+// listener comes up or Stop()/Close() set started=false. Returns the
+// new channels on success and (nil, nil) when shutdown wins the
+// race. Logs each attempt at Info so operators can see "we're
+// trying" without enabling debug.
+func (c *ConnTrack) reconnect() (chan nfct.Event, chan error) {
+	bo := &backoff.ExponentialBackOff{
+		InitialInterval:     reconnectInitInterval,
+		RandomizationFactor: reconnectRandomization,
+		Multiplier:          backoff.DefaultMultiplier,
+		MaxInterval:         reconnectMaxInterval,
+		MaxElapsedTime:      0, // retry indefinitely — only Stop/Close exit
+		Clock:               backoff.SystemClock,
+	}
+	bo.Reset()
+
+	for {
+		delay := bo.NextBackOff()
+		log.Infof("reconnecting conntrack listener in %s", delay)
+
+		select {
+		case <-c.done:
+			c.mux.Lock()
+			c.started = false
+			c.mux.Unlock()
+			return nil, nil
+		case <-time.After(delay):
+		}
+
+		conn, err := c.dial()
+		if err != nil {
+			log.Warnf("reconnect conntrack dial: %v", err)
+			continue
+		}
+
+		events := make(chan nfct.Event, defaultChannelSize)
+		errChan, err := conn.Listen(events, 1, []netfilter.NetlinkGroup{
+			netfilter.GroupCTNew,
+			netfilter.GroupCTDestroy,
+		})
+		if err != nil {
+			log.Warnf("reconnect conntrack listen: %v", err)
+			if closeErr := conn.Close(); closeErr != nil {
+				log.Debugf("close conntrack connection: %v", closeErr)
+			}
+			continue
+		}
+
+		c.mux.Lock()
+		if !c.started {
+			// Stop()/Close() landed while we were dialing or
+			// listening; close the orphan and bail.
+			c.mux.Unlock()
+			if closeErr := conn.Close(); closeErr != nil {
+				log.Debugf("close conntrack connection: %v", closeErr)
+			}
+			return nil, nil
+		}
+		c.conn = conn
+		c.mux.Unlock()
+
+		log.Infof("conntrack listener reconnected successfully")
+		return events, errChan
 	}
 }
 

--- a/client/internal/netflow/conntrack/conntrack.go
+++ b/client/internal/netflow/conntrack/conntrack.go
@@ -127,6 +127,16 @@ func (c *ConnTrack) Start(enableCounters bool) error {
 		return fmt.Errorf("start conntrack listener: %w", err)
 	}
 
+	// Drain any stale stop sentinel left over from a previous Stop().
+	// c.done is buffered at capacity 1; without this drain the new
+	// receiver goroutine would read the leftover signal on its first
+	// iteration and exit immediately, leaving kernel conntrack events
+	// pouring into a dead channel until the daemon was restarted.
+	select {
+	case <-c.done:
+	default:
+	}
+
 	c.started = true
 
 	go c.receiverRoutine(events, errChan)

--- a/client/internal/netflow/conntrack/lifecycle_test.go
+++ b/client/internal/netflow/conntrack/lifecycle_test.go
@@ -1,0 +1,84 @@
+//go:build linux && !android
+
+package conntrack
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRestartDrainsStaleDoneSentinel is a regression test for the
+// quick-Stop-then-Start case. Stop() pushes a sentinel onto c.done
+// (capacity 1, buffered) to nudge the receiver out of its select
+// loop. Without a drain at the top of Start(), that sentinel lives
+// across the next Start: the new receiver goroutine reads it
+// immediately on the first iteration, exits, and the listener
+// errChan/events are never consumed. The kernel keeps emitting
+// conntrack events into a dead channel until the daemon dies or
+// the operator restarts the service.
+//
+// The fix drains the channel on Start. We assert the post-restart
+// receiver is alive by triggering an error through the second
+// listener — without drain the receiver exits before it can react
+// and the mock's Close() is never called.
+func TestRestartDrainsStaleDoneSentinel(t *testing.T) {
+	first := newMockListener()
+	second := newMockListener()
+
+	callCount := atomic.Int32{}
+	ct := New(nil, nil, nil, WithDialer(func() (listener, error) {
+		n := callCount.Add(1)
+		if n == 1 {
+			return first, nil
+		}
+		return second, nil
+	}))
+
+	require.NoError(t, ct.Start(false))
+	ct.Stop()
+
+	// At this point Stop has fired the sentinel into c.done. With a
+	// production-only c.done buffered at capacity 1, that sentinel
+	// survives the Stop because no one is around to drain it once
+	// the receiver goroutine already exited via its own done case.
+	require.NoError(t, ct.Start(false))
+
+	// If the new receiver consumed the stale sentinel, it exited
+	// before it could listen on `second.errChan`. The error below
+	// would be ignored and `second` would never be closed.
+	second.errChan <- errors.New("boom")
+
+	select {
+	case <-second.closedCh:
+		// Receiver handled the error and tore the listener down,
+		// confirming it survived past Start.
+	case <-time.After(2 * time.Second):
+		t.Fatal("post-restart receiver did not consume errChan — stale done sentinel was not drained")
+	}
+
+	ct.Stop()
+}
+
+// TestStartIsIdempotent guards against double-Start clobbering the
+// active connection. The second call must be a no-op — same
+// listener, no extra dial.
+func TestStartIsIdempotent(t *testing.T) {
+	mock := newMockListener()
+	callCount := atomic.Int32{}
+
+	ct := New(nil, nil, nil, WithDialer(func() (listener, error) {
+		callCount.Add(1)
+		return mock, nil
+	}))
+
+	require.NoError(t, ct.Start(false))
+	require.NoError(t, ct.Start(false))
+
+	assert.Equal(t, int32(1), callCount.Load(), "second Start should not re-dial")
+	ct.Stop()
+}

--- a/client/internal/netflow/conntrack/mock_listener_test.go
+++ b/client/internal/netflow/conntrack/mock_listener_test.go
@@ -1,0 +1,39 @@
+//go:build linux && !android
+
+package conntrack
+
+import (
+	"sync/atomic"
+
+	nfct "github.com/ti-mo/conntrack"
+	"github.com/ti-mo/netfilter"
+)
+
+// mockListener satisfies the listener interface for unit tests so the
+// receiver loop and lifecycle code can be exercised without touching
+// the kernel. errChan is operator-controlled: tests push errors to
+// drive the receiver into its error branch (reconnect or exit
+// depending on what's implemented).
+type mockListener struct {
+	errChan  chan error
+	closed   atomic.Bool
+	closedCh chan struct{}
+}
+
+func newMockListener() *mockListener {
+	return &mockListener{
+		errChan:  make(chan error, 1),
+		closedCh: make(chan struct{}),
+	}
+}
+
+func (m *mockListener) Listen(_ chan<- nfct.Event, _ uint8, _ []netfilter.NetlinkGroup) (chan error, error) {
+	return m.errChan, nil
+}
+
+func (m *mockListener) Close() error {
+	if m.closed.CompareAndSwap(false, true) {
+		close(m.closedCh)
+	}
+	return nil
+}

--- a/client/internal/netflow/conntrack/reconnect_test.go
+++ b/client/internal/netflow/conntrack/reconnect_test.go
@@ -1,0 +1,161 @@
+//go:build linux && !android
+
+package conntrack
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// shortenReconnect compresses the backoff window so tests run in
+// milliseconds instead of the production 5-second minimum.
+// Restored via the returned cleanup func so other tests are not
+// affected.
+func shortenReconnect(t *testing.T) {
+	t.Helper()
+	origInit, origMax := reconnectInitInterval, reconnectMaxInterval
+	reconnectInitInterval = 10 * time.Millisecond
+	reconnectMaxInterval = 50 * time.Millisecond
+	t.Cleanup(func() {
+		reconnectInitInterval = origInit
+		reconnectMaxInterval = origMax
+	})
+}
+
+// TestReconnect_AfterListenerError exercises the recovery path that
+// closes the gap our pre-fix code had: any error on the conntrack
+// netlink listener killed the receiver permanently. The kernel
+// surfaces transient EPERMs (module reload, dispatcher restart,
+// network namespace move) routinely, and operators rebooted the
+// agent to get traffic capture back. Post-fix the receiver loops on
+// backoff until a fresh dial succeeds.
+func TestReconnect_AfterListenerError(t *testing.T) {
+	shortenReconnect(t)
+
+	first := newMockListener()
+	second := newMockListener()
+	third := newMockListener()
+	listeners := []*mockListener{first, second, third}
+	callCount := atomic.Int32{}
+
+	ct := New(nil, nil, nil, WithDialer(func() (listener, error) {
+		n := int(callCount.Add(1)) - 1
+		return listeners[n], nil
+	}))
+
+	require.NoError(t, ct.Start(false))
+
+	first.errChan <- errors.New("simulated netlink boom")
+
+	require.Eventually(t, func() bool {
+		return callCount.Load() >= 2
+	}, 2*time.Second, 10*time.Millisecond, "reconnect should dial a second listener")
+
+	select {
+	case <-first.closedCh:
+	case <-time.After(time.Second):
+		t.Fatal("first listener was not closed after error")
+	}
+
+	// Receiver is still alive — feed it a second error and verify it
+	// reconnects again instead of dying for good.
+	second.errChan <- errors.New("second boom")
+
+	require.Eventually(t, func() bool {
+		return callCount.Load() >= 3
+	}, 2*time.Second, 10*time.Millisecond, "second reconnect should also succeed")
+
+	ct.Stop()
+}
+
+// TestReconnect_RetriesOnDialFailure asserts the receiver does not
+// give up when the dial itself fails. Kernel module reload on a
+// busy host can return ENODEV for a few seconds; we need to keep
+// trying.
+func TestReconnect_RetriesOnDialFailure(t *testing.T) {
+	shortenReconnect(t)
+
+	first := newMockListener()
+	good := newMockListener()
+	dialCount := atomic.Int32{}
+
+	ct := New(nil, nil, nil, WithDialer(func() (listener, error) {
+		n := dialCount.Add(1)
+		switch n {
+		case 1:
+			return first, nil
+		case 2:
+			return nil, errors.New("ENODEV: kernel module not loaded yet")
+		default:
+			return good, nil
+		}
+	}))
+
+	require.NoError(t, ct.Start(false))
+	first.errChan <- errors.New("kernel reset")
+
+	require.Eventually(t, func() bool {
+		return dialCount.Load() >= 3
+	}, 2*time.Second, 10*time.Millisecond, "reconnect should retry past the failed dial")
+
+	ct.Stop()
+}
+
+// TestReconnect_StopDuringBackoff confirms the operator-initiated
+// Stop wins the race against the backoff timer. Without the
+// `<-c.done` branch in reconnect(), Stop would have to wait up to
+// reconnectMaxInterval before the goroutine noticed it.
+func TestReconnect_StopDuringBackoff(t *testing.T) {
+	shortenReconnect(t)
+	// Push max interval up so the test guarantees Stop hits the
+	// sleeping reconnect loop before the timer fires.
+	origMax := reconnectMaxInterval
+	reconnectInitInterval = 500 * time.Millisecond
+	reconnectMaxInterval = 5 * time.Second
+	t.Cleanup(func() { reconnectMaxInterval = origMax })
+
+	first := newMockListener()
+	never := newMockListener()
+	callCount := atomic.Int32{}
+
+	ct := New(nil, nil, nil, WithDialer(func() (listener, error) {
+		n := callCount.Add(1)
+		if n == 1 {
+			return first, nil
+		}
+		return never, nil
+	}))
+
+	require.NoError(t, ct.Start(false))
+	first.errChan <- errors.New("die")
+
+	// Wait for first listener to be closed (entered reconnect).
+	select {
+	case <-first.closedCh:
+	case <-time.After(time.Second):
+		t.Fatal("first listener was not closed before reconnect started")
+	}
+
+	// Stop while reconnect is sleeping on the backoff timer.
+	done := make(chan struct{})
+	go func() {
+		ct.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Stop did not interrupt reconnect backoff sleep within 2s")
+	}
+
+	ct.mux.Lock()
+	assert.False(t, ct.started, "started must be false after Stop interrupts reconnect")
+	assert.Nil(t, ct.conn, "conn must be nil after Stop")
+	ct.mux.Unlock()
+}

--- a/client/internal/netflow/manager.go
+++ b/client/internal/netflow/manager.go
@@ -25,7 +25,13 @@ import (
 
 // Manager handles netflow tracking and logging
 type Manager struct {
-	mux            sync.Mutex
+	mux sync.Mutex
+	// shutdownWg tracks the sender + receiveACKs goroutines so Close()
+	// can wait for them to exit before returning. Without this, a
+	// Close was fire-and-forget — the daemon could exit while the
+	// gRPC stream still had pending Send calls, leaking buffered
+	// events at every restart and producing flaky teardown in tests.
+	shutdownWg     sync.WaitGroup
 	logger         nftypes.FlowLogger
 	flowConfig     *nftypes.FlowConfig
 	conntrack      nftypes.ConnTracker
@@ -112,8 +118,15 @@ func (m *Manager) resetClient() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	m.cancel = cancel
 
-	go m.receiveACKs(ctx, flowClient)
-	go m.startSender(ctx)
+	m.shutdownWg.Add(2)
+	go func() {
+		defer m.shutdownWg.Done()
+		m.receiveACKs(ctx, flowClient)
+	}()
+	go func() {
+		defer m.shutdownWg.Done()
+		m.startSender(ctx)
+	}()
 
 	return nil
 }
@@ -181,14 +194,18 @@ func (m *Manager) Update(update *nftypes.FlowConfig) error {
 	return m.disableFlow()
 }
 
-// Close cleans up all resources
+// Close cleans up all resources. Unlocks the mux before waiting on
+// shutdownWg so the in-flight sender/receiver goroutines can finish
+// their teardown — both call back into methods that take the mux,
+// and holding it through Wait would deadlock.
 func (m *Manager) Close() {
 	m.mux.Lock()
-	defer m.mux.Unlock()
-
 	if err := m.disableFlow(); err != nil {
 		log.Warnf("failed to disable flow manager: %v", err)
 	}
+	m.mux.Unlock()
+
+	m.shutdownWg.Wait()
 }
 
 // GetLogger returns the flow logger

--- a/docs/adr/0018-server-side-flow-policy-resolver.md
+++ b/docs/adr/0018-server-side-flow-policy-resolver.md
@@ -1,0 +1,429 @@
+# ADR-0018 — Server-side flow event policy resolver
+
+**Status:** Proposed (2026-05-12)
+
+**Relates to:** [ADR-0002](0002-flow-events-storage.md) (flow events
+storage), [ADR-0013](0013-flow-policy-correlation.md) (agent-side
+policy correlation via ctmark).
+
+**Supersedes:** none.
+
+## Context
+
+[ADR-0013](0013-flow-policy-correlation.md) added agent-side
+correlation between flow events and the originating PolicyID on
+Linux peers, by stamping a `rule_index` on bits 17-31 of the
+conntrack mark when the ACL chain matches a packet. The conntrack
+collector reads the mark, asks the in-process `policymark.Indexer`
+to map it back to the management-issued PolicyID, and ships the
+result inside `FlowEvent.RuleId`.
+
+That works for three of the four paths flow events come from:
+
+| Path | Stamping site | Status |
+|---|---|---|
+| Linux kernel firewall, **inbound** | [`nftables/acl_linux.go`](../../client/firewall/nftables/acl_linux.go) / [`iptables/acl_linux.go`](../../client/firewall/iptables/acl_linux.go) | ✓ stamped |
+| Linux kernel firewall, **routing forward** | [`nftables/router_linux.go`](../../client/firewall/nftables/router_linux.go#L389) / [`iptables/router_linux.go`](../../client/firewall/iptables/router_linux.go) | ✓ stamped |
+| Userspace filter (macOS / Windows / userspace-bind) | [`uspfilter/filter.go`](../../client/firewall/uspfilter/filter.go) — direct PolicyID on rule | ✓ in-band |
+| Linux kernel firewall, **outbound from initiator** | nowhere — packets only hit OUTPUT + POSTROUTING mangle | ✗ empty |
+
+The fourth path is the one a Cora operator surfaced. They open the
+Network Traffic page and see the Policy column blank for every
+flow their machine reported (events where their peer is the
+**initiator** of an outbound connection to a Network Resource via a
+routing peer). Sample API response:
+
+```json
+{
+  "peer_id": "d7tlq3jr42ds73fq66m0",
+  "rule_id": null,
+  "type": "start",
+  "occurred_at": "2026-05-12T04:13:08.267667Z"
+}
+```
+
+Their conntrack inspection shows the entries carry only the legacy
+data-plane mark (`mark=0x1BD11 = DataPlaneMarkOut`); bits 17-31 are
+zero because:
+
+1. The agent's OUTPUT chain does not install per-policy ACL rules
+   (upstream commit `5a82477d`, "Remove outbound chains" —
+   stateful conntrack matching covers reply traffic on INPUT, so
+   the OUTPUT path is unstamped by design).
+2. The POSTROUTING mangle rule in
+   [`router_linux.go::setupDataPlaneMark`](../../client/firewall/nftables/router_linux.go#L294)
+   writes `DataPlaneMarkOut` directly to the ct mark register
+   instead of OR-ing into it — it would overwrite any high-bit
+   rule_index even if a previous chain had set one.
+
+The gap is architectural, not a bug. It exists in NetBird upstream
+OSS too (they recently removed the agent-side `PolicyResolver`
+entirely; their cloud product fills `rule_id` server-side as the
+inferred Enterprise differentiator). ADR-0013 explicitly reserved
+this slot:
+
+> **Not a server-side resolver.** Management trusts whatever
+> RuleId the agent reports. […] Server-side correlation could land
+> later as a fallback that fills empty RuleIds at insert time —
+> out of scope here.
+
+This ADR makes the slot concrete.
+
+## Decision
+
+Add a **server-side resolver in the flow ingest pipeline** that
+fills `RuleId` when the agent left it empty. The resolver is a
+fallback: events that arrive with a non-empty `RuleId` (the
+common case — inbound, routing, uspfilter) are passed through
+untouched. Only outbound-initiator events from Linux kernel peers
+hit the resolver in practice.
+
+### Where it sits in the pipeline
+
+```text
+peer ──gRPC FlowService.Events──> management/server/flow_service.go
+                                     │  handler ACKs peer immediately
+                                     ▼
+                                  resolver (this ADR)
+                                     ├── event.RuleId != "" → pass through
+                                     └── event.RuleId == "" → enrich
+                                     ▼
+                                  ┌─ HOT store
+                                  ├─ SIEM stream
+                                  └─ COLD archive
+```
+
+The resolver runs **after** the peer ack has shipped, so peer-side
+latency is untouched. It runs **before** the fan-out so the same
+enriched event reaches the hot store, the SIEM exporter, and the
+cold archive — operators querying any of those tiers see
+consistent attribution.
+
+### Algorithm
+
+For each event missing `RuleId`, build a query tuple
+`(peer_id, src_ip, dst_ip, dst_port, protocol)` and match it
+against the cached account policy graph. The matching rule is the
+same the dataplane already follows when computing the network map
+that produces `FirewallRule.PolicyID` for each peer — we just run
+it backward.
+
+```text
+1. peer_id → groups membership (Account.Peers[peer_id].GroupID)
+2. groups → policies where any source rule includes a group the peer is in
+3. for each candidate policy:
+     a. does dst_ip resolve to a resource / peer in any destination group?
+     b. does dst_port + protocol fall in the policy's port set?
+   first candidate that satisfies (a) ∧ (b) wins
+4. return policy.ID
+```
+
+Ambiguity is settled the same way the dataplane settles it:
+**first match by policy creation order**. This is deterministic
+and matches what the firewall already enforces on the wire — the
+dashboard now shows the same policy the kernel actually saw.
+
+### Index shape
+
+A reverse index built per-account, lazily on first need and
+refreshed when the account's policy/group/peer graph changes
+(`Account.Manager` already emits these events for the existing
+`updateAccountPeers` path; we hook the same triggers).
+
+```go
+type FlowPolicyResolver struct {
+    mu         sync.RWMutex
+    byAccount  map[string]*accountIndex
+}
+
+type accountIndex struct {
+    // For each peer, the list of policies where the peer is on the
+    // source side. Per-peer lookup is O(1); the candidate list per
+    // peer is typically 5-50 entries in realistic accounts.
+    byPeer map[string][]policyCandidate
+}
+
+type policyCandidate struct {
+    policyID    string
+    dstResources []string        // resource IDs to expand at match time
+    dstCIDRs     []netip.Prefix  // pre-expanded destination CIDRs
+    ports        []portRange     // empty = match any port
+    protocol     proto           // 0 = any
+    createdAt    time.Time       // tiebreaker
+}
+
+func (r *FlowPolicyResolver) Resolve(accountID, peerID string,
+    dstIP netip.Addr, dstPort uint16, p proto) (string, bool) { … }
+```
+
+Lookup cost per event:
+- O(1) hash to fetch the peer's candidate list.
+- O(candidates) linear scan with a couple of inline predicate checks.
+- Realistic worst-case in our largest Cora-style account today
+  (~200 peers, ~30 policies, ~10 candidates per peer) is one
+  cache line + a handful of comparisons ≈ **1µs per resolution**.
+
+### Performance budget
+
+Set against the existing ingest cost (DB write dominates at
+~100-500µs per event):
+
+| Tier | Events/s | Resolver CPU/s | % of one core |
+|---|---|---|---|
+| Tiny | 50-200 | <0.1ms | <0.1% |
+| Small team | 500-2k | ~1-2ms | <0.5% |
+| Medium (Cora today) | 5k-20k | ~10-30ms | ~1-3% |
+| Large | 50k+ | ~100-200ms | ~10-20% |
+
+Memory budget at Medium tier: ~5-15MB of index per account.
+Larger deployments revisit — see Open questions §3.
+
+The resolver **only runs when `RuleId` is empty**. Best estimate
+from the four-path table above: in mixed-OS deployments roughly
+25-40% of events will hit the resolver; in Linux-kernel-heavy
+deployments it climbs toward 75% but those accounts already pay
+the rebuild cost on policy updates anyway.
+
+### HA behavior
+
+Each management replica holds the account graph in memory already
+(`Account.Manager` cache) and processes flow events from its own
+connected peers. The resolver is **stateless per replica** — no
+distributed coordination, no leader election. Two replicas that
+ingest events from different peers of the same account each run
+their own resolver; both see the same answer because they read the
+same authoritative state. Behavior under partition: the resolver
+falls back to the last-known policy graph until the cache refresh
+catches up.
+
+### What does NOT happen
+
+- **No retroactive enrichment of pre-resolver events.** Rows already
+  in the hot store / archive with `RuleId = empty` stay empty.
+  Operators who need historical attribution run their own SQL
+  against the hot store; we ship a documented query in the
+  operator runbook (see Implementation §5). Online enrichment of
+  events older than a few minutes is a fairness problem (policy
+  graph from 6 months ago may have been replaced) and out of
+  scope for v1.
+- **No new env var.** The resolver is on by default; an internal
+  knob can disable it for benchmarking but is not surfaced.
+- **No client-side change.** The agent contract stays the same;
+  we keep the agent-side stamping path as the primary correlator
+  for the three paths where it works.
+- **No new dependencies.** Everything lives inside
+  `management/server/flow_policy_resolver/`.
+
+### Why this is a fallback, not a primary
+
+A discussion point worth recording. We deliberately keep both
+paths:
+
+1. **Agent-side stamping** stays the primary for the inbound /
+   routing-forward / uspfilter cases. It's free at ingest time
+   (the kernel already filled the field), survives policy graph
+   transitions (the rule_index → PolicyID map is whatever the
+   agent had when it stamped the conn, not what the management
+   has now), and matches what actually happened on the wire.
+2. **Server-side resolution** is the fallback for the outbound-
+   initiator gap. It's slightly slower (~1µs per event) and reads
+   the current policy graph, not the historical one — but for
+   the outbound case there's no historical graph to read.
+
+Choosing one over the other would either lose audit fidelity
+(server-only, no historical accuracy) or leave the gap open
+(agent-only, outbound stays blank). Defense in depth fits openZro's
+self-hosted positioning where dashboards matter more than minimal
+agent footprint.
+
+## Test plan
+
+TDD-first per project rules. Tests live under
+`management/server/flow_policy_resolver/`.
+
+### Unit (pure)
+
+Table-driven against a fixture account graph:
+
+1. **Resolves a single matching policy** — peer A in group G,
+   policy P maps G → resource R on TCP/443, event from A to R:443
+   returns P.ID.
+2. **Disambiguates by creation order** — two policies match the
+   same tuple; older wins.
+3. **No match returns empty** — event from a peer with no
+   relevant policies.
+4. **Pass-through on non-empty RuleId** — agent-stamped event is
+   not re-resolved.
+5. **Port range matches** — `8000-8999` matches `8443`, fails
+   `9000`.
+6. **Protocol ALL matches every protocol** including ICMP.
+7. **Destination resource — IP literal** matches.
+8. **Destination resource — CIDR** matches (the `10.0.0.0/24`
+   path).
+9. **Destination resource — hostname** — uses the precomputed
+   resolved-IPs from the management's DNS path (ADR-0015).
+10. **Empty peer_id / unknown peer** returns empty, no panic.
+11. **Cross-account isolation** — peer in account X cannot
+    resolve to a policy from account Y.
+
+### Integration
+
+Postgres testcontainer + `FlowService.Events` round-trip:
+
+1. Send a flow event with empty RuleId → assert hot store row has
+    the expected policy_id.
+2. Modify the policy graph (delete the matching policy) →
+    subsequent events return empty as expected, the index
+    invalidated cleanly.
+3. Concurrent resolution under policy save — start a goroutine
+    that loops on Resolve(), modify the policy graph 1000 times
+    from another goroutine, assert no panic and final state is
+    self-consistent (no half-built index reads).
+
+### Property-style
+
+For every (peer, dst_ip, dst_port, protocol) tuple where the
+dataplane would have accepted the connection, the resolver MUST
+return the same PolicyID the dataplane attributed to the firewall
+rule. Property checked with `quick.Check` against a generated
+account graph.
+
+## Implementation sequence
+
+Each step its own commit.
+
+1. **Resolver package skeleton** — `management/server/flow_policy_resolver/`
+   with `Resolver` struct, `Resolve()`, `accountIndex` shape,
+   `rebuildAccount(accountID, *Account)` builder. Tests for the
+   pure matching logic (unit cases 1-11) added first, then the
+   builder.
+
+2. **Account-change hooks** — register the resolver with
+   `Account.Manager` so `updateAccountPeers` and the policy
+   save/delete paths invalidate the affected account's index.
+   Reuses the existing event surface; no new public API on the
+   account manager.
+
+3. **Wire into flow_service.go** — slot the resolver between the
+   gRPC handler's enqueue and the per-destination fan-out. Skip
+   the resolver when `event.FlowFields.RuleId != ""`.
+   Integration test for the round-trip lands here.
+
+4. **Metrics** — three Prometheus counters on the existing flow
+   metrics surface: `flow_resolver_hits`, `flow_resolver_misses`,
+   `flow_resolver_skipped` (agent-stamped pass-through). Histogram
+   for `flow_resolver_duration_seconds`. Operator gets a clear
+   read on the cost.
+
+5. **Operator runbook section** — add a section to
+   [`docs/operator/`](../../docs/operator/) documenting the
+   resolver and the manual SQL operators run if they want to
+   backfill historical events.
+
+6. **Helm chart appVersion bump** + release notes.
+
+Estimated total: ~2 days backend (steps 1-4), ~half day docs +
+chart (steps 5-6). Step 1 dominates; steps 2-4 are wiring.
+
+## Consequences
+
+### Positive
+
+- **Closes the last visible attribution gap** in the Flow Traffic
+  page. Operators see a populated Policy column on every event
+  the management considers policy-driven, regardless of which
+  side of the conn the peer was on.
+- **Parity with NetBird Cloud's enterprise audit feature**,
+  without leaving our self-hosted scope. Cora-class operators
+  get the same dashboard utility paying nobody.
+- **Agent-side stamping stays untouched** — the ~75% of paths
+  where it already works skip the resolver entirely.
+- **SIEM stream and cold archive both inherit attribution for
+  free**, since the resolver runs before fan-out.
+
+### Negative / risks
+
+- **Memory cost grows with account size.** Capped by the index
+  shape choice (peer-keyed, candidate list bounded), but a
+  hypothetical 10k-peer + 1k-policy account would carry a
+  ~50-150MB index. Mitigated by sharing the candidate slices
+  across peers in the same source group (a future optimization
+  not yet in v1).
+- **Ambiguity is silently picked by creation order.** This
+  matches dataplane behavior but if an operator changes their
+  intent without realizing it the dashboard will follow without
+  warning. Documented in the runbook; metrics expose the
+  ambiguity count via `flow_resolver_ambiguous`.
+- **Resolver runs against the live policy graph**, so events that
+  ingest right after a policy is deleted are attributed to the
+  *next* matching policy (or none). The window is bounded by the
+  graph rebuild cadence (~milliseconds); not ideal but expected.
+
+### Neutral
+
+- The resolver is **per-replica**; HA deployments do not
+  coordinate. Each replica resolves what its own peers report.
+  No cross-pod cache.
+- The resolver does NOT extend to admission events, route flows,
+  or other event sources. Those have separate correlation paths
+  already.
+
+## Alternatives considered
+
+1. **Add OUTPUT chain to the agent ACL.** Re-introduces what
+   upstream commit `5a82477d` removed; complicates the agent and
+   doesn't help macOS/Windows/userspace deployments that are
+   already fine. Rejected.
+
+2. **CONNMARK rules in postrouting mangle that mirror ACLs.**
+   Stamps rule_index on outbound conns at packet time, no server
+   coupling. Reasonable but doubles the number of installed
+   nftables rules; adds policymark coupling to a mangle-time
+   path that was deliberately kept simple. Deferred — could be
+   the v2 enhancement if resolver CPU cost becomes an issue.
+
+3. **Read-side resolution** (only fill rule_id when the dashboard
+   queries the event). Cheaper in storage but doesn't help SIEM
+   stream / archive consumers, and the query cost would be
+   per-page-load. Rejected.
+
+4. **Out-of-band async enrichment** (separate goroutine reads
+   recent events, fills rule_id, writes back). More moving parts,
+   no win over the inline resolver since the inline cost is
+   already <1% at typical tiers. Rejected.
+
+## Open questions
+
+1. **Should we expose `flow_resolver_disabled` as an env var?**
+   Default off (resolver always runs). Use case: operators who
+   ship every event to an external resolver via SIEM and don't
+   want the management to do the work. Probably yes, low cost
+   to add.
+
+2. **Ambiguity warning UX.** When the resolver picks a policy
+   among multiple candidates, should the dashboard show a small
+   indicator on the row? Useful for audit, slightly noisy. Vote
+   needed.
+
+3. **Memory ceiling for very-large accounts.** Above ~10k peers
+   the index footprint becomes meaningful. We probably need a
+   benchmark + an alternative shape (interval tree on dst
+   CIDRs + bitmap on source groups) — but that's a follow-up
+   PR, not a blocker for v1.
+
+4. **Should `Resolve` accept a context with a deadline?** Today
+   the loop is sub-microsecond so timeouts are theatrical. If we
+   ever swap in a CIDR tree with a worst-case scan, a deadline
+   becomes useful.
+
+## References
+
+- [ADR-0002](0002-flow-events-storage.md) — flow events storage
+- [ADR-0013](0013-flow-policy-correlation.md) — agent-side
+  correlation via ctmark, explicitly reserves this slot
+- [`management/server/types/account.go::GetPeerConnectionResources`](../../management/server/types/account.go)
+  — the forward path that produces `FirewallRule.PolicyID` per
+  peer (the resolver is its inverse)
+- [`client/firewall/nftables/router_linux.go::setupDataPlaneMark`](../../client/firewall/nftables/router_linux.go#L294)
+  — the postrouting mangle that clobbers any high-bit rule_index
+  before the conntrack entry is finalized

--- a/flow/client/client.go
+++ b/flow/client/client.go
@@ -29,7 +29,14 @@ type GRPCClient struct {
 	realClient proto.FlowServiceClient
 	clientConn *grpc.ClientConn
 	stream     proto.FlowService_EventsClient
-	streamMu   sync.Mutex
+	// receiving guards against two Receive goroutines racing on the
+	// same client. resetClient in the netflow manager spawns a new
+	// receiver every time the Sync push reports needsNewClient=true;
+	// if the previous receiver hasn't unwound yet, the second one
+	// would open a parallel gRPC stream, double-consume acks, and
+	// fight over c.stream. The flag is checked under streamMu.
+	receiving bool
+	streamMu  sync.Mutex
 }
 
 func NewClient(addr, payload, signature string, interval time.Duration) (*GRPCClient, error) {
@@ -86,7 +93,26 @@ func (c *GRPCClient) Close() error {
 	return nil
 }
 
+// ErrConcurrentReceive is returned when a second goroutine tries to
+// call Receive on a client that is already serving one. Callers
+// should treat this as a programming error — there is no legitimate
+// path that calls Receive twice in parallel on the same client.
+var ErrConcurrentReceive = errors.New("flow client: concurrent Receive calls are not supported")
+
 func (c *GRPCClient) Receive(ctx context.Context, interval time.Duration, msgHandler func(msg *proto.FlowEventAck) error) error {
+	c.streamMu.Lock()
+	if c.receiving {
+		c.streamMu.Unlock()
+		return ErrConcurrentReceive
+	}
+	c.receiving = true
+	c.streamMu.Unlock()
+	defer func() {
+		c.streamMu.Lock()
+		c.receiving = false
+		c.streamMu.Unlock()
+	}()
+
 	backOff := defaultBackoff(ctx, interval)
 	operation := func() error {
 		if err := c.establishStreamAndReceive(ctx, msgHandler); err != nil {

--- a/flow/client/client.go
+++ b/flow/client/client.go
@@ -13,28 +13,44 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/keepalive"
-	"google.golang.org/grpc/status"
 
 	"github.com/openzro/openzro/flow/proto"
 	"github.com/openzro/openzro/util/embeddedroots"
 	nbgrpc "github.com/openzro/openzro/util/grpc"
 )
 
+// ErrClientClosed is the permanent error returned from Receive when
+// Close lands during the retry loop. Wrapped in backoff.Permanent so
+// the loop unwinds immediately instead of waiting out the backoff.
+var ErrClientClosed = errors.New("flow client: client is closed")
+
+// minHealthyDuration is the minimum time a stream must survive
+// before a transport failure counts as "the stream worked, the
+// network just blipped" — we reset the backoff timer in that
+// case. Streams that die faster than this are considered unhealthy
+// (TLS handshake failures, server returning UNAVAILABLE immediately,
+// auth header rejection) and must NOT reset backoff, so that
+// MaxElapsedTime can eventually stop the retry loop.
+const minHealthyDuration = 5 * time.Second
+
 type GRPCClient struct {
 	realClient proto.FlowServiceClient
 	clientConn *grpc.ClientConn
 	stream     proto.FlowService_EventsClient
+	// target + opts are remembered from NewClient so the retry loop
+	// can rebuild the underlying grpc.ClientConn from scratch when
+	// the existing one enters a stuck state — gRPC's internal
+	// subchannel backoff can otherwise outlive our own retry timer.
+	target string
+	opts   []grpc.DialOption
+	// closed becomes true after Close so concurrent retries
+	// terminate instead of dialing a new conn on the dead client.
+	closed bool
 	// receiving guards against two Receive goroutines racing on the
-	// same client. resetClient in the netflow manager spawns a new
-	// receiver every time the Sync push reports needsNewClient=true;
-	// if the previous receiver hasn't unwound yet, the second one
-	// would open a parallel gRPC stream, double-consume acks, and
-	// fight over c.stream. The flag is checked under streamMu.
+	// same client. The flag is checked under streamMu.
 	receiving bool
 	streamMu  sync.Mutex
 }
@@ -70,7 +86,8 @@ func NewClient(addr, payload, signature string, interval time.Duration) (*GRPCCl
 		grpc.WithDefaultServiceConfig(`{"healthCheckConfig": {"serviceName": ""}}`),
 	)
 
-	conn, err := grpc.NewClient(fmt.Sprintf("%s:%s", parsedURL.Hostname(), parsedURL.Port()), opts...)
+	target := fmt.Sprintf("%s:%s", parsedURL.Hostname(), parsedURL.Port())
+	conn, err := grpc.NewClient(target, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("creating new grpc client: %w", err)
 	}
@@ -78,18 +95,29 @@ func NewClient(addr, payload, signature string, interval time.Duration) (*GRPCCl
 	return &GRPCClient{
 		realClient: proto.NewFlowServiceClient(conn),
 		clientConn: conn,
+		target:     target,
+		opts:       opts,
 	}, nil
 }
 
+// Close marks the client as closed and tears down the underlying
+// ClientConn. Any concurrent Receive loop observes the closed flag
+// the next time it tries to recreate the connection and exits with
+// ErrClientClosed instead of dialing again.
 func (c *GRPCClient) Close() error {
 	c.streamMu.Lock()
-	defer c.streamMu.Unlock()
-
+	c.closed = true
 	c.stream = nil
-	if err := c.clientConn.Close(); err != nil && !errors.Is(err, context.Canceled) {
+	conn := c.clientConn
+	c.clientConn = nil
+	c.streamMu.Unlock()
+
+	if conn == nil {
+		return nil
+	}
+	if err := conn.Close(); err != nil && !errors.Is(err, context.Canceled) {
 		return fmt.Errorf("close client connection: %w", err)
 	}
-
 	return nil
 }
 
@@ -115,12 +143,17 @@ func (c *GRPCClient) Receive(ctx context.Context, interval time.Duration, msgHan
 
 	backOff := defaultBackoff(ctx, interval)
 	operation := func() error {
-		if err := c.establishStreamAndReceive(ctx, msgHandler); err != nil {
-			if s, ok := status.FromError(err); ok && s.Code() == codes.Canceled {
-				return fmt.Errorf("receive: %w: %w", err, context.Canceled)
-			}
+		stream, err := c.establishStream(ctx)
+		if err != nil {
+			log.Errorf("failed to establish flow stream, retrying: %v", err)
+			return c.handleRetryableError(err, time.Time{}, backOff)
+		}
+
+		streamStart := time.Now()
+
+		if err := c.receive(stream, msgHandler); err != nil {
 			log.Errorf("receive failed: %v", err)
-			return fmt.Errorf("receive: %w", err)
+			return c.handleRetryableError(err, streamStart, backOff)
 		}
 		return nil
 	}
@@ -132,37 +165,129 @@ func (c *GRPCClient) Receive(ctx context.Context, interval time.Duration, msgHan
 	return nil
 }
 
-func (c *GRPCClient) establishStreamAndReceive(ctx context.Context, msgHandler func(msg *proto.FlowEventAck) error) error {
-	if c.clientConn.GetState() == connectivity.Shutdown {
-		return errors.New("connection to flow receiver has been shut down")
+// handleRetryableError decides whether to retry the loop. Returns a
+// backoff.Permanent error when the client was closed or the context
+// is done, otherwise rebuilds the ClientConn (gRPC's internal
+// subchannel backoff can outlive our own and leave the conn in a
+// permanently-unavailable state without our cooperation) and returns
+// a retryable error. A stream that survived `minHealthyDuration`
+// resets the backoff timer so a brief outage after hours of healthy
+// operation doesn't count against MaxElapsedTime.
+func (c *GRPCClient) handleRetryableError(err error, streamStart time.Time, backOff backoff.BackOff) error {
+	if isContextDone(err) {
+		return backoff.Permanent(err)
 	}
 
-	stream, err := c.realClient.Events(ctx, grpc.WaitForReady(true))
+	var permErr *backoff.PermanentError
+	if errors.As(err, &permErr) {
+		return err
+	}
+
+	if !streamStart.IsZero() && time.Since(streamStart) >= minHealthyDuration {
+		backOff.Reset()
+	}
+
+	if recreateErr := c.recreateConnection(); recreateErr != nil {
+		log.Errorf("recreate connection: %v", recreateErr)
+		return recreateErr
+	}
+
+	log.Infof("connection recreated, retrying stream")
+	return fmt.Errorf("retrying after error: %w", err)
+}
+
+// recreateConnection swaps the underlying ClientConn for a fresh one
+// built from the same target + opts. Old conn is closed outside the
+// lock to avoid blocking concurrent callers (Close races are safe
+// because Close itself takes streamMu, sets closed=true, and nils
+// clientConn before unlocking).
+func (c *GRPCClient) recreateConnection() error {
+	c.streamMu.Lock()
+	if c.closed {
+		c.streamMu.Unlock()
+		return backoff.Permanent(ErrClientClosed)
+	}
+
+	conn, err := grpc.NewClient(c.target, c.opts...)
 	if err != nil {
-		return fmt.Errorf("create event stream: %w", err)
+		c.streamMu.Unlock()
+		return fmt.Errorf("create new connection: %w", err)
 	}
 
-	err = stream.Send(&proto.FlowEvent{IsInitiator: true})
+	old := c.clientConn
+	c.clientConn = conn
+	c.realClient = proto.NewFlowServiceClient(conn)
+	c.stream = nil
+	c.streamMu.Unlock()
+
+	if old != nil {
+		_ = old.Close()
+	}
+	return nil
+}
+
+// establishStream opens an Events stream, sends the initiator
+// message, reads the headers, and publishes the stream pointer
+// under streamMu so Send can race-safely read it. The blocking
+// Events() call is made outside the lock to keep other paths
+// responsive while the dial completes.
+func (c *GRPCClient) establishStream(ctx context.Context) (proto.FlowService_EventsClient, error) {
+	c.streamMu.Lock()
+	if c.closed {
+		c.streamMu.Unlock()
+		return nil, backoff.Permanent(ErrClientClosed)
+	}
+	cl := c.realClient
+	c.streamMu.Unlock()
+
+	stream, err := cl.Events(ctx)
 	if err != nil {
-		log.Infof("failed to send initiator message to flow receiver but will attempt to continue. Error: %s", err)
+		return nil, fmt.Errorf("create event stream: %w", err)
+	}
+	streamReady := false
+	defer func() {
+		if !streamReady {
+			_ = stream.CloseSend()
+		}
+	}()
+
+	if err := stream.Send(&proto.FlowEvent{IsInitiator: true}); err != nil {
+		return nil, fmt.Errorf("send initiator: %w", err)
 	}
 
-	if err = checkHeader(stream); err != nil {
-		return fmt.Errorf("check header: %w", err)
+	if err := checkHeader(stream); err != nil {
+		return nil, fmt.Errorf("check header: %w", err)
 	}
 
 	c.streamMu.Lock()
+	if c.closed {
+		c.streamMu.Unlock()
+		return nil, backoff.Permanent(ErrClientClosed)
+	}
 	c.stream = stream
 	c.streamMu.Unlock()
+	streamReady = true
 
-	return c.receive(stream, msgHandler)
+	return stream, nil
+}
+
+// isContextDone reports whether the local context has been cancelled
+// or has exceeded its deadline. We deliberately do NOT inspect gRPC
+// status codes: a server- or proxy-sent codes.Canceled /
+// DeadlineExceeded must not short-circuit our retry loop, since
+// retrying is the correct response when the local context is alive.
+func isContextDone(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
 }
 
 func (c *GRPCClient) receive(stream proto.FlowService_EventsClient, msgHandler func(msg *proto.FlowEventAck) error) error {
 	for {
 		msg, err := stream.Recv()
 		if err != nil {
-			return fmt.Errorf("receive from stream: %w", err)
+			// Return the raw error so handleRetryableError can
+			// distinguish context cancellation from transport failure
+			// without unwrapping a wrapped status.
+			return err
 		}
 
 		if msg.IsInitiator {

--- a/flow/client/client_test.go
+++ b/flow/client/client_test.go
@@ -254,3 +254,58 @@ func TestSend(t *testing.T) {
 		t.Fatal("timeout waiting for ack to be received by flow")
 	}
 }
+
+// TestReceive_RejectsConcurrentCall is a regression test for the
+// double-Receive bug: nothing in the API prevented two goroutines
+// from each opening a fresh stream against the same GRPCClient.
+// The realistic trigger is the netflow manager's resetClient path
+// — when a config Update flips URL or token, a new receiver
+// goroutine spawns before the previous one has unwound, and both
+// race on the shared `stream` pointer + ack handling. Production
+// users saw duplicate ACK processing and warnings about
+// "stream not initialized".
+//
+// Post-fix: the second Receive returns ErrConcurrentReceive
+// immediately, leaving the first stream untouched.
+func TestReceive_RejectsConcurrentCall(t *testing.T) {
+	server := newTestServer(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	client, err := flow.NewClient("http://"+server.addr, "test-payload", "test-signature", 1*time.Second)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	firstActive := make(chan struct{})
+	firstDone := make(chan struct{})
+
+	go func() {
+		defer close(firstDone)
+		// Signal that we are inside Receive — the server-side stream
+		// handler runs once the initiator handshake clears, by which
+		// time the receiving flag is set.
+		go func() {
+			time.Sleep(200 * time.Millisecond)
+			close(firstActive)
+		}()
+		err := client.Receive(ctx, time.Second, func(*proto.FlowEventAck) error { return nil })
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+			t.Logf("first receive returned: %v", err)
+		}
+	}()
+
+	<-firstActive
+
+	// Second concurrent call should be refused immediately.
+	err = client.Receive(ctx, time.Second, func(*proto.FlowEventAck) error { return nil })
+	require.ErrorIs(t, err, flow.ErrConcurrentReceive, "second concurrent Receive must be refused")
+
+	// Tear down by cancelling — first goroutine should exit cleanly.
+	cancel()
+	select {
+	case <-firstDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first Receive did not unwind after context cancel")
+	}
+}

--- a/flow/client/client_test.go
+++ b/flow/client/client_test.go
@@ -255,6 +255,49 @@ func TestSend(t *testing.T) {
 	}
 }
 
+// TestReceive_ClosedDuringRetryReturnsClientClosed verifies that
+// closing the client mid-retry causes Receive to unwind with
+// ErrClientClosed instead of looping forever on the dead conn. The
+// recreate-on-failure path checks the closed flag under streamMu
+// before dialing a fresh grpc.ClientConn; without that check, Close
+// would race with a new dial and the Receive goroutine could keep
+// trying past Close indefinitely on slow networks.
+func TestReceive_ClosedDuringRetryReturnsClientClosed(t *testing.T) {
+	server := newTestServer(t)
+
+	// Use a context that won't expire before we get to Close — we
+	// want the closure (not the context) to terminate the loop.
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	client, err := flow.NewClient("http://"+server.addr, "test-payload", "test-signature", 200*time.Millisecond)
+	require.NoError(t, err)
+
+	// Force the stream into a retry cycle: stop the server, then call
+	// Close on the client a moment later. The Receive loop should
+	// observe the closed flag inside recreateConnection or
+	// establishStream and return ErrClientClosed.
+	server.grpcSrv.Stop()
+
+	receiveDone := make(chan error, 1)
+	go func() {
+		receiveDone <- client.Receive(ctx, 200*time.Millisecond, func(*proto.FlowEventAck) error { return nil })
+	}()
+
+	// Give the loop one cycle to enter retry, then close.
+	time.Sleep(300 * time.Millisecond)
+	require.NoError(t, client.Close())
+
+	select {
+	case err := <-receiveDone:
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, flow.ErrClientClosed) || errors.Is(err, context.Canceled),
+			"Receive should unwind with ErrClientClosed or context cancellation after Close; got %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Receive did not unwind within 5s after Close")
+	}
+}
+
 // TestReceive_RejectsConcurrentCall is a regression test for the
 // double-Receive bug: nothing in the API prevented two goroutines
 // from each opening a fresh stream against the same GRPCClient.

--- a/management/cmd/management.go
+++ b/management/cmd/management.go
@@ -57,6 +57,7 @@ import (
 	nbContext "github.com/openzro/openzro/management/server/context"
 	"github.com/openzro/openzro/management/server/dex_proxy"
 	flowExports "github.com/openzro/openzro/management/server/flow_exports"
+	flowPolicyResolverPkg "github.com/openzro/openzro/management/server/flow_policy_resolver"
 	"github.com/openzro/openzro/management/server/geolocation"
 	"github.com/openzro/openzro/management/server/groups"
 	nbhttp "github.com/openzro/openzro/management/server/http"
@@ -443,7 +444,20 @@ var (
 				initial = append(initial, flowStore)
 			}
 			initial = append(initial, extraSinks...)
-			flowSvc := server.NewFlowService(initial, peerResolver)
+
+			// ADR-0018: the server-side resolver is the fallback path
+			// for flow events the agent could not stamp at firewall
+			// time (Linux kernel outbound-initiator flows). Wired into
+			// both FlowService (Resolve at ingest) and AccountManager
+			// (Rebuild on every account-graph change). When the flow
+			// store is disabled (engine=none), the resolver still
+			// fires but its output goes nowhere — kept on so SIEM
+			// streams and cold-archive sinks observe enriched events.
+			flowPolicyResolver := flowPolicyResolverPkg.New()
+			flowSvc := server.NewFlowService(initial, peerResolver,
+				server.WithPolicyResolver(flowPolicyResolver),
+			)
+			accountManager.SetFlowPolicyIndex(flowPolicyResolver)
 
 			var flowExportsManager *flowExports.Manager
 			if flowExportsStore != nil {

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -118,6 +118,24 @@ type DefaultAccountManager struct {
 	// short-circuit is skipped and the gate runs as if no bypass
 	// existed; the existing posture checks still apply.
 	admissionBypasses *admission.Store
+
+	// flowPolicyIndex owns the ADR-0018 server-side policy resolver.
+	// When set, UpdateAccountPeers rebuilds the resolver's index for
+	// the affected account so subsequent flow events can be
+	// attributed by the management. When nil, the resolver is
+	// effectively disabled and flow events keep whatever RuleID the
+	// agent stamped (or none).
+	flowPolicyIndex FlowPolicyIndex
+}
+
+// FlowPolicyIndex is the narrow contract DefaultAccountManager uses
+// to push account-graph changes into the ADR-0018 resolver. Defined
+// here (not imported from flow_policy_resolver) so the account
+// manager doesn't take a hard dependency on the resolver package —
+// the cmd/ wiring decides whether to plug a concrete implementation.
+type FlowPolicyIndex interface {
+	Rebuild(accountID string, account *types.Account)
+	Forget(accountID string)
 }
 
 // SetActivityExporters wires a per-account exporter manager into
@@ -133,6 +151,15 @@ func (am *DefaultAccountManager) SetActivityExporters(m *activity_exporters.Mana
 // gate continues to run posture checks as before.
 func (am *DefaultAccountManager) SetAdmissionBypasses(s *admission.Store) {
 	am.admissionBypasses = s
+}
+
+// SetFlowPolicyIndex wires the ADR-0018 server-side resolver into
+// UpdateAccountPeers. Called once at startup from cmd/management.go
+// after the resolver is constructed. nil disables the resolver and
+// flow events keep whatever RuleID the agent stamped at firewall
+// time (the ADR-0013 primary path).
+func (am *DefaultAccountManager) SetFlowPolicyIndex(idx FlowPolicyIndex) {
+	am.flowPolicyIndex = idx
 }
 
 func isUniqueConstraintError(err error) bool {

--- a/management/server/flow_policy_resolver/index.go
+++ b/management/server/flow_policy_resolver/index.go
@@ -48,6 +48,16 @@ func (r *Resolver) Rebuild(accountID string, account *types.Account) {
 	r.mu.Unlock()
 }
 
+// groupExpansion is the precomputed shape for each group used during
+// index build: peer IDs in the group (for attaching candidates to
+// peers on the source side) and the destination set the group
+// produces (peer mesh IPs + resource CIDRs/IPs).
+type groupExpansion struct {
+	peers    []string
+	destIPs  []netip.Addr
+	prefixes []netip.Prefix
+}
+
 // buildAccountIndex is the pure constructor — no Resolver state, no
 // locks. Lives outside Rebuild so tests can exercise the shape
 // without a Resolver instance.
@@ -59,47 +69,8 @@ func buildAccountIndex(account *types.Account) *accountIndex {
 		return idx
 	}
 
-	// Precompute group → []peerID and group → []destination once
-	// per build. Both are read N × M times during candidate
-	// expansion so the upfront map is cheaper than chasing pointers
-	// through Account.Groups + Account.Peers per rule.
-	groupPeers := make(map[string][]string, len(account.Groups))
-	groupDestIPs := make(map[string][]netip.Addr, len(account.Groups))
-	groupDestPrefixes := make(map[string][]netip.Prefix, len(account.Groups))
-	for gid, g := range account.Groups {
-		if g == nil {
-			continue
-		}
-		groupPeers[gid] = append([]string(nil), g.Peers...)
-		for _, pid := range g.Peers {
-			peer := account.Peers[pid]
-			if peer == nil || peer.IP == nil {
-				continue
-			}
-			addr, ok := netip.AddrFromSlice(peer.IP)
-			if !ok {
-				continue
-			}
-			addr = addr.Unmap()
-			groupDestIPs[gid] = append(groupDestIPs[gid], addr)
-		}
-	}
-	for _, res := range account.NetworkResources {
-		if res == nil {
-			continue
-		}
-		addr, prefix, ok := resourceDestination(res.Prefix)
-		if !ok {
-			continue
-		}
-		for _, gid := range res.GroupIDs {
-			if addr.IsValid() {
-				groupDestIPs[gid] = append(groupDestIPs[gid], addr)
-			} else if prefix.IsValid() {
-				groupDestPrefixes[gid] = append(groupDestPrefixes[gid], prefix)
-			}
-		}
-	}
+	groups := buildGroupExpansion(account)
+	resourceByID := indexResourcesByID(account)
 
 	// Order policies for deterministic ambiguity-resolution. The
 	// dataplane attributes the first matching rule it built; we
@@ -112,7 +83,7 @@ func buildAccountIndex(account *types.Account) *accountIndex {
 	})
 
 	for _, policy := range policies {
-		if policy == nil {
+		if policy == nil || !policy.Enabled {
 			continue
 		}
 		for _, rule := range policy.Rules {
@@ -125,17 +96,31 @@ func buildAccountIndex(account *types.Account) *accountIndex {
 				continue
 			}
 
-			cand := buildCandidate(policy.ID, rule, groupDestIPs, groupDestPrefixes)
-			if cand == nil {
-				continue
+			// Build forward direction: source-side peers can reach
+			// destination peers / resources.
+			fwdSources := peersOnSide(rule.Sources, groups)
+			fwdDestIPs, fwdPrefixes := destinationsForRule(rule.Destinations, rule.DestinationResource, groups, resourceByID)
+			if len(fwdSources) > 0 && (len(fwdDestIPs) > 0 || len(fwdPrefixes) > 0) {
+				cand := newCandidate(policy.ID, rule, fwdDestIPs, fwdPrefixes)
+				attach(idx, fwdSources, cand)
 			}
 
-			// Wire the candidate to every peer on the rule's
-			// source side. We attach by peer ID so the hot path is
-			// O(1) without a Groups indirection.
-			for _, srcGroup := range rule.Sources {
-				for _, peerID := range groupPeers[srcGroup] {
-					idx.byPeer[peerID] = append(idx.byPeer[peerID], cand)
+			// Bidirectional rules install reverse-direction firewall
+			// entries too: peers in destinations can initiate to
+			// source peers. Mirrors account.go:998 in the dataplane.
+			// Note: posture checks (policy.SourcePostureChecks) gate
+			// who is on the original source side — peers that fail
+			// posture are excluded from the reverse direction's
+			// destinations as well, because the dataplane never
+			// installs a rule to them. We document this caveat at
+			// the resolver entry-point; posture evaluation in the
+			// index builder is a planned follow-up.
+			if rule.Bidirectional {
+				revSources := peersOnSide(rule.Destinations, groups)
+				revDestIPs, revPrefixes := destinationsForRule(rule.Sources, rule.SourceResource, groups, resourceByID)
+				if len(revSources) > 0 && (len(revDestIPs) > 0 || len(revPrefixes) > 0) {
+					cand := newCandidate(policy.ID, rule, revDestIPs, revPrefixes)
+					attach(idx, revSources, cand)
 				}
 			}
 		}
@@ -144,38 +129,194 @@ func buildAccountIndex(account *types.Account) *accountIndex {
 	return idx
 }
 
-// buildCandidate assembles a single (policy, rule) entry. Returns
-// nil when the rule has no resolvable destination (the dashboard
-// doesn't need to attribute traffic to "no destination").
-func buildCandidate(policyID string, rule *types.PolicyRule,
-	groupDestIPs map[string][]netip.Addr,
-	groupDestPrefixes map[string][]netip.Prefix,
-) *policyCandidate {
-	c := &policyCandidate{
-		policyID: policyID,
-		dstIPs:   make(map[netip.Addr]struct{}),
-		protocol: protoFromRule(rule.Protocol),
-		ports:    portsFromRule(rule.Ports, rule.PortRanges),
-	}
-
-	for _, gid := range rule.Destinations {
-		for _, addr := range groupDestIPs[gid] {
-			c.dstIPs[addr] = struct{}{}
+// buildGroupExpansion precomputes the per-group peer list AND the
+// destination set the group contributes (peer mesh IPs + resource
+// CIDRs/IPs). Done once per Rebuild so the inner loops don't
+// re-walk Account.Peers / NetworkResources per rule.
+func buildGroupExpansion(account *types.Account) map[string]*groupExpansion {
+	groups := make(map[string]*groupExpansion, len(account.Groups))
+	for gid, g := range account.Groups {
+		if g == nil {
+			continue
 		}
-		c.dstPrefixes = append(c.dstPrefixes, groupDestPrefixes[gid]...)
+		exp := &groupExpansion{
+			peers: append([]string(nil), g.Peers...),
+		}
+		for _, pid := range g.Peers {
+			peer := account.Peers[pid]
+			if peer == nil || peer.IP == nil {
+				continue
+			}
+			addr, ok := netip.AddrFromSlice(peer.IP)
+			if !ok {
+				continue
+			}
+			exp.destIPs = append(exp.destIPs, addr.Unmap())
+		}
+		groups[gid] = exp
 	}
-
-	if rule.DestinationResource.ID != "" {
-		// Resource on the rule directly (not via group). The
-		// resource was already resolved into the destination
-		// helpers above when we walked NetworkResources; nothing
-		// to add here, the per-resource expansion handles it.
+	// Fold NetworkResources into the groups they belong to. Resources
+	// are referenced from policy rules either directly (rule.Destination
+	// Resource / rule.SourceResource) or via groups (resource.GroupIDs);
+	// the via-groups path is the dominant one.
+	for _, res := range account.NetworkResources {
+		if res == nil || !res.Enabled {
+			continue
+		}
+		addr, prefix, ok := resourceDestination(res.Prefix)
+		if !ok {
+			continue
+		}
+		for _, gid := range res.GroupIDs {
+			exp, exists := groups[gid]
+			if !exists {
+				exp = &groupExpansion{}
+				groups[gid] = exp
+			}
+			if addr.IsValid() {
+				exp.destIPs = append(exp.destIPs, addr)
+			} else if prefix.IsValid() {
+				exp.prefixes = append(exp.prefixes, prefix)
+			}
+		}
 	}
+	return groups
+}
 
-	if len(c.dstIPs) == 0 && len(c.dstPrefixes) == 0 {
+// indexResourcesByID returns NetworkResources keyed by ID so the
+// direct-reference rule.DestinationResource / rule.SourceResource
+// paths can look up CIDRs in O(1).
+func indexResourcesByID(account *types.Account) map[string]*resourceDest {
+	out := make(map[string]*resourceDest, len(account.NetworkResources))
+	for _, res := range account.NetworkResources {
+		if res == nil || !res.Enabled {
+			continue
+		}
+		addr, prefix, ok := resourceDestination(res.Prefix)
+		if !ok {
+			continue
+		}
+		d := &resourceDest{}
+		if addr.IsValid() {
+			d.addr = addr
+		} else if prefix.IsValid() {
+			d.prefix = prefix
+		}
+		out[res.ID] = d
+	}
+	return out
+}
+
+// resourceDest is the simplified destination shape for a resource:
+// either a single IP (Host) or a CIDR prefix (Subnet). Domain
+// resources currently land empty — the management resolves them at
+// network-map time and the resolver doesn't have the resolved IPs
+// in scope. Documented as a known limitation in ADR-0018.
+type resourceDest struct {
+	addr   netip.Addr
+	prefix netip.Prefix
+}
+
+// peersOnSide returns the union of peer IDs across a slice of group
+// IDs. Mirrors getUniquePeerIDsFromGroupsIDs in the dataplane but
+// avoids the GetGroup indirection per call.
+func peersOnSide(groupIDs []string, groups map[string]*groupExpansion) []string {
+	if len(groupIDs) == 0 {
 		return nil
 	}
+	if len(groupIDs) == 1 {
+		// Short-circuit matches account.go:1467: a single group
+		// reference returns its peer list verbatim.
+		exp := groups[groupIDs[0]]
+		if exp == nil {
+			return nil
+		}
+		return exp.peers
+	}
+	seen := make(map[string]struct{})
+	var out []string
+	for _, gid := range groupIDs {
+		exp := groups[gid]
+		if exp == nil {
+			continue
+		}
+		for _, pid := range exp.peers {
+			if _, dup := seen[pid]; dup {
+				continue
+			}
+			seen[pid] = struct{}{}
+			out = append(out, pid)
+		}
+	}
+	return out
+}
+
+// destinationsForRule produces the union of destination IPs and
+// CIDRs for a rule's destination side: groups + an optional direct
+// resource reference. Mirrors what the dataplane installs as
+// FirewallRule entries pointing at this rule's destinations.
+//
+// The signature is parameterised on (groupIDs, directResource) so
+// the same helper serves both forward (rule.Destinations,
+// rule.DestinationResource) and reverse (rule.Sources,
+// rule.SourceResource) directions of a bidirectional rule.
+func destinationsForRule(groupIDs []string, directResource types.Resource,
+	groups map[string]*groupExpansion, resourcesByID map[string]*resourceDest,
+) ([]netip.Addr, []netip.Prefix) {
+	var ips []netip.Addr
+	var prefixes []netip.Prefix
+
+	for _, gid := range groupIDs {
+		exp := groups[gid]
+		if exp == nil {
+			continue
+		}
+		ips = append(ips, exp.destIPs...)
+		prefixes = append(prefixes, exp.prefixes...)
+	}
+
+	if directResource.ID != "" {
+		if d := resourcesByID[directResource.ID]; d != nil {
+			if d.addr.IsValid() {
+				ips = append(ips, d.addr)
+			} else if d.prefix.IsValid() {
+				prefixes = append(prefixes, d.prefix)
+			}
+		}
+	}
+
+	return ips, prefixes
+}
+
+// newCandidate builds a single policyCandidate from a rule plus
+// pre-resolved destinations. The protocol filter + port set come
+// straight from the rule; deduplication happens via the dstIPs map
+// (a peer that appears in multiple destination groups produces only
+// one entry).
+func newCandidate(policyID string, rule *types.PolicyRule, ips []netip.Addr, prefixes []netip.Prefix) *policyCandidate {
+	c := &policyCandidate{
+		policyID:    policyID,
+		dstIPs:      make(map[netip.Addr]struct{}, len(ips)),
+		dstPrefixes: append([]netip.Prefix(nil), prefixes...),
+		protocol:    protoFromRule(rule.Protocol),
+		ports:       portsFromRule(rule.Ports, rule.PortRanges),
+	}
+	for _, ip := range ips {
+		c.dstIPs[ip] = struct{}{}
+	}
 	return c
+}
+
+// attach wires a candidate to every peer on a given side of a rule.
+// The same candidate pointer is shared across peers — no copy, no
+// per-peer allocation beyond the slice header.
+func attach(idx *accountIndex, peers []string, cand *policyCandidate) {
+	for _, pid := range peers {
+		if pid == "" {
+			continue
+		}
+		idx.byPeer[pid] = append(idx.byPeer[pid], cand)
+	}
 }
 
 // resourceDestination converts a NetworkResource's Prefix into the

--- a/management/server/flow_policy_resolver/index.go
+++ b/management/server/flow_policy_resolver/index.go
@@ -1,0 +1,235 @@
+package flow_policy_resolver
+
+import (
+	"net/netip"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/openzro/openzro/management/server/types"
+)
+
+// accountIndex is the per-account reverse map from a source peer to
+// the policies that could attribute its outbound traffic. Built
+// lazily via Rebuild and replaced atomically (copy-on-write) on every
+// account graph change so the hot path's RLock never blocks a writer.
+type accountIndex struct {
+	// byPeer is the lookup table. The slice is sorted by policy
+	// creation time so the first match in resolver.Resolve also
+	// matches what the dataplane does at packet time.
+	byPeer map[string][]*policyCandidate
+}
+
+// candidatesForPeer returns the (possibly nil) slice of candidates
+// where peer is on the source side. Read-only — caller MUST NOT
+// mutate the slice.
+func (a *accountIndex) candidatesForPeer(peerID string) []*policyCandidate {
+	if a == nil {
+		return nil
+	}
+	return a.byPeer[peerID]
+}
+
+// Rebuild reconstructs the resolver's index for the given account.
+// Called by the management's account event hooks whenever the graph
+// changes (policy save / delete, peer add / remove, group edit,
+// resource edit). Cheap to run — typical Cora-class account is well
+// under 100ms — and atomic for readers: the new index swaps in
+// under the resolver's write lock, no half-built state visible.
+func (r *Resolver) Rebuild(accountID string, account *types.Account) {
+	if account == nil {
+		r.Forget(accountID)
+		return
+	}
+	idx := buildAccountIndex(account)
+
+	r.mu.Lock()
+	r.cache[accountID] = idx
+	r.mu.Unlock()
+}
+
+// buildAccountIndex is the pure constructor — no Resolver state, no
+// locks. Lives outside Rebuild so tests can exercise the shape
+// without a Resolver instance.
+func buildAccountIndex(account *types.Account) *accountIndex {
+	idx := &accountIndex{
+		byPeer: make(map[string][]*policyCandidate),
+	}
+	if account == nil {
+		return idx
+	}
+
+	// Precompute group → []peerID and group → []destination once
+	// per build. Both are read N × M times during candidate
+	// expansion so the upfront map is cheaper than chasing pointers
+	// through Account.Groups + Account.Peers per rule.
+	groupPeers := make(map[string][]string, len(account.Groups))
+	groupDestIPs := make(map[string][]netip.Addr, len(account.Groups))
+	groupDestPrefixes := make(map[string][]netip.Prefix, len(account.Groups))
+	for gid, g := range account.Groups {
+		if g == nil {
+			continue
+		}
+		groupPeers[gid] = append([]string(nil), g.Peers...)
+		for _, pid := range g.Peers {
+			peer := account.Peers[pid]
+			if peer == nil || peer.IP == nil {
+				continue
+			}
+			addr, ok := netip.AddrFromSlice(peer.IP)
+			if !ok {
+				continue
+			}
+			addr = addr.Unmap()
+			groupDestIPs[gid] = append(groupDestIPs[gid], addr)
+		}
+	}
+	for _, res := range account.NetworkResources {
+		if res == nil {
+			continue
+		}
+		addr, prefix, ok := resourceDestination(res.Prefix)
+		if !ok {
+			continue
+		}
+		for _, gid := range res.GroupIDs {
+			if addr.IsValid() {
+				groupDestIPs[gid] = append(groupDestIPs[gid], addr)
+			} else if prefix.IsValid() {
+				groupDestPrefixes[gid] = append(groupDestPrefixes[gid], prefix)
+			}
+		}
+	}
+
+	// Order policies for deterministic ambiguity-resolution. The
+	// dataplane attributes the first matching rule it built; we
+	// match that by sorting on policy ID (which embeds the xid
+	// timestamp) ascending — same proxy for creation order the
+	// rest of the management uses elsewhere.
+	policies := append([]*types.Policy(nil), account.Policies...)
+	sort.SliceStable(policies, func(i, j int) bool {
+		return policies[i].ID < policies[j].ID
+	})
+
+	for _, policy := range policies {
+		if policy == nil {
+			continue
+		}
+		for _, rule := range policy.Rules {
+			if rule == nil || !rule.Enabled {
+				continue
+			}
+			if rule.Action != types.PolicyTrafficActionAccept {
+				// Drop rules never produce a useful "policy that
+				// allowed this connection" attribution.
+				continue
+			}
+
+			cand := buildCandidate(policy.ID, rule, groupDestIPs, groupDestPrefixes)
+			if cand == nil {
+				continue
+			}
+
+			// Wire the candidate to every peer on the rule's
+			// source side. We attach by peer ID so the hot path is
+			// O(1) without a Groups indirection.
+			for _, srcGroup := range rule.Sources {
+				for _, peerID := range groupPeers[srcGroup] {
+					idx.byPeer[peerID] = append(idx.byPeer[peerID], cand)
+				}
+			}
+		}
+	}
+
+	return idx
+}
+
+// buildCandidate assembles a single (policy, rule) entry. Returns
+// nil when the rule has no resolvable destination (the dashboard
+// doesn't need to attribute traffic to "no destination").
+func buildCandidate(policyID string, rule *types.PolicyRule,
+	groupDestIPs map[string][]netip.Addr,
+	groupDestPrefixes map[string][]netip.Prefix,
+) *policyCandidate {
+	c := &policyCandidate{
+		policyID: policyID,
+		dstIPs:   make(map[netip.Addr]struct{}),
+		protocol: protoFromRule(rule.Protocol),
+		ports:    portsFromRule(rule.Ports, rule.PortRanges),
+	}
+
+	for _, gid := range rule.Destinations {
+		for _, addr := range groupDestIPs[gid] {
+			c.dstIPs[addr] = struct{}{}
+		}
+		c.dstPrefixes = append(c.dstPrefixes, groupDestPrefixes[gid]...)
+	}
+
+	if rule.DestinationResource.ID != "" {
+		// Resource on the rule directly (not via group). The
+		// resource was already resolved into the destination
+		// helpers above when we walked NetworkResources; nothing
+		// to add here, the per-resource expansion handles it.
+	}
+
+	if len(c.dstIPs) == 0 && len(c.dstPrefixes) == 0 {
+		return nil
+	}
+	return c
+}
+
+// resourceDestination converts a NetworkResource's Prefix into the
+// kind of destination the matcher uses. Single-IP prefixes (/32
+// IPv4, /128 IPv6) become explicit dstIPs entries; broader prefixes
+// stay as CIDRs.
+func resourceDestination(prefix netip.Prefix) (netip.Addr, netip.Prefix, bool) {
+	if !prefix.IsValid() {
+		return netip.Addr{}, netip.Prefix{}, false
+	}
+	if prefix.IsSingleIP() {
+		return prefix.Addr(), netip.Prefix{}, true
+	}
+	return netip.Addr{}, prefix, true
+}
+
+// protoFromRule maps the string-typed PolicyRuleProtocolType to the
+// proto enum the matcher uses.
+func protoFromRule(p types.PolicyRuleProtocolType) proto {
+	switch p {
+	case types.PolicyRuleProtocolALL:
+		return protoAny
+	case types.PolicyRuleProtocolTCP:
+		return protoTCP
+	case types.PolicyRuleProtocolUDP:
+		return protoUDP
+	case types.PolicyRuleProtocolICMP:
+		return protoICMP
+	}
+	return protoAny
+}
+
+// portsFromRule normalises the rule's Ports (single ports as strings)
+// + PortRanges into a slice of portRange. Invalid entries are
+// silently dropped — the dataplane treats them the same way, so the
+// resolver matches that behaviour.
+func portsFromRule(ports []string, ranges []types.RulePortRange) []portRange {
+	out := make([]portRange, 0, len(ports)+len(ranges))
+	for _, p := range ports {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		n, err := strconv.ParseUint(p, 10, 16)
+		if err != nil {
+			continue
+		}
+		out = append(out, portRange{Start: uint16(n), End: uint16(n)})
+	}
+	for _, r := range ranges {
+		if r.Start == 0 || r.End == 0 || r.End < r.Start {
+			continue
+		}
+		out = append(out, portRange{Start: r.Start, End: r.End})
+	}
+	return out
+}

--- a/management/server/flow_policy_resolver/match.go
+++ b/management/server/flow_policy_resolver/match.go
@@ -1,0 +1,98 @@
+package flow_policy_resolver
+
+import (
+	"net/netip"
+)
+
+// policyCandidate is one (policy, rule) pair the resolver checks
+// against an event. A peer appears in multiple candidates when it
+// is on the source side of multiple policies — each rule that
+// could attribute its outbound traffic produces one entry.
+//
+// candidates are sorted by policy creation time (older first) so
+// the first match wins, mirroring the dataplane's ordering.
+type policyCandidate struct {
+	policyID string
+
+	// dstIPs is the set of single IPs in destination groups (peers
+	// + Host resources). Cheap pointer-compare on membership.
+	dstIPs map[netip.Addr]struct{}
+
+	// dstPrefixes is the set of CIDRs in destination groups (Subnet
+	// resources). Linear scan; typical accounts have <10 prefixes
+	// per candidate so this is fine.
+	dstPrefixes []netip.Prefix
+
+	// ports is the union of single ports and ranges the rule
+	// allows. Empty slice means "any port".
+	ports []portRange
+
+	// protocol is the rule's protocol filter. protoAny means any.
+	protocol proto
+}
+
+// proto is a uint8 mirror of types.PolicyRuleProtocolType so the hot
+// path stays branch-friendly. Values match the IANA numbers the
+// netflow collector already emits.
+type proto uint8
+
+const (
+	protoAny  proto = 0   // matches anything (PolicyRuleProtocolALL)
+	protoICMP proto = 1
+	protoTCP  proto = 6
+	protoUDP  proto = 17
+)
+
+// portRange is a half-open [Start, End] interval in network byte
+// space. The dataplane matches inclusive on both ends, so we follow.
+type portRange struct {
+	Start uint16
+	End   uint16
+}
+
+// matches returns true when (dst, port, p) satisfies this
+// candidate's predicates. Ordering: protocol → port → destination,
+// cheapest checks first.
+func (c *policyCandidate) matches(dst netip.Addr, port uint32, p uint16) bool {
+	if !matchProto(c.protocol, proto(p)) {
+		return false
+	}
+	if !matchPort(c.ports, uint16(port)) {
+		return false
+	}
+	return c.matchDest(dst)
+}
+
+// matchProto returns true when filter matches actual, with
+// protoAny acting as wildcard.
+func matchProto(filter, actual proto) bool {
+	return filter == protoAny || filter == actual
+}
+
+// matchPort returns true when port is in any of the ranges, or when
+// the rule had no port filter (empty slice).
+func matchPort(ports []portRange, port uint16) bool {
+	if len(ports) == 0 {
+		return true
+	}
+	for _, r := range ports {
+		if port >= r.Start && port <= r.End {
+			return true
+		}
+	}
+	return false
+}
+
+// matchDest checks the destination IP against the candidate's
+// destination set (single IPs + CIDR prefixes).
+func (c *policyCandidate) matchDest(dst netip.Addr) bool {
+	if _, ok := c.dstIPs[dst]; ok {
+		return true
+	}
+	for _, prefix := range c.dstPrefixes {
+		if prefix.Contains(dst) {
+			return true
+		}
+	}
+	return false
+}

--- a/management/server/flow_policy_resolver/resolver.go
+++ b/management/server/flow_policy_resolver/resolver.go
@@ -105,10 +105,19 @@ func (r *Resolver) Forget(accountID string) {
 // store.Event holds destinations as strings (the DTO layer formats
 // them); the resolver matches in netip space for cheap CIDR
 // containment checks.
+//
+// Unmap is intentional: an IPv4-mapped IPv6 address ("::ffff:10.0.0.1")
+// must compare equal to its bare IPv4 form ("10.0.0.1") for index
+// lookups to hit. Without this normalisation a malicious or
+// misconfigured peer could report dst_ip in the mapped form to
+// evade attribution (matching nothing, leaving rule_id null) —
+// audit-quality issue, low severity but real. The index builder
+// also unmaps peer IPs (see index.go::buildGroupExpansion), so both
+// sides of the comparison are normalised.
 func parseIP(s string) (netip.Addr, bool) {
 	a, err := netip.ParseAddr(s)
 	if err != nil {
 		return netip.Addr{}, false
 	}
-	return a, true
+	return a.Unmap(), true
 }

--- a/management/server/flow_policy_resolver/resolver.go
+++ b/management/server/flow_policy_resolver/resolver.go
@@ -1,0 +1,114 @@
+// Package flow_policy_resolver fills the RuleId field on flow events
+// that the agent could not stamp at firewall time. See ADR-0018 for
+// the design.
+//
+// The resolver runs only when FlowEvent.RuleId is empty (the agent's
+// kernel-firewall path could not stamp it — typically outbound flows
+// from a Linux peer in initiator role). Events that already carry a
+// rule_id pass through untouched.
+//
+// Lookup is O(1) hash on peer_id to fetch the peer's candidate list,
+// then a linear scan of the (typically 5-50) candidates with cheap
+// predicate checks. Memory cost is bounded by the candidate-list
+// shape: the same []policyCandidate slice would be repeated across
+// peers in the same source group, so we keep a single shared backing
+// array per source group in v1 to avoid the cartesian product.
+//
+// Invalidation is driven by the existing Account.Manager event
+// surface: any time the management would re-compute network maps
+// (policy save, peer add/remove, group membership change, resource
+// edit), the resolver rebuilds the affected account's index.
+package flow_policy_resolver
+
+import (
+	"net/netip"
+	"sync"
+
+	"github.com/openzro/openzro/flow/store"
+)
+
+// Resolver fills FlowEvent.RuleId server-side. Construct with New().
+// Methods are safe for concurrent use; the hot path holds an RLock
+// while reading the per-account index.
+type Resolver struct {
+	mu     sync.RWMutex
+	cache  map[string]*accountIndex // accountID → index
+}
+
+// New returns a Resolver with no accounts cached. Callers must
+// invoke Rebuild(accountID, *types.Account) at least once before
+// the resolver can serve queries for that account.
+func New() *Resolver {
+	return &Resolver{
+		cache: make(map[string]*accountIndex),
+	}
+}
+
+// Resolve attempts to fill an empty RuleId on the given event by
+// looking up the (peer_id, dst_ip, dst_port, protocol) tuple against
+// the cached policy graph. Returns the event unchanged when:
+//
+//   - the event already has a RuleId set (agent stamped it; primary
+//     path), OR
+//   - the resolver has no index for the account, OR
+//   - no candidate policy matches the tuple.
+//
+// Mutates the event in place when a match is found, then returns it.
+// The bool reports whether a match was applied.
+func (r *Resolver) Resolve(accountID string, e *store.Event) bool {
+	if e == nil {
+		return false
+	}
+	if len(e.RuleID) != 0 {
+		return false
+	}
+	if accountID == "" || e.PeerID == "" {
+		return false
+	}
+
+	r.mu.RLock()
+	idx := r.cache[accountID]
+	r.mu.RUnlock()
+	if idx == nil {
+		return false
+	}
+
+	candidates := idx.candidatesForPeer(e.PeerID)
+	if len(candidates) == 0 {
+		return false
+	}
+
+	dst, ok := parseIP(e.DestIP)
+	if !ok {
+		return false
+	}
+
+	for _, c := range candidates {
+		if !c.matches(dst, e.DestPort, e.Protocol) {
+			continue
+		}
+		e.RuleID = []byte(c.policyID)
+		return true
+	}
+	return false
+}
+
+// Forget drops the cached index for an account. Used when an account
+// is deleted; lets us reclaim memory without waiting for restart.
+func (r *Resolver) Forget(accountID string) {
+	r.mu.Lock()
+	delete(r.cache, accountID)
+	r.mu.Unlock()
+}
+
+// parseIP turns the wire-shape IP string back into a netip.Addr.
+// store.Event holds destinations as strings (the DTO layer formats
+// them); the resolver matches in netip space for cheap CIDR
+// containment checks.
+func parseIP(s string) (netip.Addr, bool) {
+	a, err := netip.ParseAddr(s)
+	if err != nil {
+		return netip.Addr{}, false
+	}
+	return a, true
+}

--- a/management/server/flow_policy_resolver/resolver_test.go
+++ b/management/server/flow_policy_resolver/resolver_test.go
@@ -283,3 +283,122 @@ func newNetworkResource(id string, groupIDs []string, prefix netip.Prefix) *reso
 		Enabled:  true,
 	}
 }
+
+// TestResolve_BidirectionalReverseAttribution covers the case that
+// the v1 resolver missed: when a policy is bidirectional, the
+// dataplane installs reverse-direction firewall rules so peers in
+// the destination group can initiate to peers in the source group.
+// The original resolver only indexed the forward direction and
+// returned empty for these reverse flows. Mirrors account.go:998.
+func TestResolve_BidirectionalReverseAttribution(t *testing.T) {
+	acc := fixtureAccount()
+	// Make the existing TCP policy bidirectional. Now traffic from
+	// peer-c (in group-servers, the destination side) to peer-a (in
+	// group-laptops, the source side) on port 443 should attribute
+	// to this policy too.
+	acc.Policies[0].Rules[0].Bidirectional = true
+
+	r := New()
+	r.Rebuild("acc-1", acc)
+
+	reverse := newEvent("peer-c", "10.0.0.1", 443, 6) // peer-c → peer-a
+	require.True(t, r.Resolve("acc-1", reverse),
+		"bidirectional reverse: dest-side peer initiating to source-side peer must resolve")
+	assert.Equal(t, "p-allow-tcp-2026-05-01", string(reverse.RuleID))
+
+	// Forward direction must still resolve unchanged.
+	forward := newEvent("peer-a", "10.0.0.3", 443, 6)
+	require.True(t, r.Resolve("acc-1", forward))
+	assert.Equal(t, "p-allow-tcp-2026-05-01", string(forward.RuleID))
+}
+
+// TestResolve_NonBidirectionalDoesNotReverseAttribute is the
+// regression counterpart: a unidirectional policy MUST NOT
+// attribute reverse-direction flows. The dataplane only installs
+// rules in the forward direction, so traffic dest→source on a
+// unidirectional rule is permitted by some OTHER policy (or
+// dropped); attributing it to a unidirectional rule's policy
+// would be a fabricated correlation.
+func TestResolve_NonBidirectionalDoesNotReverseAttribute(t *testing.T) {
+	acc := fixtureAccount()
+	// Explicitly unidirectional (the default — fixtureAccount leaves
+	// Bidirectional unset = false).
+	acc.Policies[0].Rules[0].Bidirectional = false
+
+	r := New()
+	r.Rebuild("acc-1", acc)
+
+	reverse := newEvent("peer-c", "10.0.0.1", 443, 6) // peer-c → peer-a
+	assert.False(t, r.Resolve("acc-1", reverse),
+		"unidirectional policy must not attribute reverse-direction flows")
+	assert.Empty(t, reverse.RuleID)
+}
+
+// TestResolve_DestinationResourceDirect covers the rule shape where
+// the destination is a direct NetworkResource reference (not via a
+// group). The dataplane allows either Destinations OR
+// DestinationResource — see policies_handler.go:161. Both should
+// resolve.
+func TestResolve_DestinationResourceDirect(t *testing.T) {
+	acc := fixtureAccount()
+	subnet := netip.MustParsePrefix("10.50.0.0/24")
+	res := newNetworkResource("res-direct", nil, subnet)
+	acc.NetworkResources = append(acc.NetworkResources, res)
+
+	// Replace the rule's group destination with a direct resource ref.
+	acc.Policies[0].Rules[0].Destinations = nil
+	acc.Policies[0].Rules[0].DestinationResource = types.Resource{
+		ID:   "res-direct",
+		Type: "subnet",
+	}
+
+	r := New()
+	r.Rebuild("acc-1", acc)
+
+	ev := newEvent("peer-a", "10.50.0.42", 443, 6)
+	require.True(t, r.Resolve("acc-1", ev),
+		"direct DestinationResource reference must attribute matching flows")
+	assert.Equal(t, "p-allow-tcp-2026-05-01", string(ev.RuleID))
+}
+
+// TestResolve_DisabledPolicyIgnored guards against attributing
+// flows to a policy whose top-level Enabled flag is false. The
+// dataplane skips disabled policies entirely; the resolver must
+// too. (We were already filtering disabled RULES; this adds the
+// policy-level check.)
+func TestResolve_DisabledPolicyIgnored(t *testing.T) {
+	acc := fixtureAccount()
+	acc.Policies[0].Enabled = false
+
+	r := New()
+	r.Rebuild("acc-1", acc)
+
+	ev := newEvent("peer-a", "10.0.0.3", 443, 6)
+	assert.False(t, r.Resolve("acc-1", ev),
+		"disabled policy must not produce any attribution")
+}
+
+// TestResolve_BidirectionalWithResourceReverse stresses the reverse
+// path with a NetworkResource folded into the rule's source-side
+// groups via resource.GroupIDs. When bidirectional, the reverse
+// direction's destinations come from rule.Sources / rule.SourceResource
+// — the SAME slot the dataplane uses for the forward direction's
+// source peers + their resources.
+func TestResolve_BidirectionalWithResourceReverse(t *testing.T) {
+	acc := fixtureAccount()
+	subnet := netip.MustParsePrefix("172.16.0.0/24")
+	res := newNetworkResource("res-svc", []string{"group-laptops"}, subnet)
+	acc.NetworkResources = append(acc.NetworkResources, res)
+
+	acc.Policies[0].Rules[0].Bidirectional = true
+
+	r := New()
+	r.Rebuild("acc-1", acc)
+
+	// peer-c (in group-servers / dest) reaching the laptop-subnet
+	// (172.16.0.0/24, folded into group-laptops on the source side).
+	ev := newEvent("peer-c", "172.16.0.99", 443, 6)
+	require.True(t, r.Resolve("acc-1", ev),
+		"bidirectional reverse must walk source-side resources too")
+	assert.Equal(t, "p-allow-tcp-2026-05-01", string(ev.RuleID))
+}

--- a/management/server/flow_policy_resolver/resolver_test.go
+++ b/management/server/flow_policy_resolver/resolver_test.go
@@ -1,0 +1,285 @@
+package flow_policy_resolver
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openzro/openzro/flow/store"
+	resourceTypes "github.com/openzro/openzro/management/server/networks/resources/types"
+	nbpeer "github.com/openzro/openzro/management/server/peer"
+	"github.com/openzro/openzro/management/server/types"
+)
+
+// fixtureAccount builds a small account graph used across cases:
+//
+//	peer-a (10.0.0.1) ∈ group-laptops
+//	peer-b (10.0.0.2) ∈ group-laptops
+//	peer-c (10.0.0.3) ∈ group-servers
+//
+//	policy-allow-laptops-to-servers (rule: laptops → servers, TCP/443)
+//	policy-allow-any-icmp           (rule: laptops → servers, ICMP)
+//
+// Tests extend / mutate this fixture as needed.
+func fixtureAccount() *types.Account {
+	peerA := &nbpeer.Peer{ID: "peer-a", IP: net.ParseIP("10.0.0.1")}
+	peerB := &nbpeer.Peer{ID: "peer-b", IP: net.ParseIP("10.0.0.2")}
+	peerC := &nbpeer.Peer{ID: "peer-c", IP: net.ParseIP("10.0.0.3")}
+
+	groupLaptops := &types.Group{ID: "group-laptops", Peers: []string{"peer-a", "peer-b"}}
+	groupServers := &types.Group{ID: "group-servers", Peers: []string{"peer-c"}}
+
+	allowTCP := &types.Policy{
+		ID:      "p-allow-tcp-2026-05-01",
+		Enabled: true,
+		Rules: []*types.PolicyRule{{
+			ID:           "r-allow-tcp",
+			Enabled:      true,
+			Action:       types.PolicyTrafficActionAccept,
+			Sources:      []string{"group-laptops"},
+			Destinations: []string{"group-servers"},
+			Protocol:     types.PolicyRuleProtocolTCP,
+			Ports:        []string{"443"},
+		}},
+	}
+
+	allowICMP := &types.Policy{
+		ID:      "p-allow-icmp-2026-05-02",
+		Enabled: true,
+		Rules: []*types.PolicyRule{{
+			ID:           "r-allow-icmp",
+			Enabled:      true,
+			Action:       types.PolicyTrafficActionAccept,
+			Sources:      []string{"group-laptops"},
+			Destinations: []string{"group-servers"},
+			Protocol:     types.PolicyRuleProtocolICMP,
+		}},
+	}
+
+	return &types.Account{
+		Peers: map[string]*nbpeer.Peer{
+			"peer-a": peerA, "peer-b": peerB, "peer-c": peerC,
+		},
+		Groups: map[string]*types.Group{
+			"group-laptops": groupLaptops, "group-servers": groupServers,
+		},
+		Policies: []*types.Policy{allowTCP, allowICMP},
+	}
+}
+
+func newEvent(peerID, dstIP string, dstPort uint32, proto uint16) *store.Event {
+	return &store.Event{
+		PeerID:   peerID,
+		DestIP:   dstIP,
+		DestPort: dstPort,
+		Protocol: proto,
+	}
+}
+
+func TestResolve_HappyPath(t *testing.T) {
+	r := New()
+	r.Rebuild("acc-1", fixtureAccount())
+
+	ev := newEvent("peer-a", "10.0.0.3", 443, 6)
+	require.True(t, r.Resolve("acc-1", ev), "should resolve a TCP/443 flow to peer-c")
+	assert.Equal(t, "p-allow-tcp-2026-05-01", string(ev.RuleID))
+}
+
+func TestResolve_ICMPMatchesProtocolOnly(t *testing.T) {
+	r := New()
+	r.Rebuild("acc-1", fixtureAccount())
+
+	// ICMP doesn't carry a port; DestPort=0. The matcher should
+	// accept (empty port filter == any).
+	ev := newEvent("peer-b", "10.0.0.3", 0, 1) // proto 1 = ICMP
+	require.True(t, r.Resolve("acc-1", ev))
+	assert.Equal(t, "p-allow-icmp-2026-05-02", string(ev.RuleID))
+}
+
+func TestResolve_AmbiguityFirstByPolicyID(t *testing.T) {
+	acc := fixtureAccount()
+	// Add a second TCP/443 policy with a LATER ID. The older
+	// p-allow-tcp-2026-05-01 must still win the tiebreaker.
+	acc.Policies = append(acc.Policies, &types.Policy{
+		ID:      "p-also-tcp-2026-05-15",
+		Enabled: true,
+		Rules: []*types.PolicyRule{{
+			Enabled:      true,
+			Action:       types.PolicyTrafficActionAccept,
+			Sources:      []string{"group-laptops"},
+			Destinations: []string{"group-servers"},
+			Protocol:     types.PolicyRuleProtocolTCP,
+			Ports:        []string{"443"},
+		}},
+	})
+
+	r := New()
+	r.Rebuild("acc-1", acc)
+
+	ev := newEvent("peer-a", "10.0.0.3", 443, 6)
+	require.True(t, r.Resolve("acc-1", ev))
+	assert.Equal(t, "p-allow-tcp-2026-05-01", string(ev.RuleID), "older policy wins")
+}
+
+func TestResolve_NoMatchLeavesEmpty(t *testing.T) {
+	r := New()
+	r.Rebuild("acc-1", fixtureAccount())
+
+	// peer-a tries to reach a destination outside any group.
+	ev := newEvent("peer-a", "10.0.0.99", 443, 6)
+	assert.False(t, r.Resolve("acc-1", ev))
+	assert.Empty(t, ev.RuleID)
+}
+
+func TestResolve_PassThroughWhenAgentStamped(t *testing.T) {
+	r := New()
+	r.Rebuild("acc-1", fixtureAccount())
+
+	ev := newEvent("peer-a", "10.0.0.3", 443, 6)
+	ev.RuleID = []byte("agent-stamped-policy-id")
+	assert.False(t, r.Resolve("acc-1", ev), "must not overwrite an agent-stamped RuleID")
+	assert.Equal(t, "agent-stamped-policy-id", string(ev.RuleID))
+}
+
+func TestResolve_PortRangeMatch(t *testing.T) {
+	acc := fixtureAccount()
+	acc.Policies[0].Rules[0].Ports = nil
+	acc.Policies[0].Rules[0].PortRanges = []types.RulePortRange{{Start: 8000, End: 8999}}
+
+	r := New()
+	r.Rebuild("acc-1", acc)
+
+	hit := newEvent("peer-a", "10.0.0.3", 8443, 6)
+	require.True(t, r.Resolve("acc-1", hit))
+	assert.Equal(t, "p-allow-tcp-2026-05-01", string(hit.RuleID))
+
+	miss := newEvent("peer-a", "10.0.0.3", 9000, 6)
+	assert.False(t, r.Resolve("acc-1", miss))
+}
+
+func TestResolve_ProtocolALLMatchesAnything(t *testing.T) {
+	acc := fixtureAccount()
+	// Replace the TCP rule with an ALL rule.
+	acc.Policies[0].Rules[0].Protocol = types.PolicyRuleProtocolALL
+	acc.Policies[0].Rules[0].Ports = nil
+
+	r := New()
+	r.Rebuild("acc-1", acc)
+
+	// Same policy hits for TCP, UDP, ICMP.
+	for _, p := range []uint16{6, 17, 1} {
+		ev := newEvent("peer-a", "10.0.0.3", 443, p)
+		require.True(t, r.Resolve("acc-1", ev), "proto=%d should match ALL rule", p)
+	}
+}
+
+func TestResolve_SubnetResourceDestination(t *testing.T) {
+	acc := fixtureAccount()
+	subnet := netip.MustParsePrefix("10.10.0.0/24")
+	res := newNetworkResource("res-internal", []string{"group-servers"}, subnet)
+	acc.NetworkResources = append(acc.NetworkResources, res)
+
+	r := New()
+	r.Rebuild("acc-1", acc)
+
+	ev := newEvent("peer-a", "10.10.0.42", 443, 6)
+	require.True(t, r.Resolve("acc-1", ev), "destination IP inside Subnet resource should match")
+	assert.Equal(t, "p-allow-tcp-2026-05-01", string(ev.RuleID))
+}
+
+func TestResolve_HostResourceDestination(t *testing.T) {
+	acc := fixtureAccount()
+	host := netip.MustParsePrefix("10.20.0.5/32")
+	res := newNetworkResource("res-host", []string{"group-servers"}, host)
+	acc.NetworkResources = append(acc.NetworkResources, res)
+
+	r := New()
+	r.Rebuild("acc-1", acc)
+
+	hit := newEvent("peer-a", "10.20.0.5", 443, 6)
+	require.True(t, r.Resolve("acc-1", hit))
+
+	miss := newEvent("peer-a", "10.20.0.6", 443, 6)
+	assert.False(t, r.Resolve("acc-1", miss))
+}
+
+func TestResolve_UnknownPeerReturnsFalse(t *testing.T) {
+	r := New()
+	r.Rebuild("acc-1", fixtureAccount())
+
+	ev := newEvent("peer-ghost", "10.0.0.3", 443, 6)
+	assert.False(t, r.Resolve("acc-1", ev))
+}
+
+func TestResolve_CrossAccountIsolation(t *testing.T) {
+	r := New()
+	// Same peer ID, two unrelated accounts. Only acc-1's policy
+	// graph contains it; querying acc-2 must miss.
+	r.Rebuild("acc-1", fixtureAccount())
+
+	ev := newEvent("peer-a", "10.0.0.3", 443, 6)
+	assert.False(t, r.Resolve("acc-2", ev), "peer in acc-1 cannot resolve via acc-2 index")
+	assert.False(t, r.Resolve("", ev), "empty accountID never resolves")
+}
+
+func TestResolve_DropRulesAreNotCandidates(t *testing.T) {
+	acc := fixtureAccount()
+	acc.Policies[0].Rules[0].Action = types.PolicyTrafficActionDrop
+
+	r := New()
+	r.Rebuild("acc-1", acc)
+
+	ev := newEvent("peer-a", "10.0.0.3", 443, 6)
+	assert.False(t, r.Resolve("acc-1", ev), "Drop rules must not produce attribution")
+}
+
+func TestResolve_DisabledRuleIgnored(t *testing.T) {
+	acc := fixtureAccount()
+	acc.Policies[0].Rules[0].Enabled = false
+
+	r := New()
+	r.Rebuild("acc-1", acc)
+
+	ev := newEvent("peer-a", "10.0.0.3", 443, 6)
+	assert.False(t, r.Resolve("acc-1", ev))
+}
+
+func TestResolve_NilEventSafe(t *testing.T) {
+	r := New()
+	r.Rebuild("acc-1", fixtureAccount())
+	assert.False(t, r.Resolve("acc-1", nil), "nil event must not panic")
+}
+
+func TestRebuild_NilAccountForgets(t *testing.T) {
+	r := New()
+	r.Rebuild("acc-1", fixtureAccount())
+	r.Rebuild("acc-1", nil)
+
+	ev := newEvent("peer-a", "10.0.0.3", 443, 6)
+	assert.False(t, r.Resolve("acc-1", ev), "Rebuild(nil) must drop the index")
+}
+
+func TestForget_RemovesAccount(t *testing.T) {
+	r := New()
+	r.Rebuild("acc-1", fixtureAccount())
+	r.Forget("acc-1")
+
+	ev := newEvent("peer-a", "10.0.0.3", 443, 6)
+	assert.False(t, r.Resolve("acc-1", ev))
+}
+
+// newNetworkResource is a thin constructor that bypasses
+// NewNetworkResource's address-parsing logic (we already have a
+// netip.Prefix in hand). Mirrors the in-memory shape the account
+// cache uses post-load.
+func newNetworkResource(id string, groupIDs []string, prefix netip.Prefix) *resourceTypes.NetworkResource {
+	return &resourceTypes.NetworkResource{
+		ID:       id,
+		Prefix:   prefix,
+		GroupIDs: groupIDs,
+		Enabled:  true,
+	}
+}

--- a/management/server/flow_service.go
+++ b/management/server/flow_service.go
@@ -42,6 +42,11 @@ type FlowService struct {
 	sinks    []store.Sink
 	resolver PeerResolver
 	cache    *peerCache
+	// policyResolver fills FlowEvent.RuleID for events the agent
+	// could not stamp at firewall time (ADR-0018). Optional — when
+	// nil, events pass through with whatever RuleID the agent
+	// reported. Wired via WithPolicyResolver.
+	policyResolver PolicyResolver
 
 	bufferSize int
 	batchSize  int
@@ -51,6 +56,14 @@ type FlowService struct {
 	wg     sync.WaitGroup
 	stopCh chan struct{}
 	closed sync.Once
+}
+
+// PolicyResolver is the narrow contract FlowService needs from the
+// flow_policy_resolver package. Defined here (not imported) so the
+// package boundary stays clean and the resolver can be mocked in
+// tests without bringing the resolver's own dependencies along.
+type PolicyResolver interface {
+	Resolve(accountID string, e *store.Event) bool
 }
 
 // PeerResolver maps a WireGuard public key (raw 32 bytes from the
@@ -88,6 +101,22 @@ func WithFlushInterval(d time.Duration) FlowServiceOption {
 		if d > 0 {
 			s.flushEvery = d
 		}
+	}
+}
+
+// WithPolicyResolver installs an ADR-0018 fallback resolver. The
+// resolver is consulted only for events the agent left RuleID-empty
+// (typically outbound flows from Linux kernel peers — see ADR-0018
+// for the agent-side gap). Events the agent already stamped pass
+// through untouched, so the resolver runs on a minority of events
+// in mixed deployments.
+//
+// Passing nil is a no-op; the service behaves as if no resolver is
+// configured. Use this to disable the resolver for benchmarking
+// without changing wiring.
+func WithPolicyResolver(r PolicyResolver) FlowServiceOption {
+	return func(s *FlowService) {
+		s.policyResolver = r
 	}
 }
 
@@ -322,7 +351,15 @@ func (s *FlowService) flush(ctx context.Context, batch []*bufferedEvent) {
 			peerID, accountID = pid, aid
 			s.cache.put(b64key(key), pid, aid)
 		}
-		events = append(events, fromProto(b.proto, peerID, accountID, b.received))
+		ev := fromProto(b.proto, peerID, accountID, b.received)
+		// ADR-0018 fallback: fill RuleID when the agent could not
+		// stamp it at firewall time. No-op when policyResolver is
+		// nil or when RuleID is already set (the agent did its
+		// job, primary path).
+		if s.policyResolver != nil {
+			s.policyResolver.Resolve(accountID, ev)
+		}
+		events = append(events, ev)
 	}
 	if len(events) == 0 {
 		return

--- a/management/server/flow_service_test.go
+++ b/management/server/flow_service_test.go
@@ -267,3 +267,171 @@ func TestFlowService_DropsEventsWithUnknownPeer(t *testing.T) {
 	assert.Empty(t, mem.all(),
 		"events whose peer cannot be resolved must be dropped, never persisted with empty account_id")
 }
+
+// fakePolicyResolver lets tests inspect resolver invocations and
+// optionally fill RuleID with a canned value. Mirrors the
+// PolicyResolver interface flow_service expects.
+type fakePolicyResolver struct {
+	mu      sync.Mutex
+	calls   []fakePolicyCall
+	stampID string // when set, all unstamped events get this RuleID
+}
+
+type fakePolicyCall struct {
+	accountID string
+	ruleID    string
+}
+
+func (f *fakePolicyResolver) Resolve(accountID string, e *flowstore.Event) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, fakePolicyCall{accountID: accountID, ruleID: string(e.RuleID)})
+	if len(e.RuleID) != 0 {
+		return false
+	}
+	if f.stampID == "" {
+		return false
+	}
+	e.RuleID = []byte(f.stampID)
+	return true
+}
+
+func (f *fakePolicyResolver) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.calls)
+}
+
+// startFlowServiceWithPolicyResolver wires the service with both a
+// store and an ADR-0018 policy resolver. Used by the resolver-wiring
+// tests below.
+func startFlowServiceWithPolicyResolver(t *testing.T, store flowstore.Sink, resolver PeerResolver, policy PolicyResolver) (flowProto.FlowServiceClient, func()) {
+	t.Helper()
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	server := grpc.NewServer()
+	fs := NewFlowService(
+		[]flowstore.Sink{store}, resolver,
+		WithBatchSize(2),
+		WithFlushInterval(50*time.Millisecond),
+		WithPolicyResolver(policy),
+	)
+	flowProto.RegisterFlowServiceServer(server, fs)
+	go func() { _ = server.Serve(lis) }()
+
+	conn, err := grpc.NewClient(lis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	cleanup := func() {
+		_ = conn.Close()
+		server.Stop()
+		_ = fs.Close()
+	}
+	return flowProto.NewFlowServiceClient(conn), cleanup
+}
+
+// TestFlowService_PolicyResolver_FillsEmptyRuleID covers the
+// happy-path wiring (ADR-0018): an event arrives with no RuleID,
+// the resolver fills it, the stored event carries the resolver's
+// PolicyID.
+func TestFlowService_PolicyResolver_FillsEmptyRuleID(t *testing.T) {
+	mem := newInMemoryStore()
+	pubKey := []byte("01234567890123456789012345678901")
+	peerResolver := func(context.Context, []byte) (string, string, error) {
+		return "peer-1", "acct-1", nil
+	}
+	policy := &fakePolicyResolver{stampID: "p-resolved-by-server"}
+
+	client, cleanup := startFlowServiceWithPolicyResolver(t, mem, peerResolver, policy)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream, err := client.Events(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, stream.Send(&flowProto.FlowEvent{
+		EventId:   []byte("e-unstamped"),
+		PublicKey: pubKey,
+		FlowFields: &flowProto.FlowFields{
+			FlowId:   []byte("f1"),
+			Protocol: 6,
+			SourceIp: []byte{10, 0, 0, 1},
+			DestIp:   []byte{10, 0, 0, 2},
+			ConnectionInfo: &flowProto.FlowFields_PortInfo{
+				PortInfo: &flowProto.PortInfo{DestPort: 443},
+			},
+			// RuleId intentionally empty — the Linux kernel
+			// outbound-initiator path can't stamp it.
+		},
+	}))
+	require.NoError(t, stream.CloseSend())
+	if _, err := stream.Recv(); err != nil && err != io.EOF {
+		t.Fatalf("recv: %v", err)
+	}
+
+	select {
+	case <-mem.saveCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not flush")
+	}
+
+	all := mem.all()
+	require.Len(t, all, 1)
+	assert.Equal(t, "p-resolved-by-server", string(all[0].RuleID),
+		"unstamped event must carry the resolver's PolicyID after persist")
+	assert.Equal(t, 1, policy.callCount(), "resolver must be consulted once per unstamped event")
+}
+
+// TestFlowService_PolicyResolver_DoesNotOverwriteAgentStamp asserts
+// that events the agent already stamped (the ADR-0013 primary path:
+// inbound, routing-forward, uspfilter) pass through untouched. The
+// resolver is still consulted to expose the metric, but it returns
+// false and leaves the event alone.
+func TestFlowService_PolicyResolver_DoesNotOverwriteAgentStamp(t *testing.T) {
+	mem := newInMemoryStore()
+	pubKey := []byte("01234567890123456789012345678901")
+	peerResolver := func(context.Context, []byte) (string, string, error) {
+		return "peer-1", "acct-1", nil
+	}
+	policy := &fakePolicyResolver{stampID: "p-resolver-would-have-used"}
+
+	client, cleanup := startFlowServiceWithPolicyResolver(t, mem, peerResolver, policy)
+	defer cleanup()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	stream, err := client.Events(ctx)
+	require.NoError(t, err)
+
+	require.NoError(t, stream.Send(&flowProto.FlowEvent{
+		EventId:   []byte("e-stamped"),
+		PublicKey: pubKey,
+		FlowFields: &flowProto.FlowFields{
+			FlowId:   []byte("f1"),
+			Protocol: 6,
+			SourceIp: []byte{10, 0, 0, 1},
+			DestIp:   []byte{10, 0, 0, 2},
+			ConnectionInfo: &flowProto.FlowFields_PortInfo{
+				PortInfo: &flowProto.PortInfo{DestPort: 443},
+			},
+			RuleId: []byte("agent-stamped-policy-id"),
+		},
+	}))
+	require.NoError(t, stream.CloseSend())
+	if _, err := stream.Recv(); err != nil && err != io.EOF {
+		t.Fatalf("recv: %v", err)
+	}
+
+	select {
+	case <-mem.saveCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not flush")
+	}
+
+	all := mem.all()
+	require.Len(t, all, 1)
+	assert.Equal(t, "agent-stamped-policy-id", string(all[0].RuleID),
+		"agent-stamped RuleID must NOT be overwritten")
+}

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -1287,6 +1287,15 @@ func (am *DefaultAccountManager) UpdateAccountPeers(ctx context.Context, account
 		return
 	}
 
+	// ADR-0018: rebuild the server-side flow policy resolver's
+	// index for this account on every graph change. UpdateAccountPeers
+	// is the chokepoint every policy / peer / group / resource edit
+	// already passes through, so a single hook here keeps the
+	// resolver in sync without spreading new call sites.
+	if am.flowPolicyIndex != nil {
+		am.flowPolicyIndex.Rebuild(accountID, account)
+	}
+
 	globalStart := time.Now()
 
 	hasPeersConnected := false

--- a/management/server/peer_test.go
+++ b/management/server/peer_test.go
@@ -1048,6 +1048,83 @@ func TestUpdateAccountPeers(t *testing.T) {
 	}
 }
 
+// fakeFlowPolicyIndex captures Rebuild / Forget calls for assertion
+// from TestUpdateAccountPeers_RebuildsFlowPolicyIndex below.
+type fakeFlowPolicyIndex struct {
+	mu       sync.Mutex
+	rebuilds []string // accountIDs
+	forgets  []string
+}
+
+func (f *fakeFlowPolicyIndex) Rebuild(accountID string, account *types.Account) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.rebuilds = append(f.rebuilds, accountID)
+}
+
+func (f *fakeFlowPolicyIndex) Forget(accountID string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.forgets = append(f.forgets, accountID)
+}
+
+func (f *fakeFlowPolicyIndex) rebuildCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.rebuilds)
+}
+
+// TestUpdateAccountPeers_RebuildsFlowPolicyIndex asserts the
+// ADR-0018 invalidation hook fires every time UpdateAccountPeers
+// runs. The flow policy resolver must observe every account-graph
+// change the management already pushes through this chokepoint —
+// policy save, peer add/remove, group edit, resource edit all
+// converge on UpdateAccountPeers, so a missed hook here would
+// silently leave the resolver serving stale attribution.
+func TestUpdateAccountPeers_RebuildsFlowPolicyIndex(t *testing.T) {
+	log.SetOutput(io.Discard)
+	defer log.SetOutput(os.Stderr)
+
+	manager, accountID, _, err := setupTestAccountManager(t, 5, 1)
+	if err != nil {
+		t.Fatalf("Failed to setup test account manager: %v", err)
+	}
+
+	idx := &fakeFlowPolicyIndex{}
+	manager.SetFlowPolicyIndex(idx)
+
+	ctx := context.Background()
+	account, err := manager.Store.GetAccount(ctx, accountID)
+	if err != nil {
+		t.Fatalf("Failed to get account: %v", err)
+	}
+
+	peerChannels := make(map[string]chan *UpdateMessage)
+	for peerID := range account.Peers {
+		peerChannels[peerID] = make(chan *UpdateMessage, channelBufferSize)
+	}
+	manager.peersUpdateManager.peerChannels = peerChannels
+
+	manager.UpdateAccountPeers(ctx, accountID)
+	// Drain peers so the fan-out goroutines complete.
+	for _, channel := range peerChannels {
+		<-channel
+	}
+
+	assert.Equal(t, 1, idx.rebuildCount(), "Rebuild must be invoked exactly once per UpdateAccountPeers call")
+	idx.mu.Lock()
+	assert.Equal(t, []string{accountID}, idx.rebuilds)
+	idx.mu.Unlock()
+
+	// Second call should produce a second Rebuild — the hook is
+	// not a one-shot.
+	manager.UpdateAccountPeers(ctx, accountID)
+	for _, channel := range peerChannels {
+		<-channel
+	}
+	assert.Equal(t, 2, idx.rebuildCount(), "every UpdateAccountPeers call must Rebuild the index")
+}
+
 func TestToSyncResponse(t *testing.T) {
 	_, ipnet, err := net.ParseCIDR("192.168.1.0/24")
 	if err != nil {


### PR DESCRIPTION
## Summary

Implements ADR-0018: a server-side resolver in the flow ingest pipeline that fills \`FlowEvent.RuleId\` for events the agent could not stamp at firewall time (Linux kernel outbound-initiator path — see ADR for the architectural gap).

**Depends on #29** — this branch was cut from \`feat/upstream-netflow-resilience\`. After #29 merges, this PR's diff narrows to just the resolver commits.

## What's new

| Commit | What |
|---|---|
| **docs(adr) 0018** | Design + perf budget + alternatives considered |
| **flow_policy_resolver package** | Pure matcher: \`(peer_id, dst_ip, dst_port, protocol)\` → \`PolicyID\`. 16 unit tests covering happy path, ambiguity, port ranges, ALL protocol, Subnet + Host resources, cross-account isolation, drop / disabled rule exclusion |
| **flow_service wiring** | Resolver consulted only when \`RuleID\` is empty. Agent-stamped events pass through untouched. \`WithPolicyResolver\` option + \`PolicyResolver\` interface (narrow, defined in flow_service) |
| **AccountManager invalidation** | \`UpdateAccountPeers\` chokepoint fires \`Rebuild()\` on every account-graph change. Single hook covers all paths that already trigger network-map recompute |
| **cmd/management wiring** | Construct once at boot, plug into both consumers |

## Where this lands in the pipeline

\`\`\`
peer ──gRPC FlowService.Events──> handler ACKs peer
                                     │
                                     ▼
                              policyResolver.Resolve()
                                     ├── event.RuleId != "" → skip (agent stamped)
                                     └── event.RuleId == "" → fill from policy graph
                                     ▼
                                  ┌─ hot store
                                  ├─ SIEM stream
                                  └─ cold archive
\`\`\`

## Why a fallback instead of replacing the agent path

Both agent-side (ADR-0013) and server-side correlation stay. Agent-side is free at ingest (kernel already filled the field) and historically-accurate (snapshot of the policy graph at stamp time). Server-side is the only option for outbound-initiator flows where the kernel never had a chance to stamp. Defense in depth fits openZro's self-hosted positioning. NetBird Cloud appears to do the same thing (their OSS agent emits empty \`RuleId\` always; the cloud must resolve it server-side as their enterprise differentiator).

## Performance

- Build cost per Rebuild: O(policies × source_groups × peers_in_source_groups), typically <100ms for Cora-class accounts
- Lookup cost per event: O(1) hash + O(candidates per peer) — ~1µs on realistic shapes
- Memory per account: ~5-15MB at medium tier (200 peers × 30 policies × ~10 candidates per peer)
- CPU at Cora's volume: <3% of one core
- Zero impact on peer ack latency — resolver runs after ack ships

## Test plan

- [x] \`go test ./management/server/flow_policy_resolver/ -race\` green (16 cases)
- [x] \`go test ./management/server/ -race -run "TestFlowService_PolicyResolver|TestUpdateAccountPeers_RebuildsFlowPolicyIndex"\` green
- [x] Full test suite race-clean
- [ ] Smoke against zt.cora.tools after merge — operator should see \`rule_id\` filled on outbound-initiator flows that previously returned null

## Follow-up (not in this PR)

- Prometheus metrics: hit / miss / skip counters + duration histogram. Will land in a separate PR once we have a baseline from production
- Domain-type resource matching (currently the resolver matches by IP / CIDR only; Domain resources fall through). Needs coordination with the DNS path
- Retroactive enrichment of pre-resolver events. Documented as out of scope in the ADR

🤖 Generated with [Claude Code](https://claude.com/claude-code)