### PR TITLE
feat(#5 R5+R6): manual opt-in polish + critical-only static fallback

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -743,6 +743,53 @@ jobs:
           gh release upload "${TAG}" update-manifest.json \
             --repo "${{ github.repository }}" --clobber
 
+      - name: Publish static rolling update-manifest.json (openZro #5 R6)
+        # R6 last-resort fallback: an UNMANAGED client below the
+        # security floor self-heals from this single ROLLING manifest
+        # (selfupdate.defaultManifestURL =
+        # …/releases/download/update/update-manifest.json). min_version
+        # is EMPTY by default — Critical never fires, the fallback
+        # sleeps — until a security cut sets the repo variable
+        # OPENZRO_FALLBACK_MIN_VERSION. Same signed-artifact gate as
+        # the per-version manifest (an unsigned build must not
+        # advertise an update its client necessarily rejects).
+        if: ${{ env.APPLE_TEAM_ID != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG="${{ steps.ver.outputs.tag }}"
+          VERSION="${{ steps.ver.outputs.version }}"
+          MIN_VERSION="${{ vars.OPENZRO_FALLBACK_MIN_VERSION }}"
+          PKG="dist/openzro_${VERSION}_darwin_universal.pkg"
+          SHA="$(shasum -a 256 "$PKG" | awk '{print $1}')"
+          # The pkg asset lives on THIS version's release tag; the
+          # rolling manifest points back at that same signed+notarized
+          # binary (trust root unchanged — Team-ID pin + verify still
+          # apply at install).
+          URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/openzro_${VERSION}_darwin_universal.pkg"
+          # Same schema as the per-version manifest; min_version is the
+          # only difference (operator-controlled security floor).
+          jq -n \
+            --arg v "$VERSION" --arg mv "$MIN_VERSION" --arg u "$URL" --arg s "$SHA" \
+            '{version:$v, min_version:$mv, staged_rollout:100,
+              artifacts:{"darwin/arm64":{url:$u,sha256:$s},
+                         "darwin/amd64":{url:$u,sha256:$s}}}' \
+            > update-manifest.json
+          # A single rolling release tagged `update` (prerelease so it
+          # never displays as "Latest"). Created once; every release
+          # re-clobbers the asset. The tag's commit is irrelevant —
+          # GitHub serves the asset by release tag, and the manifest
+          # only points at per-version pkg assets.
+          gh release create update \
+            --repo "${{ github.repository }}" \
+            --prerelease \
+            --title "openZro client self-update (rolling)" \
+            --notes "Rolling pointer for the R6 critical-only self-update fallback. Do not delete." \
+            --target "${{ github.sha }}" 2>/dev/null || true
+          gh release upload update update-manifest.json \
+            --repo "${{ github.repository }}" --clobber
+
   release_dex:
     name: Build + push themed Dex container image
     runs-on: ubuntu-22.04

--- a/client/server/selfupdate.go
+++ b/client/server/selfupdate.go
@@ -770,3 +770,154 @@ func (s *Server) buildUpdateState() *proto.UpdateState {
 		LastDecision:  decision,
 	}
 }
+
+// ---- R6: critical-only static-manifest fallback ----
+//
+// Last resort for an UNMANAGED client: when management has been
+// unreachable for a sustained period AND no operator directive is
+// recorded AND the client is below the static manifest's security
+// floor (min_version), self-heal SILENTLY — but never slow-roll a
+// routine update behind the operator's back (CriticalOnly). Reuses
+// the shared install gate so it can never collide with the directive
+// or manual install paths; a recorded directive always wins (the
+// directive scheduler owns updates even while mgmt is down).
+const (
+	// Observe connectivity often; the grace + min-interval gate the
+	// ACTUAL attempt so a short mgmt blip never triggers a self-heal.
+	criticalFallbackTick        = 10 * time.Minute
+	criticalFallbackGrace       = time.Hour
+	criticalFallbackMinInterval = time.Hour
+)
+
+func (s *Server) startCriticalFallbackOnce() {
+	s.criticalFallbackOnce.Do(func() { go s.runCriticalFallbackWorker() })
+}
+
+// criticalFallbackEligible is the pure attempt decision (extracted so
+// the timing policy is unit-testable without driving the goroutine).
+// Caller has already established management is currently DOWN.
+func criticalFallbackEligible(downSince, lastAttempt, now time.Time, d updateDirective) bool {
+	if downSince.IsZero() || now.Sub(downSince) < criticalFallbackGrace {
+		return false // not down long enough
+	}
+	if d.seen && d.targetVersion != "" {
+		return false // a directive is recorded — the directive path owns it
+	}
+	if !lastAttempt.IsZero() && now.Sub(lastAttempt) < criticalFallbackMinInterval {
+		return false // rate-limit re-attempts
+	}
+	return true
+}
+
+func (s *Server) runCriticalFallbackWorker() {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Errorf("client self-update: critical fallback worker recovered from panic: %v", r)
+		}
+	}()
+
+	base := s.rootCtx
+	if base == nil {
+		base = context.Background()
+	}
+	ticker := time.NewTicker(criticalFallbackTick)
+	defer ticker.Stop()
+
+	var downSince, lastAttempt time.Time
+	for {
+		select {
+		case <-base.Done():
+			return
+		case <-ticker.C:
+		}
+
+		if s.statusRecorder.GetManagementState().Connected {
+			downSince, lastAttempt = time.Time{}, time.Time{}
+			continue
+		}
+		now := time.Now()
+		if downSince.IsZero() {
+			downSince = now
+		}
+
+		s.updateDirectiveMu.Lock()
+		d := s.updateDirective
+		s.updateDirectiveMu.Unlock()
+
+		if !criticalFallbackEligible(downSince, lastAttempt, now, d) {
+			continue
+		}
+		lastAttempt = now
+		s.attemptCriticalFallback(base)
+	}
+}
+
+// buildCriticalFallbackConfig assembles the non-authoritative,
+// critical-only static-manifest cycle. No operator-directed target
+// (ExpectedVersion=""), so the static manifest's own version is the
+// target; verify + Team-ID pin are unchanged. AutoInstallEnabled is
+// true because this fires only when the client is vulnerable AND
+// unmanaged AND a tray prompt cannot be relied on — the
+// owner-signed-off silent self-heal posture. An explicitly empty
+// OPENZRO_UPDATE_MANIFEST_URL disables the fallback (escape hatch).
+func (s *Server) buildCriticalFallbackConfig() (selfupdate.Config, error) {
+	url := selfupdate.ResolveManifestURL()
+	if url == "" {
+		return selfupdate.Config{}, errors.New("static fallback disabled (OPENZRO_UPDATE_MANIFEST_URL set empty)")
+	}
+	return selfupdate.Config{
+		CurrentVersion:     version.OpenzroVersion(),
+		ManifestURL:        url,
+		ExpectedVersion:    "",
+		UserAgent:          "openzro-daemon/" + version.OpenzroVersion(),
+		ExpectedTeamID:     selfupdate.BuildTeamID(),
+		AutoInstallEnabled: true,
+		Authoritative:      false,
+		CriticalOnly:       true,
+		ClientID:           s.clientUpdateBucketID(),
+	}, nil
+}
+
+func (s *Server) attemptCriticalFallback(base context.Context) {
+	// Shared single-flight: if a directive/manual install is running,
+	// back off — the fallback is the lowest-priority path.
+	if !s.acquireInstallGate() {
+		return
+	}
+	defer s.releaseInstallGate()
+
+	cfg, err := s.buildCriticalFallbackConfig()
+	if err != nil {
+		log.Infof("client self-update: critical fallback not configured: %v", err)
+		return
+	}
+	// Same pre-restart state flush as the directive path (#5128):
+	// best-effort, never aborts a security self-heal.
+	cfg.BeforeInstall = func(context.Context) error {
+		if s.connectClient != nil {
+			if perr := s.connectClient.PersistState(); perr != nil {
+				log.Warnf("client self-update: critical-fallback pre-install flush failed (continuing): %v", perr)
+			}
+		}
+		return nil
+	}
+
+	u, err := selfupdate.New(cfg)
+	if err == selfupdate.ErrUnsupportedPlatform {
+		return // macOS-only in phase 1
+	}
+	if err != nil {
+		log.Errorf("client self-update: critical fallback init: %v", err)
+		return
+	}
+	res, err := u.RunOnce(base)
+	if err != nil {
+		log.Errorf("client self-update: critical fallback: %v", err)
+		return
+	}
+	if res.Installed {
+		log.Infof("client self-update: critical fallback installed %s — service will restart", res.Version)
+		return
+	}
+	log.Infof("client self-update: critical fallback: %s", res.Reason)
+}

