### PR TITLE
fix(#5 R4): pre-update state flush (#5128) + release-pipeline update-manifest producer

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -672,6 +672,39 @@ jobs:
             "dist/openzro_${{ steps.ver.outputs.version }}_darwin_universal.pkg" \
             --repo "${{ github.repository }}" --clobber
 
+      - name: Publish update-manifest.json (openZro #5 R4b)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.ver.outputs.tag }}"
+          VERSION="${{ steps.ver.outputs.version }}"
+          PKG="dist/openzro_${VERSION}_darwin_universal.pkg"
+          # sha256 of the FINAL notarized+stapled pkg. Stapling rewrites
+          # the pkg, so this MUST run after stapler/upload — never hash
+          # a pre-staple artifact (openZro #5 R4b spec, corner case).
+          SHA="$(shasum -a 256 "$PKG" | awk '{print $1}')"
+          URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/openzro_${VERSION}_darwin_universal.pkg"
+          # Schema = version/selfupdate.Manifest (pinned by the Go test
+          # TestManifest_ReleasePipelineShape). One universal pkg, so
+          # both arch keys point at it — selfupdate.ArtifactFor resolves
+          # darwin/<arch> and both map to the universal artifact.
+          # staged_rollout=100 + min_version="" per the signed-off R4
+          # spec: the management-driven path skips staged_rollout (Q2
+          # Authoritative); only the future critical-only fallback (R6)
+          # reads it. jq guarantees valid JSON (no heredoc pitfalls).
+          jq -n \
+            --arg v "$VERSION" --arg u "$URL" --arg s "$SHA" \
+            '{version:$v, min_version:"", staged_rollout:100,
+              artifacts:{"darwin/arm64":{url:$u,sha256:$s},
+                         "darwin/amd64":{url:$u,sha256:$s}}}' \
+            > update-manifest.json
+          # Resolver (ResolveManifestTemplateURL) expects exactly this
+          # asset at the v{version} tag:
+          #   https://github.com/<repo>/releases/download/v{version}/update-manifest.json
+          gh release upload "${TAG}" update-manifest.json \
+            --repo "${{ github.repository }}" --clobber
+
   release_dex:
     name: Build + push themed Dex container image
     runs-on: ubuntu-22.04

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -117,6 +117,12 @@ jobs:
           # `--skip=homebrew` flag (set above when token is absent)
           # bypasses the brews step entirely.
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          # #5 R4: the openzro build ldflag pins
+          # selfupdate.buildTeamID via `{{ index .Env "APPLE_TEAM_ID" }}`.
+          # Without this export the shipped daemon has BuildTeamID()==""
+          # and every future self-update fails closed at Verify. Empty
+          # (no secret) stays fail-closed by design.
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Upload snapshot artifacts
         if: github.event_name != 'push'
@@ -553,22 +559,43 @@ jobs:
             "$APP"
           codesign --verify --deep --strict --verbose=2 "$APP"
 
-      - name: Author postinstall script
+      - name: Author pkg pre/postinstall scripts
         run: |
           set -euo pipefail
           mkdir -p pkg-scripts
 
+          # PREINSTALL runs BEFORE the payload is written. On an
+          # upgrade this is the OLD binary stopping its own daemon, so
+          # the stale process cannot keep running the old code after
+          # the new files land. Without this the pkg only replaced
+          # files on disk and the daemon kept executing the previous
+          # version — "installed" did not mean "running the new
+          # version" (openZro #5 R4 review #2). Best-effort.
+          cat > pkg-scripts/preinstall <<'PREINSTALL'
+          #!/bin/bash
+          set -u
+          /usr/local/bin/openzro service stop >/dev/null 2>&1 || true
+          /usr/bin/osascript -e 'quit app "openZro UI"' >/dev/null 2>&1 || true
+          exit 0
+          PREINSTALL
+          chmod 0755 pkg-scripts/preinstall
+
+          # POSTINSTALL registers the daemon then FORCES the freshly
+          # installed binary to be the running process. kardianos
+          # `service start` on macOS is only `launchctl load` — a
+          # no-op when the label is already loaded from the prior
+          # version, so an upgrade would otherwise keep the old daemon
+          # alive. stop+start clears a stale load; `launchctl
+          # kickstart -k` guarantees a kill+respawn under the new
+          # binary. All non-fatal: the pkg still lays down the
+          # binaries even if launchd is unhappy.
           cat > pkg-scripts/postinstall <<'POSTINSTALL'
           #!/bin/bash
-          # openZro pkg postinstall — register the daemon via the
-          # binary's built-in `service install` (kardianos/service
-          # writes a /Library/LaunchDaemons/io.openzro.client.plist).
-          # Failures are non-fatal: the package still installs the
-          # binaries, the user can run `sudo openzro service install`
-          # by hand if anything blocks here.
           set -u
           /usr/local/bin/openzro service install >/dev/null 2>&1 || true
+          /usr/local/bin/openzro service stop    >/dev/null 2>&1 || true
           /usr/local/bin/openzro service start   >/dev/null 2>&1 || true
+          /bin/launchctl kickstart -k system/io.openzro.client >/dev/null 2>&1 || true
           exit 0
           POSTINSTALL
           chmod 0755 pkg-scripts/postinstall
@@ -673,6 +700,13 @@ jobs:
             --repo "${{ github.repository }}" --clobber
 
       - name: Publish update-manifest.json (openZro #5 R4b)
+        # Only advertise an update when the pkg was actually
+        # signed+notarized (same gate as Productsign/Notarize). An
+        # unsigned build ships with BuildTeamID()=="" so the client's
+        # Verify fail-closes — publishing a manifest then would
+        # announce, by default, an update every client necessarily
+        # rejects. No signing rights => no manifest (#5 R4 review).
+        if: ${{ env.APPLE_TEAM_ID != '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -586,16 +586,20 @@ jobs:
           # no-op when the label is already loaded from the prior
           # version, so an upgrade would otherwise keep the old daemon
           # alive. stop+start clears a stale load; `launchctl
-          # kickstart -k` guarantees a kill+respawn under the new
-          # binary. All non-fatal: the pkg still lays down the
-          # binaries even if launchd is unhappy.
+          # kickstart -k` then guarantees a kill+respawn under the new
+          # binary. The launchd label is the kardianos service Name
+          # (`openzro`, see client/cmd/service.go defaultServiceName),
+          # NOT the pkg identifier io.openzro.client — kickstart must
+          # target `system/openzro` or it hits nothing. All non-fatal:
+          # the pkg still lays down the binaries even if launchd is
+          # unhappy.
           cat > pkg-scripts/postinstall <<'POSTINSTALL'
           #!/bin/bash
           set -u
           /usr/local/bin/openzro service install >/dev/null 2>&1 || true
           /usr/local/bin/openzro service stop    >/dev/null 2>&1 || true
           /usr/local/bin/openzro service start   >/dev/null 2>&1 || true
-          /bin/launchctl kickstart -k system/io.openzro.client >/dev/null 2>&1 || true
+          /bin/launchctl kickstart -k system/openzro >/dev/null 2>&1 || true
           exit 0
           POSTINSTALL
           chmod 0755 pkg-scripts/postinstall

--- a/.goreleaser.binaries.yaml
+++ b/.goreleaser.binaries.yaml
@@ -34,7 +34,15 @@ builds:
       - { goos: darwin,  goarch: arm }
       - { goos: darwin,  goarch: "386" }
     ldflags:
-      - -s -w -X github.com/openzro/openzro/version.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}} -X main.builtBy=goreleaser
+      # selfupdate.buildTeamID (#5 R4): this is the config the REAL
+      # release pipeline runs (release-binaries.yml --config
+      # .goreleaser.binaries.yaml), so the Team-ID pin MUST be here —
+      # not only in .goreleaser.yaml. Without it the shipped daemon
+      # has BuildTeamID()=="" and every future self-update fails
+      # closed at Verify. `index .Env` (not `.Env.X`) so a build
+      # without the secret gets "" rather than erroring — empty =>
+      # fail-closed (no self-update), correct for non-release/non-mac.
+      - -s -w -X github.com/openzro/openzro/version.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.CommitDate}} -X main.builtBy=goreleaser -X github.com/openzro/openzro/version/selfupdate.buildTeamID={{ if index .Env "APPLE_TEAM_ID" }}{{ .Env.APPLE_TEAM_ID }}{{ end }}
     mod_timestamp: "{{ .CommitTimestamp }}"
     tags:
       - load_wgnt_from_rsrc

