### PR TITLE
test: close #45 + #46 (parked test-infra debt)

### DIFF
--- a/client/server/server_test.go
+++ b/client/server/server_test.go
@@ -54,6 +54,24 @@ var (
 // TestConnectWithRetryRuns checks that the connectWithRetry function runs and runs the retries according to the times specified via environment variables
 // we will use a management server started via to simulate the server and capture the number of retries
 func TestConnectWithRetryRuns(t *testing.T) {
+	// Redirect privileged profile state to a temp dir so the test runs
+	// unprivileged (default is /var/lib/openzro, root-only). Mirrors the
+	// override TestServer_Up already uses; see issue #46.
+	stateDir := t.TempDir()
+	origDefaultProfileDir := profilemanager.DefaultConfigPathDir
+	origDefaultConfigPath := profilemanager.DefaultConfigPath
+	origActiveProfileStatePath := profilemanager.ActiveProfileStatePath
+	profilemanager.ConfigDirOverride = stateDir
+	profilemanager.DefaultConfigPathDir = stateDir
+	profilemanager.ActiveProfileStatePath = filepath.Join(stateDir, "active_profile.json")
+	profilemanager.DefaultConfigPath = filepath.Join(stateDir, "default.json")
+	t.Cleanup(func() {
+		profilemanager.DefaultConfigPathDir = origDefaultProfileDir
+		profilemanager.ActiveProfileStatePath = origActiveProfileStatePath
+		profilemanager.DefaultConfigPath = origDefaultConfigPath
+		profilemanager.ConfigDirOverride = ""
+	})
+
 	// start the signal server
 	_, signalAddr, err := startSignal(t)
 	if err != nil {

--- a/management/server/client_update_targeting_test.go
+++ b/management/server/client_update_targeting_test.go
@@ -1,8 +1,12 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/openzro/openzro/management/server/types"
 )
@@ -262,4 +266,76 @@ func TestIsGroupLinkedToClientUpdate(t *testing.T) {
 		isGroupLinkedToClientUpdate(inactive, "infra") {
 		t.Fatal("no active target version => not linked (cheap unused path)")
 	}
+}
+
+// TestClientUpdateGroupDeleteFanout is the channel-level regression for
+// the Q2 review-2 wiring (#5): a group referenced only by the
+// client-update directive is NOT in any delete-prevention chain (so it
+// can be deleted), but deleting it MUST still wake peers, because the
+// resolved per-peer UpdateConfig may change. This is the deferred E2E
+// that issue #45 tracked. The original #45 blocker (in-memory store
+// couldn't seed/round-trip account Settings) no longer reproduces:
+// ClientUpdate* settings round-trip cleanly through
+// manager.UpdateAccountSettings on the same automigrate store
+// setupNetworkMapTest uses, so the E2E is writable as-is with no
+// store-layer change.
+//
+// It asserts three things over a real peer update channel:
+//  1. activating the directive (UpdateAccountSettings) fans out;
+//  2. deleting an unrelated, unlinked group is silent (no false wake);
+//  3. deleting the directive-linked group fans out
+//     (isGroupLinkedToClientUpdate -> areGroupChangesAffectPeers ->
+//     UpdateAccountPeers, reached via DeleteGroups).
+func TestClientUpdateGroupDeleteFanout(t *testing.T) {
+	manager, account, peer1, _, _ := setupNetworkMapTest(t)
+
+	err := manager.SaveGroups(context.Background(), account.Id, userID, []*types.Group{
+		{ID: "cu-group", Name: "CUGroup", Peers: []string{peer1.ID}},
+		{ID: "unrelated", Name: "Unrelated", Peers: []string{}},
+	}, true)
+	require.NoError(t, err)
+
+	updMsg := manager.peersUpdateManager.CreateChannel(context.Background(), peer1.ID)
+	t.Cleanup(func() {
+		manager.peersUpdateManager.CloseChannel(context.Background(), peer1.ID)
+	})
+
+	s, err := manager.GetAccountSettings(context.Background(), account.Id, userID)
+	require.NoError(t, err)
+	s.ClientUpdateTargetVersion = "1.2.3"
+	s.ClientUpdateTargetGroups = []string{"cu-group"}
+	_, err = manager.UpdateAccountSettings(context.Background(), account.Id, userID, s)
+	require.NoError(t, err)
+
+	t.Run("activating the directive fans out", func(t *testing.T) {
+		peerShouldReceiveUpdate(t, updMsg)
+	})
+
+	t.Run("unrelated unlinked group delete is silent", func(t *testing.T) {
+		done := make(chan struct{})
+		go func() {
+			peerShouldNotReceiveUpdate(t, updMsg)
+			close(done)
+		}()
+		require.NoError(t, manager.DeleteGroups(context.Background(), account.Id, userID, []string{"unrelated"}))
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("timeout waiting for peerShouldNotReceiveUpdate")
+		}
+	})
+
+	t.Run("directive-linked group delete fans out", func(t *testing.T) {
+		done := make(chan struct{})
+		go func() {
+			peerShouldReceiveUpdate(t, updMsg)
+			close(done)
+		}()
+		require.NoError(t, manager.DeleteGroups(context.Background(), account.Id, userID, []string{"cu-group"}))
+		select {
+		case <-done:
+		case <-time.After(6 * time.Second):
+			t.Error("timeout waiting for peerShouldReceiveUpdate")
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Two **test-only** fixes for the parked follow-ups filed during #5. No production code changes; the merged #5 behavior (PRs #42/#43/#44) is untouched.

- **#46** — `TestConnectWithRetryRuns` wrote privileged profile state to `/var/lib/openzro/active_profile.json` (it never overrode the state dir, unlike `TestServer_Up`), so `go test ./client/server` was red in any unprivileged dev/CI env. Applied the identical temp-dir override `TestServer_Up` already uses. `TestServer_Up` itself was only guilty-by-association (package-level FAIL) — it passes in isolation and still does.
- **#45** — Added the deferred Q2 review-2 channel-level regression E2E: deleting a group referenced only by the client-update directive must still wake peers (`DeleteGroups -> areGroupChangesAffectPeers -> UpdateAccountPeers`), even though such a group is intentionally deletable. **The original #45 blocker no longer reproduces** — `ClientUpdate*` settings round-trip cleanly through `manager.UpdateAccountSettings` on the same automigrate store `setupNetworkMapTest` uses (verified via throwaway scratch tests), so the E2E is writable with no store-layer change.

## Verification

- `gofmt`/`go vet` clean on both touched files.
- `go test ./client/server` — full package now green (previously red only on these two).
- `go test ./management/server -run 'TestClientUpdateGroupDeleteFanout|TestPeerTargetedForUpdate|TestIsGroupLinkedToClientUpdate|TestUpdateBucket|TestClientUpdate|TestGroupAccountPeersUpdate'` — green.
- Package builds.

## Test plan

- [ ] CI runs `go test ./client/server` unprivileged and it is green.
- [ ] CI runs the new `TestClientUpdateGroupDeleteFanout` and it is green.
- [ ] Confirm no behavioral/production diff (test files only).

Closes #45
Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)