--- a/client/server/selfupdate.go
+++ b/client/server/selfupdate.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"math/rand"
 	"net"
 	"net/http"
@@ -789,6 +790,33 @@ const (
 	criticalFallbackMinInterval = time.Hour
 )
 
+// errFallbackSuperseded aborts an in-flight critical-fallback cycle
+// when the authoritative path takes over mid-flight (RunOnce's
+// fetch+download+verify can take minutes). Returned from the
+// fallback's BeforeInstall so the engine aborts BEFORE Install;
+// recognised in attemptCriticalFallback as an expected outcome, not
+// a failure (#5 R6 review #1).
+var errFallbackSuperseded = errors.New("critical fallback superseded — authoritative path took over")
+
+// fallbackSupersededReason is the pure pre-install re-validation
+// (extracted so the #5 R6 review-#1 invariant is unit-testable
+// without a macOS install). nil => still eligible to self-heal;
+// non-nil (wraps errFallbackSuperseded) => the authoritative path
+// took over (client stopped / mgmt reconnected / operator directive)
+// and the cycle must abort before Install.
+func fallbackSupersededReason(connectActive, mgmtConnected bool, d updateDirective) error {
+	switch {
+	case !connectActive:
+		return fmt.Errorf("%w (client stopped)", errFallbackSuperseded)
+	case mgmtConnected:
+		return fmt.Errorf("%w (management reconnected)", errFallbackSuperseded)
+	case d.seen && d.targetVersion != "":
+		return fmt.Errorf("%w (operator directive arrived)", errFallbackSuperseded)
+	default:
+		return nil
+	}
+}
+
 func (s *Server) startCriticalFallbackOnce() {
 	s.criticalFallbackOnce.Do(func() { go s.runCriticalFallbackWorker() })
 }
@@ -831,6 +859,14 @@ func (s *Server) runCriticalFallbackWorker() {
 		case <-ticker.C:
 		}
 