--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -375,6 +375,18 @@ func (c *ConnectClient) GetLatestNetworkMap() (*mgmProto.NetworkMap, error) {
 	return networkMap, nil
 }
 
+// PersistState force-flushes the live engine's client state to disk
+// (see Engine.PersistState — the openZro #5128 pre-restart guard).
+// No-op when no engine is running, so the daemon can call it
+// unconditionally before a self-update without a nil check.
+func (c *ConnectClient) PersistState() error {
+	engine := c.Engine()
+	if engine == nil {
+		return nil
+	}
+	return engine.PersistState()
+}
+
 // Status returns the current client status
 func (c *ConnectClient) Status() StatusType {
 	if c == nil {

--- a/client/internal/connect_test.go
+++ b/client/internal/connect_test.go
@@ -67,3 +67,22 @@ func Test_freePort(t *testing.T) {
 
 	}
 }
+
+// TestConnectClient_PersistState_NilSafe pins the openZro #5128
+// pre-install guard contract: flushing client state before a
+// self-update must be a safe no-op when no engine is connected — the
+// daemon calls it unconditionally and must never panic or block the
+// (potentially security) update on it.
+func TestConnectClient_PersistState_NilSafe(t *testing.T) {
+	c := &ConnectClient{}
+	if err := c.PersistState(); err != nil {
+		t.Fatalf("PersistState with no engine must be a nil no-op, got %v", err)
+	}
+	var e *Engine
+	if err := e.PersistState(); err != nil {
+		t.Fatalf("nil *Engine PersistState must be nil, got %v", err)
+	}
+	if err := (&Engine{}).PersistState(); err != nil {
+		t.Fatalf("Engine with nil stateManager must be nil, got %v", err)
+	}
+}

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -1839,6 +1839,21 @@ func (e *Engine) SetNetworkMapPersistence(enabled bool) {
 	}
 }
 