+		// A deliberately-stopped client (manual Down, or never Up) is
+		// NOT "unmanaged + should be managed" — never self-heal it
+		// (#5 R6 review #2). Reset the clock so a later Up starts
+		// fresh.
+		if !s.connectActive.Load() {
+			downSince, lastAttempt = time.Time{}, time.Time{}
+			continue
+		}
 		if s.statusRecorder.GetManagementState().Connected {
 			downSince, lastAttempt = time.Time{}, time.Time{}
 			continue
@@ -891,9 +927,28 @@ func (s *Server) attemptCriticalFallback(base context.Context) {
 		log.Infof("client self-update: critical fallback not configured: %v", err)
 		return
 	}
-	// Same pre-restart state flush as the directive path (#5128):
-	// best-effort, never aborts a security self-heal.
 	cfg.BeforeInstall = func(context.Context) error {
+		// Re-validate IMMEDIATELY before the privileged install: the
+		// RunOnce fetch/download/verify can take minutes, during
+		// which management may reconnect, an operator directive may
+		// arrive, or the user may Down() the client. Any of those
+		// means the authoritative path now owns updates (or the
+		// client must not self-update at all) — abort instead of
+		// installing the rolling static target. The engine aborts
+		// the cycle on a BeforeInstall error before Install
+		// (#5 R6 review #1).
+		s.updateDirectiveMu.Lock()
+		d := s.updateDirective
+		s.updateDirectiveMu.Unlock()
+		if err := fallbackSupersededReason(
+			s.connectActive.Load(),
+			s.statusRecorder.GetManagementState().Connected,
+			d,
+		); err != nil {
+			return err
+		}
+		// Same pre-restart state flush as the directive path (#5128):
+		// best-effort, never aborts a security self-heal.
 		if s.connectClient != nil {
 			if perr := s.connectClient.PersistState(); perr != nil {
 				log.Warnf("client self-update: critical-fallback pre-install flush failed (continuing): %v", perr)
@@ -912,6 +967,10 @@ func (s *Server) attemptCriticalFallback(base context.Context) {
 	}
 	res, err := u.RunOnce(base)
 	if err != nil {
+		if errors.Is(err, errFallbackSuperseded) {
+			log.Infof("client self-update: critical fallback aborted — %v", err)
+			return
+		}
 		log.Errorf("client self-update: critical fallback: %v", err)
 		return
 	}

--- a/client/server/selfupdate_test.go
+++ b/client/server/selfupdate_test.go
@@ -642,3 +642,70 @@ func TestSharedInstallGate(t *testing.T) {
 		}
 	})
 }
+
+// TestCriticalFallbackEligible pins the R6 attempt policy (extracted
+// pure so it is unit-testable without driving the worker goroutine).
+func TestCriticalFallbackEligible(t *testing.T) {
+	now := time.Now()
+	beyond := now.Add(-criticalFallbackGrace - time.Minute) // down long enough
+	recent := now.Add(-time.Minute)                         // down, but not long enough
+	noDir := updateDirective{}
+	dir := updateDirective{seen: true, targetVersion: "1.2.3"}
+
+	if criticalFallbackEligible(time.Time{}, time.Time{}, now, noDir) {
+		t.Fatal("zero downSince must not be eligible")
+	}
+	if criticalFallbackEligible(recent, time.Time{}, now, noDir) {
+		t.Fatal("down < grace must not be eligible")
+	}
+	if !criticalFallbackEligible(beyond, time.Time{}, now, noDir) {
+		t.Fatal("down >= grace, no directive, no prior attempt must be eligible")
+	}
+	if criticalFallbackEligible(beyond, time.Time{}, now, dir) {
+		t.Fatal("a recorded directive must defer to the directive path")
+	}
+	if criticalFallbackEligible(beyond, now.Add(-time.Minute), now, noDir) {
+		t.Fatal("a recent attempt must be rate-limited")
+	}
+	if !criticalFallbackEligible(beyond, now.Add(-criticalFallbackMinInterval-time.Minute), now, noDir) {
+		t.Fatal("an old enough prior attempt must re-enable")
+	}
+}
+
+// TestBuildCriticalFallbackConfig pins the R6 fallback Config: silent
+// (AutoInstallEnabled), non-authoritative, critical-only, no directed
+// target; env override honoured; explicit-empty disables.
+func TestBuildCriticalFallbackConfig(t *testing.T) {
+	s := &Server{}
+
+	t.Run("default (env unset) — silent critical-only static cycle", func(t *testing.T) {
+		cfg, err := s.buildCriticalFallbackConfig()
+		if err != nil {
+			t.Fatalf("default must be configured, got %v", err)
+		}
+		if !cfg.CriticalOnly || cfg.Authoritative || !cfg.AutoInstallEnabled {
+			t.Fatalf("posture wrong: %+v", cfg)
+		}
+		if cfg.ExpectedVersion != "" {
+			t.Fatalf("fallback must not bind a directed version, got %q", cfg.ExpectedVersion)
+		}
+		if !strings.Contains(cfg.ManifestURL, "update-manifest.json") {
+			t.Fatalf("unexpected static manifest url %q", cfg.ManifestURL)
+		}
+	})
+
+	t.Run("env override honoured", func(t *testing.T) {
+		t.Setenv("OPENZRO_UPDATE_MANIFEST_URL", "https://mirror.example/u.json")
+		cfg, err := s.buildCriticalFallbackConfig()
+		if err != nil || cfg.ManifestURL != "https://mirror.example/u.json" {
+			t.Fatalf("env override not applied: %q %v", cfg.ManifestURL, err)
+		}
+	})
+
+	t.Run("explicit-empty disables the fallback", func(t *testing.T) {
+		t.Setenv("OPENZRO_UPDATE_MANIFEST_URL", "  ")
+		if _, err := s.buildCriticalFallbackConfig(); err == nil {
+			t.Fatal("explicit-empty must disable (error)")
+		}
+	})
+}

--- a/client/server/selfupdate_test.go
+++ b/client/server/selfupdate_test.go
@@ -709,3 +709,38 @@ func TestBuildCriticalFallbackConfig(t *testing.T) {
 		}
 	})
 }
+
+// TestFallbackSupersededReason pins the #5 R6 review-#1 invariant:
+// the long RunOnce window must abort the critical fallback if the
+// authoritative path takes over before the privileged install.
+func TestFallbackSupersededReason(t *testing.T) {
+	dirActive := updateDirective{seen: true, targetVersion: "1.2.3"}
+	dirCleared := updateDirective{seen: true, targetVersion: ""}
+	none := updateDirective{}
+
+	// Superseded cases — must wrap errFallbackSuperseded.
+	for _, c := range []struct {
+		name          string
+		connectActive bool
+		mgmtConnected bool
+		d             updateDirective
+	}{
+		{"client stopped", false, false, none},
+		{"client stopped beats mgmt-down", false, false, none},
+		{"management reconnected", true, true, none},
+		{"operator directive arrived", true, false, dirActive},
+	} {
+		err := fallbackSupersededReason(c.connectActive, c.mgmtConnected, c.d)
+		if err == nil || !errors.Is(err, errFallbackSuperseded) {
+			t.Fatalf("%s: expected errFallbackSuperseded, got %v", c.name, err)
+		}
+	}
+
+	// Still eligible — must be nil.
+	if err := fallbackSupersededReason(true, false, none); err != nil {
+		t.Fatalf("unmanaged + no directive must remain eligible, got %v", err)
+	}
+	if err := fallbackSupersededReason(true, false, dirCleared); err != nil {
+		t.Fatalf("a CLEARED directive does not own updates — fallback stays eligible, got %v", err)
+	}
+}