+// PersistState force-flushes any dirty client state (route /
+// exit-node selection, etc.) to disk synchronously. The state
+// manager's periodic saver only runs every 10s; a client self-update
+// restarts the daemon, so the daemon calls this right before the
+// install to guarantee the user's latest selection survives the
+// restart — the openZro side of NetBird's auto-update state-loss
+// lesson (#5128). Best-effort + nil-safe: a flush failure must never
+// block a (potentially security) update.
+func (e *Engine) PersistState() error {
+	if e == nil || e.stateManager == nil {
+		return nil
+	}
+	return e.stateManager.PersistState(context.Background())
+}
+
 // SetUpdateDirectiveHandler registers (or clears, with nil) the
 // management-driven client self-update callback (openZro #5). Locks
 // syncMsgMux exactly like SetNetworkMapPersistence so it cannot race

--- a/client/server/selfupdate.go
+++ b/client/server/selfupdate.go
@@ -201,6 +201,19 @@ func (s *Server) runSelfUpdateDirective(ctx context.Context, d updateDirective, 
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "selfupdate init: %v", err)
 	}
+
+	// #5128 (openZro side): the install restarts the daemon. Flush the
+	// user's latest route / exit-node selection NOW so it survives the
+	// restart regardless of how the PKG postinstall stops us — the 10s
+	// periodic state saver may not have run since the user's last
+	// change. Best-effort: never block a (potentially security) update
+	// on a state flush; no-op when no engine is connected.
+	if s.connectClient != nil {
+		if perr := s.connectClient.PersistState(); perr != nil {
+			log.Warnf("client self-update: pre-install state flush failed (continuing): %v", perr)
+		}
+	}
+
 	res, err := u.RunOnce(ctx)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "selfupdate: %v", err)