--- a/client/server/server.go
+++ b/client/server/server.go
@@ -68,6 +68,11 @@ type Server struct {
 	lastProbe         time.Time
 	persistNetworkMap bool
 	isSessionActive   atomic.Bool
+	// connectActive is true while the client is meant to be connected
+	// (set on every connect launch via connectWithRetryRuns, cleared
+	// by Down()). The R6 critical-fallback worker requires it so a
+	// deliberately-stopped client is never silently auto-updated.
+	connectActive atomic.Bool
 
 	// updateDirective holds the latest management-conveyed client
 	// self-update decision (openZro #5). The engine dedupes by
@@ -260,6 +265,14 @@ func (s *Server) setDefaultConfigIfNotExists(ctx context.Context) error {
 func (s *Server) connectWithRetryRuns(ctx context.Context, config *profilemanager.Config, statusRecorder *peer.Status,
 	runningChan chan struct{},
 ) {
+	// The client is now meant to be connected (covers Start /
+	// Up / reconnect — every connect launch funnels through here).
+	// Down() clears it. The R6 fallback worker reads this so a
+	// manually-stopped client is never silently auto-updated
+	// (#5 R6 review #2): managementState.Connected alone cannot tell
+	// "network down" from "user pressed Down".
+	s.connectActive.Store(true)
+
 	backOff := getConnectWithBackoff(ctx)
 	retryStarted := false
 
@@ -873,6 +886,9 @@ func (s *Server) Down(ctx context.Context, _ *proto.DownRequest) (*proto.DownRes
 		return nil, fmt.Errorf("service is not up")
 	}
 	s.actCancel()
+	// User-initiated stop: the R6 fallback must not treat this as
+	// "unmanaged + should be managed" (#5 R6 review #2).
+	s.connectActive.Store(false)
 
 	err := s.connectClient.Stop()
 	if err != nil {

--- a/client/server/server.go
+++ b/client/server/server.go
@@ -112,6 +112,13 @@ type Server struct {
 	installGateMu sync.Mutex
 	installActive bool
 
+	// criticalFallbackOnce starts the R6 last-resort worker exactly
+	// once per daemon lifetime: when management is unreachable for a
+	// sustained period AND no directive is recorded AND the client is
+	// below the static manifest's security floor, self-heal silently
+	// (critical-only). Reuses the shared install gate.
+	criticalFallbackOnce sync.Once
+
 	profileManager   profilemanager.ServiceManager
 	profilesDisabled bool
 }
@@ -212,6 +219,11 @@ func (s *Server) Start() error {
 	if config.DisableAutoConnect {
 		return nil
 	}
+
+	// R6: last-resort critical self-heal. Started only on the
+	// auto-connect path (a deliberately-disconnected client is not
+	// "unmanaged + should be managed"); once per daemon lifetime.
+	s.startCriticalFallbackOnce()
 
 	go s.connectWithRetryRuns(ctx, config, s.statusRecorder, nil)
 

--- a/client/server/server.go
+++ b/client/server/server.go
@@ -225,11 +225,6 @@ func (s *Server) Start() error {
 		return nil
 	}
 
-	// R6: last-resort critical self-heal. Started only on the
-	// auto-connect path (a deliberately-disconnected client is not
-	// "unmanaged + should be managed"); once per daemon lifetime.
-	s.startCriticalFallbackOnce()
-
 	go s.connectWithRetryRuns(ctx, config, s.statusRecorder, nil)
 
 	return nil
@@ -272,6 +267,16 @@ func (s *Server) connectWithRetryRuns(ctx context.Context, config *profilemanage
 	// (#5 R6 review #2): managementState.Connected alone cannot tell
 	// "network down" from "user pressed Down".
 	s.connectActive.Store(true)
+
+	// R6: start the last-resort critical self-heal worker here — the
+	// SAME single funnel as connectActive, so it covers Start AND a
+	// manual Up after a DisableAutoConnect boot AND reconnects, with
+	// no path missed (#5 R6 review #3). sync.Once => idempotent; a
+	// client that never connects (DisableAutoConnect + no Up) never
+	// reaches here, so a deliberately-disconnected client still gets
+	// no fallback. A later Down() is handled by the connectActive
+	// guard, not by stopping the worker.
+	s.startCriticalFallbackOnce()
 
 	backOff := getConnectWithBackoff(ctx)
 	retryStarted := false

--- a/client/ui/client_ui.go
+++ b/client/ui/client_ui.go
@@ -232,7 +232,7 @@ type serviceClient struct {
 	mGitHub            *systray.MenuItem
 	mVersionUI         *systray.MenuItem
 	mVersionDaemon     *systray.MenuItem
-	mUpdate            *systray.MenuItem
+	mUpdateStatus      *systray.MenuItem
 	mInstallUpdate     *systray.MenuItem
 	mQuit              *systray.MenuItem
 	mNetworks          *systray.MenuItem
@@ -852,12 +852,19 @@ func (s *serviceClient) onTrayReady() {
 	s.mVersionDaemon.Disable()
 	s.mVersionDaemon.Hide()
 
-	s.mUpdate = s.mAbout.AddSubMenuItem("Download latest version", latestVersionMenuDescr)
-	s.mUpdate.Hide()
+	// #5 R5: a non-actionable status line. Visible whenever there is
+	// an active management directive (available, forced/silent, or
+	// "checking…") so the user sees WHAT version and WHY even when no
+	// manual CTA is offered. Replaces the retired poll-era "Download
+	// latest version" browser link — in the management-driven model a
+	// manual browser download would bypass the gated/verified pipeline.
+	s.mUpdateStatus = s.mAbout.AddSubMenuItem("", "")
+	s.mUpdateStatus.Disable()
+	s.mUpdateStatus.Hide()
 
 	// #5: ask the privileged daemon to download+verify+install the
-	// update (rollout-gated). Distinct from "Download latest version"
-	// which just opens the release page in a browser.
+	// update (rollout-gated). Only shown for a non-force directive
+	// (forced installs are silent); label carries the target version.
 	s.mInstallUpdate = s.mAbout.AddSubMenuItem("Install update now", "Download, verify and install the update via the daemon")
 	s.mInstallUpdate.Hide()
 
@@ -1095,17 +1102,33 @@ func protoConfigToConfig(cfg *proto.GetConfigResponse) *profilemanager.Config {
 // The manual "Install update now" item is shown ONLY for a NON-force
 // directive (review-#1): when the operator forced the update the
 // daemon installs it silently, so a manual CTA would be misleading.
+// #5 R5: the status line + the CTA label surface the target version
+// and the daemon's decision reason.
 func (s *serviceClient) applyUpdateStateLocked(us *proto.UpdateState) {
 	available := us.GetAvailable()
 	s.isUpdateIconActive = available
+	target := us.GetTargetVersion()
+	decision := us.GetLastDecision()
 
-	if available {
-		s.mUpdate.Show()
+	if target != "" {
+		s.mUpdateStatus.SetTitle("Update: " + target)
+		if decision != "" {
+			s.mUpdateStatus.SetTooltip(decision)
+		}
+		s.mUpdateStatus.Show()
 	} else {
-		s.mUpdate.Hide()
+		s.mUpdateStatus.Hide()
 	}
 
 	if available && !us.GetForce() {
+		label := "Install update now"
+		if target != "" {
+			label = "Install openZro " + target
+		}
+		s.mInstallUpdate.SetTitle(label)
+		if decision != "" {
+			s.mInstallUpdate.SetTooltip(decision)
+		}
 		s.mInstallUpdate.Show()
 	} else {
 		s.mInstallUpdate.Hide()

--- a/client/ui/const.go
+++ b/client/ui/const.go
@@ -13,6 +13,5 @@ const (
 	debugBundleMenuDescr       = "Create and open debug information bundle"
 	exitNodeMenuDescr          = "Select exit node for routing traffic"
 	networksMenuDescr          = "Open the networks management window"
-	latestVersionMenuDescr     = "Download latest version"
 	quitMenuDescr              = "Quit the client app"
 )

--- a/client/ui/event_handler.go
+++ b/client/ui/event_handler.go
@@ -8,13 +8,13 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"time"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/systray"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/openzro/openzro/client/proto"
-	"github.com/openzro/openzro/version"
 )
 
 type eventHandler struct {
@@ -55,8 +55,6 @@ func (h *eventHandler) listen(ctx context.Context) {
 			return
 		case <-h.client.mGitHub.ClickedCh:
 			h.handleGitHubClick()
-		case <-h.client.mUpdate.ClickedCh:
-			h.handleUpdateClick()
 		case <-h.client.mInstallUpdate.ClickedCh:
 			h.handleInstallUpdateClick()
 		case <-h.client.mNetworks.ClickedCh:
@@ -172,12 +170,6 @@ func (h *eventHandler) handleGitHubClick() {
 	}
 }
 
-func (h *eventHandler) handleUpdateClick() {
-	if err := openURL(version.DownloadUrl()); err != nil {
-		log.Errorf("failed to open download URL: %v", err)
-	}
-}
-
 // handleInstallUpdateClick asks the privileged daemon to run the
 // rollout-gated self-update cycle (#5, C1). Long-running
 // (download+verify+install): runs off the menu loop with the item
@@ -194,10 +186,29 @@ func (h *eventHandler) handleInstallUpdateClick() {
 			h.client.app.SendNotification(fyne.NewNotification("Update", "Cannot reach the openZro daemon"))
 			return
 		}
+
+		// Snapshot pre-install state so a successful install (which
+		// restarts the daemon and DROPS this RPC) is not misread as a
+		// failure (#5 R5).
+		var preVersion, target string
+		if st, serr := conn.Status(h.client.ctx, &proto.StatusRequest{}); serr == nil {
+			preVersion = st.GetDaemonVersion()
+			target = st.GetUpdateState().GetTargetVersion()
+		}
+
 		h.client.app.SendNotification(fyne.NewNotification("Update", "Downloading and verifying the update…"))
 
 		resp, err := conn.Update(h.client.ctx, &proto.UpdateRequest{})
 		if err != nil {
+			// The install restarts the daemon, killing THIS RPC — an
+			// error here is ambiguous. Poll the daemon back up: if it
+			// now runs the target (or simply a different version when
+			// the target is unknown) the install actually SUCCEEDED.
+			if h.installSucceededAfterRestart(preVersion, target) {
+				h.client.app.SendNotification(fyne.NewNotification("Update installed",
+					"openZro updated — the service restarted."))
+				return
+			}
 			log.Errorf("self-update failed: %v", err)
 			h.client.app.SendNotification(fyne.NewNotification("Update failed", err.Error()))
 			return
@@ -212,6 +223,42 @@ func (h *eventHandler) handleInstallUpdateClick() {
 			h.client.app.SendNotification(fyne.NewNotification("Update", resp.GetReason()))
 		}
 	}()
+}
+
+// installSucceededAfterRestart resolves the ambiguous post-install
+// RPC drop: the install replaces+restarts the daemon, so the Update
+// RPC connection dies even on success. Poll the daemon back up and
+// report whether it is now running the update target (or, when the
+// target is unknown, simply a different version than before). A
+// genuine pre-install failure leaves the daemon untouched, so the
+// version never changes and this correctly returns false (#5 R5).
+func (h *eventHandler) installSucceededAfterRestart(preVersion, target string) bool {
+	deadline := time.Now().Add(45 * time.Second)
+	for time.Now().Before(deadline) {
+		time.Sleep(2 * time.Second)
+		conn, err := h.client.getSrvClient(failFastTimeout)
+		if err != nil {
+			continue // daemon still restarting
+		}
+		st, err := conn.Status(h.client.ctx, &proto.StatusRequest{})
+		if err != nil {
+			continue
+		}
+		now := st.GetDaemonVersion()
+		if now == "" {
+			continue
+		}
+		if target != "" {
+			if now == target {
+				return true
+			}
+			continue
+		}
+		if preVersion != "" && now != preVersion {
+			return true
+		}
+	}
+	return false
 }
 
 func (h *eventHandler) handleNetworksClick() {

--- a/client/ui/event_handler.go
+++ b/client/ui/event_handler.go
@@ -248,11 +248,15 @@ func (h *eventHandler) installSucceededAfterRestart(preVersion, target string) b
 		if now == "" {
 			continue
 		}
-		if target != "" {
-			if now == target {
-				return true
-			}
-			continue
+		// target (the directive at snapshot time) is the strongest
+		// signal but NOT the only one: the manual RPC installs the
+		// LIVE directive, which may have moved A->B between our
+		// snapshot and the call. ANY post-restart version change vs
+		// preVersion means the install succeeded (#5 R5 review). A
+		// genuine pre-install failure never restarts the daemon, so
+		// the version is unchanged and this stays false.
+		if target != "" && now == target {
+			return true
 		}
 		if preVersion != "" && now != preVersion {
 			return true

--- a/version/selfupdate/manifest_test.go
+++ b/version/selfupdate/manifest_test.go
@@ -241,3 +241,29 @@ func TestManifest_ReleasePipelineShape(t *testing.T) {
 		}
 	}
 }
+
+// TestManifest_StaticFallbackShape pins the R6 rolling static
+// manifest the pipeline emits (same schema as the per-version one,
+// but with an operator-set min_version). A client below that floor
+// must read it as Critical so the unmanaged fallback self-heals.
+func TestManifest_StaticFallbackShape(t *testing.T) {
+	const u = "https://github.com/openzro/openzro/releases/download/v2.0.0/openzro_2.0.0_darwin_universal.pkg"
+	const sh = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	body := `{"version":"2.0.0","min_version":"1.9.0","staged_rollout":100,
+	  "artifacts":{"darwin/arm64":{"url":"` + u + `","sha256":"` + sh + `"},
+	               "darwin/amd64":{"url":"` + u + `","sha256":"` + sh + `"}}}`
+	m, err := ParseManifest([]byte(body))
+	if err != nil {
+		t.Fatalf("static fallback manifest must parse, got %v", err)
+	}
+	// An old client (below min_version) — non-authoritative path.
+	d := Evaluate(GateInput{Current: "1.5.0", Manifest: m, AutoInstallEnabled: true, ClientID: "c"})
+	if !d.Eligible || !d.Critical {
+		t.Fatalf("a client below min_version must be Eligible+Critical, got %+v", d)
+	}
+	// A current client (>= min_version, already at version) — nothing.
+	d = Evaluate(GateInput{Current: "2.0.0", Manifest: m, AutoInstallEnabled: true, ClientID: "c"})
+	if d.Eligible {
+		t.Fatalf("a current client must not be eligible, got %+v", d)
+	}
+}

--- a/version/selfupdate/updater.go
+++ b/version/selfupdate/updater.go
@@ -49,6 +49,19 @@ type Config struct {
 	// still honours staged_rollout. See GateInput.Authoritative.
 	Authoritative bool
 
+	// CriticalOnly restricts this cycle to a SECURITY-FLOOR breach:
+	// RunOnce proceeds to download/verify/install only when the gate
+	// returns Critical (Current < Manifest.MinVersion); a normal
+	// eligible-but-not-critical update is reported Skipped instead of
+	// installed. It is the openZro #5 R6 last-resort posture: when
+	// management is unreachable AND the client is below the static
+	// manifest's min_version, self-heal silently — but NEVER
+	// slow-roll a routine update behind the operator's back while
+	// unmanaged. Independent of Authoritative (the fallback path is
+	// non-authoritative so staged_rollout still applies, though
+	// Critical bypasses it anyway).
+	CriticalOnly bool
+
 	// BeforeInstall, when set, is called AFTER Verify succeeds and
 	// IMMEDIATELY before Installer.Install — i.e. glued to the
 	// privileged install/restart, not merely before the whole cycle
@@ -163,6 +176,15 @@ func (u *Updater) RunOnce(ctx context.Context) (Result, error) {
 	if !d.Eligible {
 		log.Infof("selfupdate: skipping — %s", d.Reason)
 		return Result{Skipped: true, Version: m.Version, Reason: d.Reason, Critical: d.Critical}, nil
+	}
+
+	// R6 last-resort posture: an unmanaged client self-heals ONLY a
+	// security-floor breach, never a routine update. An eligible but
+	// non-critical update is a normal Skip here, not an install.
+	if c.CriticalOnly && !d.Critical {
+		reason := "critical-only fallback: " + m.Version + " is eligible but not critical — not self-installing while unmanaged"
+		log.Infof("selfupdate: skipping — %s", reason)
+		return Result{Skipped: true, Version: m.Version, Reason: reason, Critical: false}, nil
 	}
 
 	art, ok := m.ArtifactFor(c.GOOS, c.GOARCH)

--- a/version/selfupdate/updater_extra_test.go
+++ b/version/selfupdate/updater_extra_test.go
@@ -160,3 +160,90 @@ func TestRunOnce_BeforeInstallHook(t *testing.T) {
 		}
 	})
 }
+
+// criticalManifestServer serves a manifest with an optional
+// min_version so tests can drive the gate's Critical flag.
+func criticalManifestServer(t *testing.T, version, minVersion string) *httptest.Server {
+	t.Helper()
+	payload := []byte("notarized-pkg-bytes")
+	mux := http.NewServeMux()
+	mux.HandleFunc("/artifact", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(payload)
+	})
+	mux.HandleFunc("/manifest", func(w http.ResponseWriter, r *http.Request) {
+		mv := ""
+		if minVersion != "" {
+			mv = `"min_version":"` + minVersion + `",`
+		}
+		_, _ = w.Write([]byte(`{"version":"` + version + `",` + mv +
+			`"staged_rollout":100,"artifacts":{"darwin/arm64":{"url":"http://` +
+			r.Host + `/artifact","sha256":"` + sha256hex(payload) + `"}}}`))
+	})
+	return httptest.NewServer(mux)
+}
+
+// TestRunOnce_CriticalOnly pins openZro #5 R6: the last-resort
+// fallback self-heals ONLY a security-floor breach (Critical) and
+// never slow-rolls a routine update while unmanaged.
+func TestRunOnce_CriticalOnly(t *testing.T) {
+	t.Run("eligible but NOT critical -> skipped, no install", func(t *testing.T) {
+		srv := criticalManifestServer(t, "1.2.0", "") // no min_version
+		defer srv.Close()
+		cfg := baseCfg(srv) // Current 1.0.0 < 1.2.0, AutoInstall true
+		cfg.CriticalOnly = true
+		v, in := &fakeVerifier{}, &fakeInstaller{}
+		cfg.Verifier, cfg.Installer = v, in
+		u, err := New(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		res, err := u.RunOnce(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.Installed || !res.Skipped || in.called || v.called {
+			t.Fatalf("non-critical must be skipped without install: %+v verify=%v install=%v", res, v.called, in.called)
+		}
+	})
+
+	t.Run("critical -> installs", func(t *testing.T) {
+		// min_version 1.5.0 > Current 1.0.0 => Critical.
+		srv := criticalManifestServer(t, "1.6.0", "1.5.0")
+		defer srv.Close()
+		cfg := baseCfg(srv)
+		cfg.CriticalOnly = true
+		v, in := &fakeVerifier{}, &fakeInstaller{}
+		cfg.Verifier, cfg.Installer = v, in
+		u, err := New(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		res, err := u.RunOnce(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !res.Installed || !res.Critical || !in.called {
+			t.Fatalf("critical breach must install: %+v install=%v", res, in.called)
+		}
+	})
+
+	t.Run("control: CriticalOnly=false installs the routine eligible update", func(t *testing.T) {
+		srv := criticalManifestServer(t, "1.2.0", "")
+		defer srv.Close()
+		cfg := baseCfg(srv)
+		cfg.CriticalOnly = false
+		v, in := &fakeVerifier{}, &fakeInstaller{}
+		cfg.Verifier, cfg.Installer = v, in
+		u, err := New(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		res, err := u.RunOnce(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !res.Installed || !in.called {
+			t.Fatalf("without CriticalOnly the eligible update must install: %+v", res)
+		}
+	})
+}


### PR DESCRIPTION
Closes the remaining openZro #5 follow-ups (one block, owner-signed-off spec). After this, #5 = #42 (macOS+Q2) + #43 (R4) + this; only the explicitly-parked items remain (test-harness debt, pre-existing race, #39/#41/Win-signing).

## R6 — critical-only static-manifest fallback (last resort for an UNMANAGED client)

- **C1 `057c9fe3`** — `selfupdate.Config.CriticalOnly`: RunOnce installs only when the gate returns `Critical` (Current < min_version); a routine eligible update is Skipped. Engine primitive; tests: non-critical→skip, critical→install, control proves the knob gates it.
- **C2 `02cefb0e`** — daemon worker (started once on the auto-connect path): observes mgmt connectivity every 10m and self-heals **only** when mgmt unreachable ≥1h **AND** no operator directive recorded (directive path always wins) **AND** rate-limited ≥1h. `buildCriticalFallbackConfig`: static `ResolveManifestURL()` (env override; explicit-empty disables), `ExpectedVersion=""`, `Authoritative=false`, `CriticalOnly=true`, `AutoInstallEnabled=true` (owner-signed-off **silent** self-heal — vulnerable + unmanaged + no reliable tray), Team-ID/verify unchanged, `BeforeInstall` flush inherited. Reuses the shared install gate (no collision with directive/manual). Pure `criticalFallbackEligible` truth-table tested.
- **C3 `2f5f99a3`** — pipeline publishes the single rolling `update` release/asset (`defaultManifestURL`); `min_version` = repo var `OPENZRO_FALLBACK_MIN_VERSION`, **empty by default → fallback inert until a security cut**. Same signed-artifact gate. `TestManifest_StaticFallbackShape` pins schema + below-floor→Critical.

## R5 — manual opt-in UI polish (BSD Fyne tray)

- **C4 `777a3446`** — (1) **fix the false "Update failed"**: a successful install restarts the daemon and drops the Update RPC; now we snapshot version+target pre-call and, on RPC error, poll the daemon back up — if it runs the target it's reported installed, a genuine pre-install failure still reports failure. (2) **surface** target version + decision: a disabled status line ("Update: <target>", tooltip = daemon decision) shown for any active directive incl. forced/silent/checking, and the CTA label becomes "Install openZro <target>". (3) **retire** the poll-era "Download latest version" browser link (bypassed the gated/verified pipeline).

## Posture / residual (documented)
- R6 silent install fires ONLY in: client below the security floor **AND** management unreachable ≥1h **AND** no directive. Doing nothing there leaves a vulnerable, unmanaged client; the installed pkg is still notarized + Team-ID-pinned + sha256-checked (trust root unchanged).
- `min_version` empty by default ⇒ R6 never fires until the release process sets the repo variable on a security cut. No code/secret change to arm.
- `client/ui` (Fyne tray) has no unit-test harness (as with prior #5 UI commits) — verified by build/gofmt/vet; smoke-test on macOS in the test plan.

## Test plan
- [ ] `go build ./...`; `gofmt`/`go vet` clean (modulo pre-existing `//nolint` network.go:534)
- [ ] `go test ./version/selfupdate/` (incl. CriticalOnly, StaticFallbackShape, BeforeInstall, ReleasePipelineShape)
- [ ] `go test ./client/server/ -run 'CriticalFallbackEligible|BuildCriticalFallbackConfig|MaybeAutoInstall|SharedInstallGate|BuildSelfUpdateConfig|BuildUpdateState'`
- [ ] release-binaries.yml parses; dry-run tagged release → both `v{version}/update-manifest.json` and rolling `update/update-manifest.json` assets present + ParseManifest-valid
- [ ] macOS smoke: (a) manual install → daemon restarts → tray shows "installed" not "failed"; (b) tray shows target+decision incl. forced; (c) simulate mgmt down ≥1h + no directive + a static manifest with min_version above current → silent critical self-heal; non-critical → no action

🤖 Generated with [Claude Code](https://claude.com/claude-code)