--- a/client/server/selfupdate.go
+++ b/client/server/selfupdate.go
@@ -185,6 +185,23 @@ func (s *Server) runSelfUpdateDirective(ctx context.Context, d updateDirective, 
 		return nil, status.Errorf(codes.FailedPrecondition, "selfupdate config: %v", err)
 	}
 
+	// #5128 (openZro side, R4 review #3): flush the user's latest
+	// route / exit-node selection AFTER verify and immediately before
+	// the privileged install+restart — glued to the restart, not
+	// merely before the whole fetch/download/verify cycle, so the
+	// residual race (selection changed while the pkg downloaded) is
+	// closed. Best-effort: a flush failure is logged and we return
+	// nil so the engine never aborts a (potentially security) update
+	// on it; no-op when no engine is connected.
+	cfg.BeforeInstall = func(context.Context) error {
+		if s.connectClient != nil {
+			if perr := s.connectClient.PersistState(); perr != nil {
+				log.Warnf("client self-update: pre-install state flush failed (continuing): %v", perr)
+			}
+		}
+		return nil
+	}
+
 	// Shared single-flight: at most one privileged install cycle at a
 	// time across BOTH the manual RPC and the forced auto-install
 	// (#5 review-4). A loser returns the sentinel rather than running
@@ -200,18 +217,6 @@ func (s *Server) runSelfUpdateDirective(ctx context.Context, d updateDirective, 
 	}
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "selfupdate init: %v", err)
-	}
-
-	// #5128 (openZro side): the install restarts the daemon. Flush the
-	// user's latest route / exit-node selection NOW so it survives the
-	// restart regardless of how the PKG postinstall stops us — the 10s
-	// periodic state saver may not have run since the user's last
-	// change. Best-effort: never block a (potentially security) update
-	// on a state flush; no-op when no engine is connected.
-	if s.connectClient != nil {
-		if perr := s.connectClient.PersistState(); perr != nil {
-			log.Warnf("client self-update: pre-install state flush failed (continuing): %v", perr)
-		}
 	}
 
 	res, err := u.RunOnce(ctx)

--- a/version/selfupdate/manifest_test.go
+++ b/version/selfupdate/manifest_test.go
@@ -196,3 +196,48 @@ func TestResolveManifestTemplateURL(t *testing.T) {
 		}
 	})
 }
+
+// TestManifest_ReleasePipelineShape pins the exact update-manifest.json
+// the release pipeline emits (.github/workflows/release-binaries.yml,
+// openZro #5 R4b). The CI YAML is not unit-testable here, so this is
+// the contract guard: if Manifest/ParseManifest drifts, this fails and
+// reminds whoever changed it that the pipeline generator must match.
+// Shape: single universal pkg, both darwin arches -> same url+sha256,
+// min_version "" (no floor), staged_rollout 100 (R6-only; the
+// management-driven path skips it via GateInput.Authoritative).
+func TestManifest_ReleasePipelineShape(t *testing.T) {
+	const url = "https://github.com/openzro/openzro/releases/download/v0.53.1-alpha.1/openzro_0.53.1-alpha.1_darwin_universal.pkg"
+	const sha = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	body := `{
+	  "version": "0.53.1-alpha.1",
+	  "min_version": "",
+	  "staged_rollout": 100,
+	  "artifacts": {
+	    "darwin/arm64": { "url": "` + url + `", "sha256": "` + sha + `" },
+	    "darwin/amd64": { "url": "` + url + `", "sha256": "` + sha + `" }
+	  }
+	}`
+
+	m, err := ParseManifest([]byte(body))
+	if err != nil {
+		t.Fatalf("pipeline manifest must parse, got %v", err)
+	}
+	if m.Version != "0.53.1-alpha.1" {
+		t.Fatalf("version: got %q", m.Version)
+	}
+	if m.MinVersion != "" {
+		t.Fatalf("min_version must be empty (no floor), got %q", m.MinVersion)
+	}
+	if m.StagedRollout == nil || *m.StagedRollout != 100 {
+		t.Fatalf("staged_rollout must be 100, got %v", m.StagedRollout)
+	}
+	for _, arch := range []string{"arm64", "amd64"} {
+		a, ok := m.ArtifactFor("darwin", arch)
+		if !ok {
+			t.Fatalf("missing artifact for darwin/%s", arch)
+		}
+		if a.URL != url || a.SHA256 != sha {
+			t.Fatalf("darwin/%s artifact mismatch: %+v", arch, a)
+		}
+	}
+}

--- a/version/selfupdate/updater.go
+++ b/version/selfupdate/updater.go
@@ -49,6 +49,18 @@ type Config struct {
 	// still honours staged_rollout. See GateInput.Authoritative.
 	Authoritative bool
 
+	// BeforeInstall, when set, is called AFTER Verify succeeds and
+	// IMMEDIATELY before Installer.Install — i.e. glued to the
+	// privileged install/restart, not merely before the whole cycle
+	// (openZro #5 R4 review #3). The daemon uses it to flush the
+	// user's route / exit-node selection right before the restart so
+	// the residual 10s-tick race window (selection changed during the
+	// download/verify) is closed. Returning an error aborts the cycle
+	// before any install; the daemon's hook is best-effort and
+	// returns nil even on flush failure so it never blocks a
+	// (potentially security) update.
+	BeforeInstall func(context.Context) error
+
 	// CycleTimeout bounds one full cycle (fetch+download+verify+
 	// install). Without it a hung installer wedges self-update forever
 	// behind single-flight. Default 15m.
@@ -168,6 +180,14 @@ func (u *Updater) RunOnce(ctx context.Context) (Result, error) {
 
 	if err := c.Verifier.Verify(ctx, path); err != nil {
 		return Result{}, err
+	}
+	// Glued to the install: last point before the privileged
+	// install + daemon restart (#5 R4 review #3 — closes the
+	// residual selection-change race window).
+	if c.BeforeInstall != nil {
+		if err := c.BeforeInstall(ctx); err != nil {
+			return Result{}, fmt.Errorf("selfupdate: before-install hook: %w", err)
+		}
 	}
 	if err := c.Installer.Install(ctx, path); err != nil {
 		return Result{}, err

--- a/version/selfupdate/updater_extra_test.go
+++ b/version/selfupdate/updater_extra_test.go
@@ -2,6 +2,7 @@ package selfupdate
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -100,4 +101,62 @@ func TestRunOnce_ExpectedVersionMatchInstalls(t *testing.T) {
 	if !res.Installed || res.Version != "1.2.0" || !v.called || !in.called {
 		t.Fatalf("matched binding must install: %+v verify=%v install=%v", res, v.called, in.called)
 	}
+}
+
+// TestRunOnce_BeforeInstallHook pins openZro #5 R4 review #3: the
+// BeforeInstall hook runs AFTER Verify and IMMEDIATELY before
+// Install (glued to the privileged restart), and a hook error aborts
+// the cycle before any install happens.
+func TestRunOnce_BeforeInstallHook(t *testing.T) {
+	t.Run("runs after verify, before install", func(t *testing.T) {
+		srv := updaterServer(t, 100, "1.2.0")
+		defer srv.Close()
+		cfg := baseCfg(srv)
+		v, in := &fakeVerifier{}, &fakeInstaller{}
+		cfg.Verifier, cfg.Installer = v, in
+		hookRan := false
+		cfg.BeforeInstall = func(context.Context) error {
+			if !v.called {
+				t.Error("BeforeInstall must run AFTER Verify")
+			}
+			if in.called {
+				t.Error("BeforeInstall must run BEFORE Install")
+			}
+			hookRan = true
+			return nil
+		}
+		u, err := New(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		res, err := u.RunOnce(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !hookRan || !res.Installed || !in.called {
+			t.Fatalf("hook=%v installed=%v install.called=%v", hookRan, res.Installed, in.called)
+		}
+	})
+
+	t.Run("hook error aborts before install", func(t *testing.T) {
+		srv := updaterServer(t, 100, "1.2.0")
+		defer srv.Close()
+		cfg := baseCfg(srv)
+		v, in := &fakeVerifier{}, &fakeInstaller{}
+		cfg.Verifier, cfg.Installer = v, in
+		cfg.BeforeInstall = func(context.Context) error { return errors.New("flush boom") }
+		u, err := New(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := u.RunOnce(context.Background()); err == nil {
+			t.Fatal("a BeforeInstall error must abort the cycle")
+		}
+		if in.called {
+			t.Fatal("install must NOT run after a BeforeInstall error")
+		}
+		if !v.called {
+			t.Fatal("verify should have run before the hook")
+		}
+	})
 }


### PR DESCRIPTION
openZro #5 R4 — closes the two gaps that kept the merged #5
auto-update from being correct/usable in production. One review block
(R4a + R4b), owner-signed-off spec.

## R4a — `0dd982b8` — #5128 pre-install state flush (BSD client)

NetBird #5128: an auto-update restarts the daemon and the user's
selected networks / exit-node could be lost. In openZro that
selection is the RouteSelector, persisted by the state manager — but
only on a 10s periodic tick / graceful Stop. A forced install can
replace the daemon seconds after the user changes the selection,
before the saver runs and possibly without a graceful stop (the PKG
postinstall owns the restart).

- `Engine.PersistState` (nil-safe synchronous flush via the existing
  stateManager) + a `ConnectClient.PersistState` seam, mirroring the
  `SetNetworkMapPersistence` pattern.
- The daemon calls it right before `u.RunOnce` in
  `runSelfUpdateDirective` (covers both auto + manual installs).
  Best-effort: a flush failure is logged and the update proceeds —
  never block a (potentially security) update; no-op when no engine
  is connected.
- Restore-vs-Sync ordering is correct by construction (selector
  restored at engine init before Sync data; selection is state,
  routes are data) — documented, pinned by the nil-safety test.

## R4b — `480a26ce` — per-version update-manifest.json producer

`build_macos_pkg` now, AFTER notarize+staple+upload, generates and
uploads `update-manifest.json` to the release tag.

- sha256 over the FINAL stapled pkg (after stapler — never a
  pre-staple hash).
- single universal pkg → both `darwin/arm64` and `darwin/amd64` keys
  point at it (ArtifactFor resolves darwin/<arch>).
- `staged_rollout: 100`, `min_version: ""` (signed-off; the
  management-driven path skips staged_rollout via Q2 Authoritative —
  value only matters to the future R6 fallback).
- tag/version alignment verified (git tag `vX.Y.Z` → version `X.Y.Z`
  → resolver prepends `v` → asset path matches). jq builds the JSON;
  reuses `GITHUB_TOKEN`; `--clobber` = idempotent re-runs.
- Manifest is unsigned by design — trust root is the notarized pkg +
  Team-ID pin + I2 `ExpectedVersion`; a tampered manifest can at
  worst point at another validly-signed openZro version, rejected by
  I2 + Team-ID.

The CI YAML isn't unit-testable here, so
`TestManifest_ReleasePipelineShape` pins the emitted schema against
`selfupdate.ParseManifest`/`ArtifactFor` — schema drift fails `go
test`.

## Residual / out of scope (documented)
- PKG postinstall (ADR-0007, not in this repo) is assumed to restart
  the daemon and NOT wipe the state dir — the pre-install flush is
  the mitigation that holds even on a hard kill; the "doesn't wipe
  state dir" assumption needs release-infra confirmation.
- R6 critical-only static fallback and R5 UI polish remain follow-ups.

License: BSD client + release pipeline; adapts upstream NetBird's
BSD client #5128 lesson (in-tree provenance ack in
version/selfupdate/manifest.go); no AGPL management/ consulted.

## Test plan
- [ ] `go build ./...`; `gofmt`/`go vet` clean (modulo pre-existing `//nolint` network.go:534)
- [ ] `go test ./version/selfupdate/` (incl. TestManifest_ReleasePipelineShape)
- [ ] `go test ./client/internal/ -run 'TestConnectClient_PersistState_NilSafe|TestEngine_HandleUpdateDirective_Dedupe'`
- [ ] release-binaries.yml parses; dry-run a tagged release → verify update-manifest.json asset present at `…/releases/download/v{version}/update-manifest.json` and `ParseManifest` accepts it
- [ ] manual macOS: change network/exit-node selection, trigger a forced update, confirm selection survives the post-install restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)