### PR TITLE
feat: Control Center Phase 1 — backend access-graph (#39)

### DIFF
--- a/docs/adr/0017-control-center-access-graph.md
+++ b/docs/adr/0017-control-center-access-graph.md
@@ -143,7 +143,7 @@ GraphDTO {
   nodes: [{ id, kind: focus|policy|group|peer|route|network_resource, label, meta }]
   edges: [{
     from, to,
-    permitSource: policy | route_default_permit, // D1.1: not every route edge has a policy
+    permitSource: policy | route_default_permit | router_local, // D1.1; see amendment 2026-05-17
     policyId?, policyName?,          // present iff permitSource == policy (chip identity)
     protocol, ports, sourceRanges?,  // non-lossy: ranges preserved, not flattened
     direction,                       // in|out|bidirectional
@@ -365,3 +365,18 @@ value and de-risks the resolver contract for the v2 widening.
 - Dashboard fork posture: [ADR-0016 §Context](./0016-dashboard-redesign-v2.md).
 - Upstream reference (library choice only, not ported): `netbirdio/dashboard` `package.json` + `src/modules/control-center/*`.
 - Drift precedent: `resolved_addresses` scope-creep revert (frontend-vs-enforced divergence).
+
+## Amendments
+
+- **2026-05-17 — `permitSource` gains `router_local` (Phase 1, owner-decided).**
+  The minimum DTO envelope originally listed `permitSource: policy |
+  route_default_permit`. Phase-1 review surfaced that when the focus
+  *is* the router serving a route, labelling that reach
+  `route_default_permit` is wrong if the route carries
+  `AccessControlGroups` (those gate other clients, not the router).
+  A third value, **`router_local`**, was added: honest
+  infrastructure-local reach, no policy chip. This is part of the
+  wire contract — the Phase 2 dashboard must handle all three
+  `permitSource` values. Pinned by the C8 contract test and the
+  enum wire-value test. Not a reversal of D1.1; a faithful refinement
+  of it.

--- a/management/server/access_graph.go
+++ b/management/server/access_graph.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"context"
+
+	"github.com/openzro/openzro/management/server/controlcenter"
+)
+
+// GetAccessGraph builds the read-only Control Center access graph for a
+// focus node (ADR-0017 Phase 1). It loads the account and assembles
+// the validated-peers set from the store the same way the network-map
+// path does, then delegates to the controlcenter adapter — it makes no
+// access decisions of its own. RBAC (admin-only) is enforced at the
+// HTTP boundary, consistent with the flow-exports handler.
+//
+// Clean-room (BSD-3): wiring designed against openZro's own manager
+// helpers and ADR-0017; no upstream NetBird management/ code consulted
+// or ported.
+func (am *DefaultAccountManager) GetAccessGraph(ctx context.Context, accountID, view, focusID string) (*controlcenter.GraphDTO, error) {
+	account, err := am.Store.GetAccount(ctx, accountID)
+	if err != nil {
+		return nil, err
+	}
+
+	validatedPeers, err := am.GetValidatedPeers(ctx, accountID)
+	if err != nil {
+		return nil, err
+	}
+
+	return controlcenter.BuildGraph(ctx, account, controlcenter.Focus{
+		Type: controlcenter.FocusType(view),
+		ID:   focusID,
+	}, validatedPeers)
+}

--- a/management/server/access_graph_test.go
+++ b/management/server/access_graph_test.go
@@ -1,0 +1,47 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openzro/openzro/management/server/controlcenter"
+)
+
+// C6: the manager seam loads the account + assembles validatedPeers
+// from the store exactly like the network-map path, then delegates to
+// the exhaustively-unit-tested adapter. This e2e proves the wiring
+// (account load, validated-peers assembly, focus mapping, error
+// propagation) against a real store-backed manager.
+func TestGetAccessGraph_ManagerSeam(t *testing.T) {
+	manager, account, peer1, _, _ := setupNetworkMapTest(t)
+	ctx := context.Background()
+
+	g, err := manager.GetAccessGraph(ctx, account.Id, string(controlcenter.FocusPeer), peer1.ID)
+	require.NoError(t, err)
+	require.Equal(t, controlcenter.Focus{Type: controlcenter.FocusPeer, ID: peer1.ID}, g.Focus)
+
+	var focusNode *controlcenter.Node
+	for i := range g.Nodes {
+		if g.Nodes[i].ID == peer1.ID {
+			focusNode = &g.Nodes[i]
+		}
+	}
+	require.NotNil(t, focusNode, "the focus peer must be a node")
+	require.Equal(t, controlcenter.NodeFocus, focusNode.Kind)
+
+	// group focus is also wired (use a real group id from the account).
+	var anyGroupID string
+	for id := range account.Groups {
+		anyGroupID = id
+		break
+	}
+	require.NotEmpty(t, anyGroupID)
+	_, err = manager.GetAccessGraph(ctx, account.Id, string(controlcenter.FocusGroup), anyGroupID)
+	require.NoError(t, err)
+
+	// unknown focus type propagates the adapter error.
+	_, err = manager.GetAccessGraph(ctx, account.Id, "bogus", peer1.ID)
+	require.Error(t, err)
+}

--- a/management/server/account/manager.go
+++ b/management/server/account/manager.go
@@ -11,6 +11,7 @@ import (
 	"github.com/openzro/openzro/management/server/activity"
 	nbcache "github.com/openzro/openzro/management/server/cache"
 	nbcontext "github.com/openzro/openzro/management/server/context"
+	"github.com/openzro/openzro/management/server/controlcenter"
 	"github.com/openzro/openzro/management/server/idp"
 	nbpeer "github.com/openzro/openzro/management/server/peer"
 	"github.com/openzro/openzro/management/server/posture"
@@ -73,6 +74,7 @@ type Manager interface {
 	DeletePeer(ctx context.Context, accountID, peerID, userID string) error
 	UpdatePeer(ctx context.Context, accountID, userID string, peer *nbpeer.Peer) (*nbpeer.Peer, error)
 	GetNetworkMap(ctx context.Context, peerID string) (*types.NetworkMap, error)
+	GetAccessGraph(ctx context.Context, accountID, view, focusID string) (*controlcenter.GraphDTO, error)
 	GetPeerNetwork(ctx context.Context, peerID string) (*types.Network, error)
 	AddPeer(ctx context.Context, setupKey, userID string, peer *nbpeer.Peer) (*nbpeer.Peer, *types.NetworkMap, []*posture.Checks, error)
 	CreatePAT(ctx context.Context, accountID string, initiatorUserID string, targetUserID string, tokenName string, expiresIn int) (*types.PersonalAccessTokenGenerated, error)

--- a/management/server/controlcenter/build.go
+++ b/management/server/controlcenter/build.go
@@ -49,7 +49,8 @@ func buildPeerFocus(ctx context.Context, acc *types.Account, focus Focus, valida
 	reachable, fwRules := acc.GetPeerConnectionResources(ctx, focusPeer, validatedPeers)
 	b.addPeerReach(acc, focusPeer.ID, reachable, fwRules)
 	b.addPostureBlocked(ctx, acc, focusPeer.ID, validatedPeers)
-	b.addRouteReach(ctx, acc, focusPeer.ID, reachable, validatedPeers)
+	b.addRouteReach(ctx, acc, focusPeer.ID, reachable, validatedPeers,
+		newRouteIndex(ctx, acc, validatedPeers))
 
 	b.finalize()
 	return g, nil

--- a/management/server/controlcenter/build.go
+++ b/management/server/controlcenter/build.go
@@ -23,14 +23,14 @@ func BuildGraph(ctx context.Context, acc *types.Account, focus Focus, validatedP
 	case FocusGroup:
 		return buildGroupFocus(ctx, acc, focus, validatedPeers)
 	default:
-		return nil, fmt.Errorf("unsupported focus type %q", focus.Type)
+		return nil, fmt.Errorf("%w %q", ErrUnsupportedFocus, focus.Type)
 	}
 }
 
 func buildPeerFocus(ctx context.Context, acc *types.Account, focus Focus, validatedPeers map[string]struct{}) (*GraphDTO, error) {
 	focusPeer := acc.GetPeer(focus.ID)
 	if focusPeer == nil {
-		return nil, fmt.Errorf("focus peer %q not found", focus.ID)
+		return nil, fmt.Errorf("focus peer %q: %w", focus.ID, ErrFocusNotFound)
 	}
 
 	g := &GraphDTO{Focus: focus}

--- a/management/server/controlcenter/build.go
+++ b/management/server/controlcenter/build.go
@@ -37,6 +37,7 @@ func buildPeerFocus(ctx context.Context, acc *types.Account, focus Focus, valida
 
 	reachable, fwRules := acc.GetPeerConnectionResources(ctx, focusPeer, validatedPeers)
 	b.addPeerReach(acc, focusPeer.ID, reachable, fwRules)
+	b.addPostureBlocked(ctx, acc, focusPeer.ID, validatedPeers)
 
 	b.finalize()
 	return g, nil

--- a/management/server/controlcenter/build.go
+++ b/management/server/controlcenter/build.go
@@ -37,6 +37,15 @@ func buildPeerFocus(ctx context.Context, acc *types.Account, focus Focus, valida
 	b := newGraphBuilder(g)
 	b.addNode(focusPeer.ID, NodeFocus, peerLabel(focusPeer))
 
+	// Mirror the dataplane: GetPeerNetworkMap early-returns an empty
+	// map when the focus is not validated (account.go:262). An
+	// unvalidated peer reaches nothing "right now" — the graph must
+	// say the same, not fabricate posture/route edges (#50-r2 F1).
+	if _, ok := validatedPeers[focusPeer.ID]; !ok {
+		b.finalize()
+		return g, nil
+	}
+
 	reachable, fwRules := acc.GetPeerConnectionResources(ctx, focusPeer, validatedPeers)
 	b.addPeerReach(acc, focusPeer.ID, reachable, fwRules)
 	b.addPostureBlocked(ctx, acc, focusPeer.ID, validatedPeers)

--- a/management/server/controlcenter/build.go
+++ b/management/server/controlcenter/build.go
@@ -150,15 +150,35 @@ func (b *graphBuilder) finalize() {
 		b.g.Edges = append(b.g.Edges, *e)
 	}
 	sort.Slice(b.g.Edges, func(i, j int) bool {
-		a, c := b.g.Edges[i], b.g.Edges[j]
-		if a.From != c.From {
-			return a.From < c.From
-		}
-		if a.To != c.To {
-			return a.To < c.To
-		}
-		return a.PolicyID < c.PolicyID
+		return edgeLess(b.g.Edges[i], b.g.Edges[j])
 	})
+}
+
+// edgeLess is a TOTAL order over edges so the DTO is deterministic.
+// Sorting only by from/to/policyID left ties (different protocol /
+// state / posture-denial cause) in map-iteration order, causing wire
+// jitter (#50-r2 F4). The posture-denial signature is the final
+// tie-breaker so distinct posture_blocked causes order stably.
+func edgeLess(a, b Edge) bool {
+	switch {
+	case a.From != b.From:
+		return a.From < b.From
+	case a.To != b.To:
+		return a.To < b.To
+	case a.PolicyID != b.PolicyID:
+		return a.PolicyID < b.PolicyID
+	case a.PermitSource != b.PermitSource:
+		return a.PermitSource < b.PermitSource
+	case a.Protocol != b.Protocol:
+		return a.Protocol < b.Protocol
+	case a.State != b.State:
+		return a.State < b.State
+	}
+	return denialSig(a) < denialSig(b)
+}
+
+func denialSig(e Edge) string {
+	return e.Meta["postureCheckId"] + "/" + e.Meta["postureCheckType"]
 }
 
 func indexRuleToPolicy(acc *types.Account) map[string]*types.Policy {

--- a/management/server/controlcenter/build.go
+++ b/management/server/controlcenter/build.go
@@ -20,6 +20,8 @@ func BuildGraph(ctx context.Context, acc *types.Account, focus Focus, validatedP
 	switch focus.Type {
 	case FocusPeer:
 		return buildPeerFocus(ctx, acc, focus, validatedPeers)
+	case FocusGroup:
+		return buildGroupFocus(ctx, acc, focus, validatedPeers)
 	default:
 		return nil, fmt.Errorf("unsupported focus type %q", focus.Type)
 	}

--- a/management/server/controlcenter/build.go
+++ b/management/server/controlcenter/build.go
@@ -1,0 +1,199 @@
+package controlcenter
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	nbpeer "github.com/openzro/openzro/management/server/peer"
+	"github.com/openzro/openzro/management/server/types"
+)
+
+// BuildGraph derives the read-only access graph for a focus node from
+// openZro's own enforcement engine. v1 supports peer focus (group
+// focus lands in a later commit). It never re-decides access: it
+// composes the producers GetPeerNetworkMap uses and labels the result.
+//
+// Clean-room (BSD-3): ADR-0017; no upstream NetBird management/ code
+// consulted or ported.
+func BuildGraph(ctx context.Context, acc *types.Account, focus Focus, validatedPeers map[string]struct{}) (*GraphDTO, error) {
+	switch focus.Type {
+	case FocusPeer:
+		return buildPeerFocus(ctx, acc, focus, validatedPeers)
+	default:
+		return nil, fmt.Errorf("unsupported focus type %q", focus.Type)
+	}
+}
+
+func buildPeerFocus(ctx context.Context, acc *types.Account, focus Focus, validatedPeers map[string]struct{}) (*GraphDTO, error) {
+	focusPeer := acc.GetPeer(focus.ID)
+	if focusPeer == nil {
+		return nil, fmt.Errorf("focus peer %q not found", focus.ID)
+	}
+
+	g := &GraphDTO{Focus: focus}
+	b := newGraphBuilder(g)
+	b.addNode(focusPeer.ID, NodeFocus, peerLabel(focusPeer))
+
+	reachable, fwRules := acc.GetPeerConnectionResources(ctx, focusPeer, validatedPeers)
+	b.addPeerReach(acc, focusPeer.ID, reachable, fwRules)
+
+	b.finalize()
+	return g, nil
+}
+
+// graphBuilder accumulates nodes/edges and de-dups + sorts on
+// finalize so the DTO is deterministic (stable tests, stable wire).
+type graphBuilder struct {
+	g       *GraphDTO
+	nodes   map[string]Node
+	edgeAgg map[string]*Edge // key: from|to|policyID|protocol
+}
+
+func newGraphBuilder(g *GraphDTO) *graphBuilder {
+	return &graphBuilder{g: g, nodes: map[string]Node{}, edgeAgg: map[string]*Edge{}}
+}
+
+func (b *graphBuilder) addNode(id string, kind NodeKind, label string) {
+	if _, ok := b.nodes[id]; ok {
+		return
+	}
+	b.nodes[id] = Node{ID: id, Kind: kind, Label: label}
+}
+
+// addPeerReach turns the enforcement output (reachable peers + the
+// firewall rules that permit them) into peer nodes + enforced edges.
+func (b *graphBuilder) addPeerReach(acc *types.Account, fromID string, reachable []*nbpeer.Peer, fwRules []*types.FirewallRule) {
+	ruleToPolicy := indexRuleToPolicy(acc)
+
+	ipToPeer := map[string]*nbpeer.Peer{}
+	for _, p := range reachable {
+		if p == nil {
+			continue
+		}
+		b.addNode(p.ID, NodePeer, peerLabel(p))
+		ipToPeer[p.IP.String()] = p
+	}
+
+	for _, fr := range fwRules {
+		if fr == nil {
+			continue
+		}
+		// "0.0.0.0" is the GetGroupAll shortcut: the rule applies to
+		// every reachable peer, so fan it out to all of them.
+		var targets []*nbpeer.Peer
+		if fr.PeerIP == "0.0.0.0" {
+			targets = reachable
+		} else if p := ipToPeer[fr.PeerIP]; p != nil {
+			targets = []*nbpeer.Peer{p}
+		}
+
+		for _, p := range targets {
+			if p == nil {
+				continue
+			}
+			b.upsertPolicyEdge(fromID, p.ID, fr, ruleToPolicy[fr.PolicyID])
+		}
+	}
+}
+
+// upsertPolicyEdge merges firewall rules that differ only by direction
+// (a bidirectional policy emits separate IN/OUT rules) and unions
+// ports, keeping the DTO one-edge-per-(peer,policy,protocol).
+func (b *graphBuilder) upsertPolicyEdge(from, to string, fr *types.FirewallRule, pol *types.Policy) {
+	key := from + "|" + to + "|" + fr.PolicyID + "|" + fr.Protocol
+	e, ok := b.edgeAgg[key]
+	if !ok {
+		e = &Edge{
+			From: from, To: to,
+			PermitSource: PermitPolicy,
+			Protocol:     fr.Protocol,
+			State:        EdgeEnforced,
+		}
+		if pol != nil {
+			e.PolicyID = pol.ID
+			e.PolicyName = pol.Name
+		}
+		b.edgeAgg[key] = e
+	}
+	mergeDirection(e, fr.Direction)
+	for _, port := range firewallPorts(fr) {
+		if !contains(e.Ports, port) {
+			e.Ports = append(e.Ports, port)
+		}
+	}
+}
+
+func (b *graphBuilder) finalize() {
+	b.g.Nodes = b.g.Nodes[:0]
+	for _, n := range b.nodes {
+		b.g.Nodes = append(b.g.Nodes, n)
+	}
+	sort.Slice(b.g.Nodes, func(i, j int) bool { return b.g.Nodes[i].ID < b.g.Nodes[j].ID })
+
+	for _, e := range b.edgeAgg {
+		sort.Strings(e.Ports)
+		b.g.Edges = append(b.g.Edges, *e)
+	}
+	sort.Slice(b.g.Edges, func(i, j int) bool {
+		a, c := b.g.Edges[i], b.g.Edges[j]
+		if a.From != c.From {
+			return a.From < c.From
+		}
+		if a.To != c.To {
+			return a.To < c.To
+		}
+		return a.PolicyID < c.PolicyID
+	})
+}
+
+func indexRuleToPolicy(acc *types.Account) map[string]*types.Policy {
+	idx := map[string]*types.Policy{}
+	for _, pol := range acc.Policies {
+		for _, r := range pol.Rules {
+			if r != nil {
+				idx[r.ID] = pol
+			}
+		}
+	}
+	return idx
+}
+
+func mergeDirection(e *Edge, frDir int) {
+	d := DirectionOut
+	if frDir == types.FirewallRuleDirectionIN {
+		d = DirectionIn
+	}
+	switch {
+	case e.Direction == "":
+		e.Direction = d
+	case e.Direction != d:
+		e.Direction = DirectionBidirectional
+	}
+}
+
+func firewallPorts(fr *types.FirewallRule) []string {
+	if fr.Port != "" {
+		return []string{fr.Port}
+	}
+	if fr.PortRange.Start != 0 || fr.PortRange.End != 0 {
+		return []string{fmt.Sprintf("%d-%d", fr.PortRange.Start, fr.PortRange.End)}
+	}
+	return nil
+}
+
+func peerLabel(p *nbpeer.Peer) string {
+	if p.Name != "" {
+		return p.Name
+	}
+	return p.ID
+}
+
+func contains(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}

--- a/management/server/controlcenter/build.go
+++ b/management/server/controlcenter/build.go
@@ -38,6 +38,7 @@ func buildPeerFocus(ctx context.Context, acc *types.Account, focus Focus, valida
 	reachable, fwRules := acc.GetPeerConnectionResources(ctx, focusPeer, validatedPeers)
 	b.addPeerReach(acc, focusPeer.ID, reachable, fwRules)
 	b.addPostureBlocked(ctx, acc, focusPeer.ID, validatedPeers)
+	b.addRouteReach(ctx, acc, focusPeer.ID, reachable, validatedPeers)
 
 	b.finalize()
 	return g, nil

--- a/management/server/controlcenter/build_test.go
+++ b/management/server/controlcenter/build_test.go
@@ -1,0 +1,88 @@
+package controlcenter
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	nbpeer "github.com/openzro/openzro/management/server/peer"
+	"github.com/openzro/openzro/management/server/types"
+)
+
+// C2: peer↔peer reach. A focus peer's graph must contain the peers it
+// actually reaches (GetPeerConnectionResources) with the permitting
+// policy chip, protocol/ports and direction on the edge. No policy =>
+// no edge (absence is a distinct audit answer, never a fake node).
+
+func twoPeerAccount(policyEnabled, ruleEnabled bool) *types.Account {
+	pA := &nbpeer.Peer{ID: "pA", IP: net.IP{10, 0, 0, 1}, Name: "alice"}
+	pB := &nbpeer.Peer{ID: "pB", IP: net.IP{10, 0, 0, 2}, Name: "bob"}
+	return &types.Account{
+		Id:    "acc1",
+		Peers: map[string]*nbpeer.Peer{"pA": pA, "pB": pB},
+		Groups: map[string]*types.Group{
+			"all": {ID: "all", Name: "All", Peers: []string{"pA", "pB"}},
+			"g1":  {ID: "g1", Name: "src", Peers: []string{"pA"}},
+			"g2":  {ID: "g2", Name: "dst", Peers: []string{"pB"}},
+		},
+		Policies: []*types.Policy{
+			{
+				ID: "pol1", Name: "allow-ssh", Enabled: policyEnabled,
+				Rules: []*types.PolicyRule{
+					{
+						ID: "r1", Enabled: ruleEnabled,
+						Action:       types.PolicyTrafficActionAccept,
+						Sources:      []string{"g1"},
+						Destinations: []string{"g2"},
+						Protocol:     types.PolicyRuleProtocolTCP,
+						Ports:        []string{"22"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestBuildGraph_PeerToPeer_Enforced(t *testing.T) {
+	acc := twoPeerAccount(true, true)
+	validated := map[string]struct{}{"pA": {}, "pB": {}}
+
+	g, err := BuildGraph(context.Background(), acc, Focus{Type: FocusPeer, ID: "pA"}, validated)
+	require.NoError(t, err)
+	require.Equal(t, Focus{Type: FocusPeer, ID: "pA"}, g.Focus)
+
+	// focus node + the one reachable peer node.
+	require.Contains(t, g.Nodes, Node{ID: "pA", Kind: NodeFocus, Label: "alice"})
+	require.Contains(t, g.Nodes, Node{ID: "pB", Kind: NodePeer, Label: "bob"})
+
+	require.Len(t, g.Edges, 1)
+	e := g.Edges[0]
+	require.Equal(t, "pA", e.From)
+	require.Equal(t, "pB", e.To)
+	require.Equal(t, PermitPolicy, e.PermitSource)
+	require.Equal(t, "pol1", e.PolicyID)
+	require.Equal(t, "allow-ssh", e.PolicyName)
+	require.Equal(t, "tcp", e.Protocol)
+	require.Equal(t, []string{"22"}, e.Ports)
+	require.Equal(t, EdgeEnforced, e.State)
+	require.Equal(t, DirectionOut, e.Direction)
+}
+
+func TestBuildGraph_NoPolicy_NoEdge(t *testing.T) {
+	acc := twoPeerAccount(false, true) // policy disabled
+	validated := map[string]struct{}{"pA": {}, "pB": {}}
+
+	g, err := BuildGraph(context.Background(), acc, Focus{Type: FocusPeer, ID: "pA"}, validated)
+	require.NoError(t, err)
+	require.Empty(t, g.Edges)
+	// only the focus node; no reachable peer => no peer node.
+	require.Equal(t, []Node{{ID: "pA", Kind: NodeFocus, Label: "alice"}}, g.Nodes)
+}
+
+func TestBuildGraph_UnknownFocusPeer(t *testing.T) {
+	acc := twoPeerAccount(true, true)
+	_, err := BuildGraph(context.Background(), acc, Focus{Type: FocusPeer, ID: "ghost"}, nil)
+	require.Error(t, err)
+}

--- a/management/server/controlcenter/contract_test.go
+++ b/management/server/controlcenter/contract_test.go
@@ -1,0 +1,67 @@
+package controlcenter
+
+import (
+	"encoding/json"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// C8: the GraphDTO wire shape is the contract the Phase 2 dashboard
+// codes against. This codebase deliberately omits admin endpoints
+// from openapi.yml (flow_exports / network_events / events are all
+// registered in code but absent from the spec + its generated
+// types.gen.go), so — consistent with that precedent and to avoid
+// regenerating a 2140-line generated file — the Control Center
+// endpoint is likewise spec-omitted and its contract is pinned HERE.
+//
+// Renaming or dropping a JSON field, or changing omitempty on the
+// optional policy/route fields, breaks this test loudly. Keep it in
+// lockstep with docs/adr/0017 and the dashboard client.
+func keysOf(t *testing.T, v any) []string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	var m map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(b, &m))
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	sort.Strings(ks)
+	return ks
+}
+
+func TestWireContract_GraphDTO(t *testing.T) {
+	require.Equal(t, []string{"edges", "focus", "nodes"},
+		keysOf(t, GraphDTO{}))
+
+	require.Equal(t, []string{"id", "type"},
+		keysOf(t, Focus{Type: FocusPeer, ID: "p1"}))
+
+	// Node: meta is omitempty (absent when nil).
+	require.Equal(t, []string{"id", "kind", "label"},
+		keysOf(t, Node{ID: "p1", Kind: NodeFocus, Label: "a"}))
+	require.Equal(t, []string{"id", "kind", "label", "meta"},
+		keysOf(t, Node{ID: "p1", Kind: NodeFocus, Label: "a", Meta: map[string]string{"k": "v"}}))
+
+	// Edge: a route_default_permit edge must NOT carry policy chip
+	// fields and may omit ports/sourceRanges/meta.
+	require.Equal(t, []string{"direction", "from", "permitSource", "protocol", "state", "to"},
+		keysOf(t, Edge{
+			From: "f", To: "t", PermitSource: PermitRouteDefault,
+			Protocol: "all", Direction: DirectionOut, State: EdgeEnforced,
+		}))
+
+	// Edge: a fully-populated policy edge carries the full field set.
+	require.Equal(t,
+		[]string{"direction", "from", "meta", "permitSource", "policyId", "policyName", "ports", "protocol", "sourceRanges", "state", "to"},
+		keysOf(t, Edge{
+			From: "f", To: "t", PermitSource: PermitPolicy,
+			PolicyID: "pol1", PolicyName: "p", Protocol: "tcp",
+			Ports: []string{"22"}, SourceRanges: []string{"0.0.0.0/0"},
+			Direction: DirectionBidirectional, State: EdgePostureBlocked,
+			Meta: map[string]string{"postureCheck": "min-nb"},
+		}))
+}

--- a/management/server/controlcenter/graph.go
+++ b/management/server/controlcenter/graph.go
@@ -1,0 +1,103 @@
+// Package controlcenter builds the read-only access-graph DTO that
+// answers, for a focus node, what it reaches right now, through which
+// policy (or route default-permit), on which protocols/ports, and what
+// is policy-permitted but posture-blocked.
+//
+// Clean-room (BSD-3 tree, openZro): every type and the adapter logic
+// here are designed against openZro's own enforcement engine
+// (Account.GetPeerConnectionResources / GetRoutesToSync /
+// GetPeerRoutesFirewallRules) and the decisions recorded in
+// docs/adr/0017-control-center-access-graph.md. No upstream NetBird
+// management/ code was consulted or ported.
+package controlcenter
+
+// FocusType is the kind of node the graph is centred on. v1 ships peer
+// and group focus; network/user focus are an ADR-0017 v2 follow-up.
+type FocusType string
+
+const (
+	FocusPeer  FocusType = "peer"
+	FocusGroup FocusType = "group"
+)
+
+// Focus identifies the node the graph is built around.
+type Focus struct {
+	Type FocusType `json:"type"`
+	ID   string    `json:"id"`
+}
+
+// NodeKind tags a graph node. focus is the centred node; the rest are
+// what it relates to.
+type NodeKind string
+
+const (
+	NodeFocus           NodeKind = "focus"
+	NodePolicy          NodeKind = "policy"
+	NodeGroup           NodeKind = "group"
+	NodePeer            NodeKind = "peer"
+	NodeRoute           NodeKind = "route"
+	NodeNetworkResource NodeKind = "network_resource"
+)
+
+// EdgeState distinguishes enforced reach from reach a policy permits
+// but posture blocks (ADR-0017 D1.2). It is never collapsed into
+// "no edge" — the absence of an edge means "no policy", which is a
+// different audit answer.
+type EdgeState string
+
+const (
+	EdgeEnforced       EdgeState = "enforced"
+	EdgePostureBlocked EdgeState = "posture_blocked"
+)
+
+// PermitSource records why an edge is permitted. Not every route edge
+// is backed by an editable policy: a route with no AccessControlGroups
+// falls to a route default-permit, which has no PolicyID (ADR-0017
+// D1.1 / Point 3).
+type PermitSource string
+
+const (
+	PermitPolicy       PermitSource = "policy"
+	PermitRouteDefault PermitSource = "route_default_permit"
+)
+
+// EdgeDirection is the traffic direction the permitting rule grants.
+type EdgeDirection string
+
+const (
+	DirectionIn            EdgeDirection = "in"
+	DirectionOut           EdgeDirection = "out"
+	DirectionBidirectional EdgeDirection = "bidirectional"
+)
+
+// Node is one vertex of the access graph.
+type Node struct {
+	ID    string            `json:"id"`
+	Kind  NodeKind          `json:"kind"`
+	Label string            `json:"label"`
+	Meta  map[string]string `json:"meta,omitempty"`
+}
+
+// Edge is a permitted (or posture-blocked) reach relation. Ports and
+// SourceRanges are string slices so port ranges and CIDRs round-trip
+// without lossy flattening (ADR-0017 minimum envelope).
+type Edge struct {
+	From         string            `json:"from"`
+	To           string            `json:"to"`
+	PermitSource PermitSource      `json:"permitSource"`
+	PolicyID     string            `json:"policyId,omitempty"`
+	PolicyName   string            `json:"policyName,omitempty"`
+	Protocol     string            `json:"protocol"`
+	Ports        []string          `json:"ports,omitempty"`
+	SourceRanges []string          `json:"sourceRanges,omitempty"`
+	Direction    EdgeDirection     `json:"direction"`
+	State        EdgeState         `json:"state"`
+	Meta         map[string]string `json:"meta,omitempty"`
+}
+
+// GraphDTO is the read-only access-graph response for one focus node.
+type GraphDTO struct {
+	Focus Focus  `json:"focus"`
+	Nodes []Node `json:"nodes"`
+	Edges []Edge `json:"edges"`
+}

--- a/management/server/controlcenter/graph.go
+++ b/management/server/controlcenter/graph.go
@@ -11,6 +11,19 @@
 // management/ code was consulted or ported.
 package controlcenter
 
+import "errors"
+
+// Typed errors so the HTTP layer can map precisely instead of
+// treating every non-status error as 404 (#50 Finding 5). Wrap with
+// %w and check with errors.Is.
+var (
+	// ErrFocusNotFound — the requested focus peer/group does not
+	// exist in the account (→ 404).
+	ErrFocusNotFound = errors.New("focus not found")
+	// ErrUnsupportedFocus — the view is not peer/group (→ 400).
+	ErrUnsupportedFocus = errors.New("unsupported focus type")
+)
+
 // FocusType is the kind of node the graph is centred on. v1 ships peer
 // and group focus; network/user focus are an ADR-0017 v2 follow-up.
 type FocusType string

--- a/management/server/controlcenter/graph.go
+++ b/management/server/controlcenter/graph.go
@@ -72,6 +72,13 @@ type PermitSource string
 const (
 	PermitPolicy       PermitSource = "policy"
 	PermitRouteDefault PermitSource = "route_default_permit"
+	// PermitRouterLocal — the focus IS the router serving this route,
+	// so it reaches the routed network as its own gateway. This is
+	// NOT route_default_permit (the route may carry
+	// AccessControlGroups that gate OTHER clients); it is honestly
+	// labelled as infrastructure-local reach (#50-r2 semantic note,
+	// owner-decided 2026-05-17).
+	PermitRouterLocal PermitSource = "router_local"
 )
 
 // EdgeDirection is the traffic direction the permitting rule grants.

--- a/management/server/controlcenter/graph_test.go
+++ b/management/server/controlcenter/graph_test.go
@@ -1,0 +1,76 @@
+package controlcenter
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// C1: the DTO envelope is the contract Phase 2 (dashboard) and the
+// HTTP layer depend on. Pin the enum wire values and the omitempty
+// behaviour so a later refactor can't silently change the JSON shape.
+
+func TestEnumWireValues(t *testing.T) {
+	cases := []struct {
+		got  string
+		want string
+	}{
+		{string(FocusPeer), "peer"},
+		{string(FocusGroup), "group"},
+		{string(NodeFocus), "focus"},
+		{string(NodePolicy), "policy"},
+		{string(NodeGroup), "group"},
+		{string(NodePeer), "peer"},
+		{string(NodeRoute), "route"},
+		{string(NodeNetworkResource), "network_resource"},
+		{string(EdgeEnforced), "enforced"},
+		{string(EdgePostureBlocked), "posture_blocked"},
+		{string(PermitPolicy), "policy"},
+		{string(PermitRouteDefault), "route_default_permit"},
+		{string(DirectionIn), "in"},
+		{string(DirectionOut), "out"},
+		{string(DirectionBidirectional), "bidirectional"},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("enum wire value = %q, want %q", c.got, c.want)
+		}
+	}
+}
+
+func TestGraphDTO_JSONRoundTrip(t *testing.T) {
+	in := GraphDTO{
+		Focus: Focus{Type: FocusPeer, ID: "peer-1"},
+		Nodes: []Node{
+			{ID: "peer-1", Kind: NodeFocus, Label: "alice"},
+			{ID: "peer-2", Kind: NodePeer, Label: "bob", Meta: map[string]string{"reachedBy": "3 of 5 members"}},
+		},
+		Edges: []Edge{
+			{
+				From: "peer-1", To: "peer-2",
+				PermitSource: PermitPolicy,
+				PolicyID:     "pol-1", PolicyName: "allow-ssh",
+				Protocol: "tcp", Ports: []string{"22", "1000-2000"},
+				Direction: DirectionBidirectional, State: EdgeEnforced,
+			},
+			{
+				From: "peer-1", To: "route-1",
+				PermitSource: PermitRouteDefault,
+				Protocol:     "all", SourceRanges: []string{"0.0.0.0/0"},
+				Direction: DirectionIn, State: EdgeEnforced,
+			},
+		},
+	}
+
+	b, err := json.Marshal(in)
+	require.NoError(t, err)
+
+	// route_default_permit edge must not emit a policy chip.
+	require.NotContains(t, string(b), `"policyId":""`)
+	require.NotContains(t, string(b), `"policyName":""`)
+
+	var out GraphDTO
+	require.NoError(t, json.Unmarshal(b, &out))
+	require.Equal(t, in, out)
+}

--- a/management/server/controlcenter/graph_test.go
+++ b/management/server/controlcenter/graph_test.go
@@ -28,6 +28,7 @@ func TestEnumWireValues(t *testing.T) {
 		{string(EdgePostureBlocked), "posture_blocked"},
 		{string(PermitPolicy), "policy"},
 		{string(PermitRouteDefault), "route_default_permit"},
+		{string(PermitRouterLocal), "router_local"},
 		{string(DirectionIn), "in"},
 		{string(DirectionOut), "out"},
 		{string(DirectionBidirectional), "bidirectional"},

--- a/management/server/controlcenter/group.go
+++ b/management/server/controlcenter/group.go
@@ -79,7 +79,14 @@ func buildGroupFocus(ctx context.Context, acc *types.Account, focus Focus, valid
 			if e.State == EdgePostureBlocked {
 				denialSig = e.Meta["postureCheckId"] + "/" + e.Meta["postureCheckType"]
 			}
-			key := e.To + "|" + e.PolicyID + "|" + e.Protocol + "|" + string(e.State) + "|" + denialSig
+			// PermitSource is part of the key: router_local and
+			// route_default_permit both have an empty PolicyID, so a
+			// group holding a router AND a client over the same
+			// default-permit route would otherwise collapse into one
+			// edge and lose the router_local/route_default distinction
+			// (#50-r3).
+			key := e.To + "|" + string(e.PermitSource) + "|" + e.PolicyID + "|" +
+				e.Protocol + "|" + string(e.State) + "|" + denialSig
 			a := aggs[key]
 			if a == nil {
 				ne := e

--- a/management/server/controlcenter/group.go
+++ b/management/server/controlcenter/group.go
@@ -59,7 +59,16 @@ func buildGroupFocus(ctx context.Context, acc *types.Account, focus Focus, valid
 		}
 
 		for _, e := range tmp.Edges {
-			key := e.To + "|" + e.PolicyID + "|" + e.Protocol + "|" + string(e.State)
+			// Posture-blocked edges are split by the failing-check
+			// signature so members blocked by DIFFERENT checks do not
+			// collapse into one edge with an arbitrary first member's
+			// reason (Finding 4 — per-member posture must survive
+			// aggregation).
+			denialSig := ""
+			if e.State == EdgePostureBlocked {
+				denialSig = e.Meta["postureCheckId"] + "/" + e.Meta["postureCheckType"]
+			}
+			key := e.To + "|" + e.PolicyID + "|" + e.Protocol + "|" + string(e.State) + "|" + denialSig
 			a := aggs[key]
 			if a == nil {
 				ne := e

--- a/management/server/controlcenter/group.go
+++ b/management/server/controlcenter/group.go
@@ -20,7 +20,7 @@ import (
 func buildGroupFocus(ctx context.Context, acc *types.Account, focus Focus, validatedPeers map[string]struct{}) (*GraphDTO, error) {
 	grp := acc.Groups[focus.ID]
 	if grp == nil {
-		return nil, fmt.Errorf("focus group %q not found", focus.ID)
+		return nil, fmt.Errorf("focus group %q: %w", focus.ID, ErrFocusNotFound)
 	}
 
 	g := &GraphDTO{Focus: focus}

--- a/management/server/controlcenter/group.go
+++ b/management/server/controlcenter/group.go
@@ -34,6 +34,11 @@ func buildGroupFocus(ctx context.Context, acc *types.Account, focus Focus, valid
 	aggs := map[string]*agg{}
 	toNodes := map[string]Node{}
 
+	// Route/nr firewall indices are account-invariant — build ONCE and
+	// share across every member instead of O(members × peers)
+	// recomputation (#50-r2 F3).
+	idx := newRouteIndex(ctx, acc, validatedPeers)
+
 	for _, mID := range grp.Peers {
 		m := acc.GetPeer(mID)
 		if m == nil {
@@ -50,7 +55,7 @@ func buildGroupFocus(ctx context.Context, acc *types.Account, focus Focus, valid
 		reach, fw := acc.GetPeerConnectionResources(ctx, m, validatedPeers)
 		tb.addPeerReach(acc, mID, reach, fw)
 		tb.addPostureBlocked(ctx, acc, mID, validatedPeers)
-		tb.addRouteReach(ctx, acc, mID, reach, validatedPeers)
+		tb.addRouteReach(ctx, acc, mID, reach, validatedPeers, idx)
 		tb.finalize()
 
 		for _, nd := range tmp.Nodes {

--- a/management/server/controlcenter/group.go
+++ b/management/server/controlcenter/group.go
@@ -1,0 +1,106 @@
+package controlcenter
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/openzro/openzro/management/server/types"
+)
+
+// buildGroupFocus is ADR-0017 D3 group focus: the UNION of each
+// member's per-member reach (never the intersection — that would hide
+// access some members have, the wrong answer for an audit tool). Each
+// aggregated edge is tagged "k of n members" and posture is evaluated
+// per member, so a posture-blocked member yields a distinct
+// posture_blocked aggregate edge instead of being dropped.
+//
+// Clean-room (BSD-3): reuses the per-peer passes (C2–C4) member by
+// member; no upstream NetBird code.
+func buildGroupFocus(ctx context.Context, acc *types.Account, focus Focus, validatedPeers map[string]struct{}) (*GraphDTO, error) {
+	grp := acc.Groups[focus.ID]
+	if grp == nil {
+		return nil, fmt.Errorf("focus group %q not found", focus.ID)
+	}
+
+	g := &GraphDTO{Focus: focus}
+	groupNodeID := "group:" + focus.ID
+	n := len(grp.Peers)
+
+	type agg struct {
+		edge    Edge
+		members map[string]struct{}
+	}
+	aggs := map[string]*agg{}
+	toNodes := map[string]Node{}
+
+	for _, mID := range grp.Peers {
+		m := acc.GetPeer(mID)
+		if m == nil {
+			continue
+		}
+		tmp := &GraphDTO{}
+		tb := newGraphBuilder(tmp)
+		reach, fw := acc.GetPeerConnectionResources(ctx, m, validatedPeers)
+		tb.addPeerReach(acc, mID, reach, fw)
+		tb.addPostureBlocked(ctx, acc, mID, validatedPeers)
+		tb.addRouteReach(ctx, acc, mID, reach, validatedPeers)
+		tb.finalize()
+
+		for _, nd := range tmp.Nodes {
+			if nd.ID == mID {
+				continue // the member's own focus node — not a target
+			}
+			kind := nd.Kind
+			if kind == NodeFocus {
+				kind = NodePeer
+			}
+			toNodes[nd.ID] = Node{ID: nd.ID, Kind: kind, Label: nd.Label}
+		}
+
+		for _, e := range tmp.Edges {
+			key := e.To + "|" + e.PolicyID + "|" + e.Protocol + "|" + string(e.State)
+			a := aggs[key]
+			if a == nil {
+				ne := e
+				ne.From = groupNodeID
+				a = &agg{edge: ne, members: map[string]struct{}{}}
+				aggs[key] = a
+			}
+			a.members[mID] = struct{}{}
+			mergeDirectionValue(&a.edge, e.Direction)
+			for _, p := range e.Ports {
+				if !contains(a.edge.Ports, p) {
+					a.edge.Ports = append(a.edge.Ports, p)
+				}
+			}
+		}
+	}
+
+	g.Nodes = append(g.Nodes, Node{ID: groupNodeID, Kind: NodeFocus, Label: grp.Name})
+	for _, nd := range toNodes {
+		g.Nodes = append(g.Nodes, nd)
+	}
+	sort.Slice(g.Nodes, func(i, j int) bool { return g.Nodes[i].ID < g.Nodes[j].ID })
+
+	for _, a := range aggs {
+		e := a.edge
+		sort.Strings(e.Ports)
+		if e.Meta == nil {
+			e.Meta = map[string]string{}
+		}
+		e.Meta["reachedBy"] = fmt.Sprintf("%d of %d members", len(a.members), n)
+		g.Edges = append(g.Edges, e)
+	}
+	sort.Slice(g.Edges, func(i, j int) bool {
+		x, y := g.Edges[i], g.Edges[j]
+		if x.To != y.To {
+			return x.To < y.To
+		}
+		if x.PolicyID != y.PolicyID {
+			return x.PolicyID < y.PolicyID
+		}
+		return x.State < y.State
+	})
+	return g, nil
+}

--- a/management/server/controlcenter/group.go
+++ b/management/server/controlcenter/group.go
@@ -113,14 +113,7 @@ func buildGroupFocus(ctx context.Context, acc *types.Account, focus Focus, valid
 		g.Edges = append(g.Edges, e)
 	}
 	sort.Slice(g.Edges, func(i, j int) bool {
-		x, y := g.Edges[i], g.Edges[j]
-		if x.To != y.To {
-			return x.To < y.To
-		}
-		if x.PolicyID != y.PolicyID {
-			return x.PolicyID < y.PolicyID
-		}
-		return x.State < y.State
+		return edgeLess(g.Edges[i], g.Edges[j])
 	})
 	return g, nil
 }

--- a/management/server/controlcenter/group.go
+++ b/management/server/controlcenter/group.go
@@ -39,6 +39,12 @@ func buildGroupFocus(ctx context.Context, acc *types.Account, focus Focus, valid
 		if m == nil {
 			continue
 		}
+		// An unvalidated member reaches nothing in the dataplane
+		// (#50-r2 F1); it contributes zero reach but still counts in
+		// the "k of n" denominator (n = declared membership).
+		if _, ok := validatedPeers[mID]; !ok {
+			continue
+		}
 		tmp := &GraphDTO{}
 		tb := newGraphBuilder(tmp)
 		reach, fw := acc.GetPeerConnectionResources(ctx, m, validatedPeers)

--- a/management/server/controlcenter/group_test.go
+++ b/management/server/controlcenter/group_test.go
@@ -1,0 +1,105 @@
+package controlcenter
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	nbpeer "github.com/openzro/openzro/management/server/peer"
+	"github.com/openzro/openzro/management/server/posture"
+	"github.com/openzro/openzro/management/server/types"
+)
+
+// C5 / ADR-0017 D3: group focus is the UNION of per-member reach
+// (never the intersection — that would hide real access), each
+// aggregated edge tagged "k of n members", posture evaluated per
+// member so a posture-blocked member contributes a distinct
+// posture_blocked edge instead of being dropped from the union.
+
+func groupFocusAccount(pBVersion string) *types.Account {
+	mkPeer := func(id string, last byte, ver string) *nbpeer.Peer {
+		return &nbpeer.Peer{ID: id, IP: net.IP{10, 0, 0, last}, Name: id,
+			Meta: nbpeer.PeerSystemMeta{WtVersion: ver}}
+	}
+	return &types.Account{
+		Id: "acc1",
+		Peers: map[string]*nbpeer.Peer{
+			"pA": mkPeer("pA", 1, "99.0.0"),
+			"pB": mkPeer("pB", 2, pBVersion),
+			"pC": mkPeer("pC", 3, "99.0.0"),
+			"pX": mkPeer("pX", 9, "99.0.0"),
+		},
+		Groups: map[string]*types.Group{
+			"all":  {ID: "all", Name: "All", Peers: []string{"pA", "pB", "pC", "pX"}},
+			"team": {ID: "team", Name: "team", Peers: []string{"pA", "pB", "pC"}},
+			"gX":   {ID: "gX", Name: "gX", Peers: []string{"pX"}},
+		},
+		PostureChecks: []*posture.Checks{
+			{ID: "pc1", Name: "min-nb", Checks: posture.ChecksDefinition{
+				NBVersionCheck: &posture.NBVersionCheck{MinVersion: "99.0.0"}}},
+		},
+		Policies: []*types.Policy{
+			{
+				ID: "P", Name: "team-to-x", Enabled: true,
+				SourcePostureChecks: []string{"pc1"},
+				Rules: []*types.PolicyRule{{
+					ID: "r", Enabled: true, Action: types.PolicyTrafficActionAccept,
+					Sources: []string{"team"}, Destinations: []string{"gX"},
+					Protocol: types.PolicyRuleProtocolTCP, Ports: []string{"443"},
+				}},
+			},
+		},
+	}
+}
+
+func edgesByState(g *GraphDTO, to string) map[EdgeState]Edge {
+	m := map[EdgeState]Edge{}
+	for _, e := range g.Edges {
+		if e.To == to {
+			m[e.State] = e
+		}
+	}
+	return m
+}
+
+func TestBuildGraph_GroupFocus_UnionAllCompliant(t *testing.T) {
+	acc := groupFocusAccount("99.0.0") // pB passes too
+	validated := map[string]struct{}{"pA": {}, "pB": {}, "pC": {}, "pX": {}}
+
+	g, err := BuildGraph(context.Background(), acc, Focus{Type: FocusGroup, ID: "team"}, validated)
+	require.NoError(t, err)
+	require.Equal(t, Focus{Type: FocusGroup, ID: "team"}, g.Focus)
+	require.Contains(t, g.Nodes, Node{ID: "group:team", Kind: NodeFocus, Label: "team"})
+
+	es := edgesByState(g, "pX")
+	e, ok := es[EdgeEnforced]
+	require.True(t, ok, "all 3 members reach pX")
+	require.Equal(t, "group:team", e.From)
+	require.Equal(t, "3 of 3 members", e.Meta["reachedBy"])
+}
+
+func TestBuildGraph_GroupFocus_PostureSplitsUnion(t *testing.T) {
+	acc := groupFocusAccount("1.0.0") // pB fails the posture check
+	validated := map[string]struct{}{"pA": {}, "pB": {}, "pC": {}, "pX": {}}
+
+	g, err := BuildGraph(context.Background(), acc, Focus{Type: FocusGroup, ID: "team"}, validated)
+	require.NoError(t, err)
+
+	es := edgesByState(g, "pX")
+	enf, ok := es[EdgeEnforced]
+	require.True(t, ok)
+	require.Equal(t, "2 of 3 members", enf.Meta["reachedBy"])
+
+	blk, ok := es[EdgePostureBlocked]
+	require.True(t, ok, "posture-blocked member contributes a distinct edge, not dropped")
+	require.Equal(t, "1 of 3 members", blk.Meta["reachedBy"])
+	require.Equal(t, "min-nb", blk.Meta["postureCheck"])
+}
+
+func TestBuildGraph_UnknownFocusGroup(t *testing.T) {
+	acc := groupFocusAccount("99.0.0")
+	_, err := BuildGraph(context.Background(), acc, Focus{Type: FocusGroup, ID: "ghost"}, nil)
+	require.Error(t, err)
+}

--- a/management/server/controlcenter/group_test.go
+++ b/management/server/controlcenter/group_test.go
@@ -2,6 +2,7 @@ package controlcenter
 
 import (
 	"context"
+	"encoding/json"
 	"net"
 	"testing"
 
@@ -192,4 +193,23 @@ func TestBuildGraph_GroupFocus_UnvalidatedMemberCountsInDenominator(t *testing.T
 	require.True(t, ok)
 	require.Equal(t, "2 of 3 members", e.Meta["reachedBy"],
 		"unvalidated member excluded from k, still in n")
+}
+
+// #50-r2 F4: the DTO must be byte-stable across builds even when
+// multiple posture causes produce edges that tie on to/policy/state.
+func TestBuildGraph_GroupFocus_DeterministicOrdering(t *testing.T) {
+	validated := map[string]struct{}{"pA": {}, "pB": {}, "pC": {}, "pX": {}}
+	var first string
+	for i := 0; i < 12; i++ {
+		acc := twoCheckGroupAccount()
+		g, err := BuildGraph(context.Background(), acc, Focus{Type: FocusGroup, ID: "team"}, validated)
+		require.NoError(t, err)
+		j, err := json.Marshal(g)
+		require.NoError(t, err)
+		if i == 0 {
+			first = string(j)
+			continue
+		}
+		require.Equal(t, first, string(j), "DTO must be deterministic across builds")
+	}
 }

--- a/management/server/controlcenter/group_test.go
+++ b/management/server/controlcenter/group_test.go
@@ -178,3 +178,18 @@ func TestBuildGraph_GroupFocus_DistinctPostureCausesDoNotCollapse(t *testing.T) 
 	}
 	require.Equal(t, 1, enforced)
 }
+
+// #50-r2 F1: an unvalidated group member contributes zero reach but
+// still counts in the "k of n" denominator.
+func TestBuildGraph_GroupFocus_UnvalidatedMemberCountsInDenominator(t *testing.T) {
+	acc := groupFocusAccount("99.0.0")                             // all compliant
+	validated := map[string]struct{}{"pA": {}, "pC": {}, "pX": {}} // pB NOT validated
+
+	g, err := BuildGraph(context.Background(), acc, Focus{Type: FocusGroup, ID: "team"}, validated)
+	require.NoError(t, err)
+	es := edgesByState(g, "pX")
+	e, ok := es[EdgeEnforced]
+	require.True(t, ok)
+	require.Equal(t, "2 of 3 members", e.Meta["reachedBy"],
+		"unvalidated member excluded from k, still in n")
+}

--- a/management/server/controlcenter/group_test.go
+++ b/management/server/controlcenter/group_test.go
@@ -103,3 +103,78 @@ func TestBuildGraph_UnknownFocusGroup(t *testing.T) {
 	_, err := BuildGraph(context.Background(), acc, Focus{Type: FocusGroup, ID: "ghost"}, nil)
 	require.Error(t, err)
 }
+
+// Finding 4: two members blocked by DIFFERENT posture checks for the
+// same target/policy/protocol must NOT collapse into one aggregated
+// edge with an arbitrary member's reason.
+func twoCheckGroupAccount() *types.Account {
+	mk := func(id string, last byte, ver string) *nbpeer.Peer {
+		return &nbpeer.Peer{ID: id, IP: net.IP{10, 0, 0, last}, Name: id,
+			Meta: nbpeer.PeerSystemMeta{WtVersion: ver}}
+	}
+	return &types.Account{
+		Id: "acc1",
+		Peers: map[string]*nbpeer.Peer{
+			"pA": mk("pA", 1, "10.0.0"), // fails pcA (min 20)
+			"pB": mk("pB", 2, "30.0.0"), // passes pcA, fails pcB (min 40)
+			"pC": mk("pC", 3, "99.0.0"), // passes both -> enforced
+			"pX": mk("pX", 9, "99.0.0"),
+		},
+		Groups: map[string]*types.Group{
+			"all":  {ID: "all", Name: "All", Peers: []string{"pA", "pB", "pC", "pX"}},
+			"team": {ID: "team", Name: "team", Peers: []string{"pA", "pB", "pC"}},
+			"gX":   {ID: "gX", Name: "gX", Peers: []string{"pX"}},
+		},
+		PostureChecks: []*posture.Checks{
+			{ID: "pcA", Name: "min-20", Checks: posture.ChecksDefinition{
+				NBVersionCheck: &posture.NBVersionCheck{MinVersion: "20.0.0"}}},
+			{ID: "pcB", Name: "min-40", Checks: posture.ChecksDefinition{
+				NBVersionCheck: &posture.NBVersionCheck{MinVersion: "40.0.0"}}},
+		},
+		Policies: []*types.Policy{
+			{
+				ID: "P", Name: "team-to-x", Enabled: true,
+				SourcePostureChecks: []string{"pcA", "pcB"},
+				Rules: []*types.PolicyRule{{
+					ID: "r", Enabled: true, Action: types.PolicyTrafficActionAccept,
+					Sources: []string{"team"}, Destinations: []string{"gX"},
+					Protocol: types.PolicyRuleProtocolTCP, Ports: []string{"443"},
+				}},
+			},
+		},
+	}
+}
+
+func TestBuildGraph_GroupFocus_DistinctPostureCausesDoNotCollapse(t *testing.T) {
+	acc := twoCheckGroupAccount()
+	validated := map[string]struct{}{"pA": {}, "pB": {}, "pC": {}, "pX": {}}
+
+	g, err := BuildGraph(context.Background(), acc, Focus{Type: FocusGroup, ID: "team"}, validated)
+	require.NoError(t, err)
+
+	var blocked []Edge
+	for _, e := range g.Edges {
+		if e.To == "pX" && e.State == EdgePostureBlocked {
+			blocked = append(blocked, e)
+		}
+	}
+	require.Len(t, blocked, 2, "different posture checks must yield distinct edges")
+
+	byCheck := map[string]Edge{}
+	for _, e := range blocked {
+		byCheck[e.Meta["postureCheckId"]] = e
+	}
+	require.Contains(t, byCheck, "pcA")
+	require.Contains(t, byCheck, "pcB")
+	require.Equal(t, "1 of 3 members", byCheck["pcA"].Meta["reachedBy"])
+	require.Equal(t, "1 of 3 members", byCheck["pcB"].Meta["reachedBy"])
+
+	// pC (compliant) still produces a distinct enforced edge.
+	var enforced int
+	for _, e := range g.Edges {
+		if e.To == "pX" && e.State == EdgeEnforced {
+			enforced++
+		}
+	}
+	require.Equal(t, 1, enforced)
+}

--- a/management/server/controlcenter/nr_test.go
+++ b/management/server/controlcenter/nr_test.go
@@ -132,3 +132,29 @@ func TestBuildGraph_NetworkResource_PostureBlocked(t *testing.T) {
 	require.Equal(t, "policyC", e.PolicyID)
 	require.Equal(t, "min-nb", e.Meta["postureCheck"])
 }
+
+// #50-r2 F2: a network resource is ONE logical target. With HA
+// routers the graph must produce a single deterministic
+// "nr:<resourceID>" node, not one per router instance.
+func TestBuildGraph_NetworkResource_HA_SingleLogicalNode(t *testing.T) {
+	acc := nrAccount(true, false)
+	// add a second HA router peer + router for the SAME resource/network.
+	acc.Peers["pR2"] = &nbpeer.Peer{ID: "pR2", IP: net.IP{10, 0, 0, 8}, Key: "kR2", Name: "router2"}
+	acc.Groups["all"].Peers = append(acc.Groups["all"].Peers, "pR2")
+	acc.NetworkRouters = append(acc.NetworkRouters, &routerTypes.NetworkRouter{
+		ID: "rt2", NetworkID: "net1", AccountID: "acc1", Peer: "pR2", Enabled: true, Metric: 100,
+	})
+	validated := map[string]struct{}{"pA": {}, "pR": {}, "pR2": {}}
+
+	g, err := BuildGraph(context.Background(), acc, Focus{Type: FocusPeer, ID: "pA"}, validated)
+	require.NoError(t, err)
+
+	var nrNodes []Node
+	for _, n := range g.Nodes {
+		if n.Kind == NodeNetworkResource {
+			nrNodes = append(nrNodes, n)
+		}
+	}
+	require.Len(t, nrNodes, 1, "HA routers must collapse to one logical resource node")
+	require.Equal(t, "nr:res1", nrNodes[0].ID)
+}

--- a/management/server/controlcenter/nr_test.go
+++ b/management/server/controlcenter/nr_test.go
@@ -1,0 +1,134 @@
+package controlcenter
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	resourceTypes "github.com/openzro/openzro/management/server/networks/resources/types"
+	routerTypes "github.com/openzro/openzro/management/server/networks/routers/types"
+	networkTypes "github.com/openzro/openzro/management/server/networks/types"
+	nbpeer "github.com/openzro/openzro/management/server/peer"
+	"github.com/openzro/openzro/management/server/posture"
+	"github.com/openzro/openzro/management/server/types"
+)
+
+// C* / Finding 1: network-resource reach must come from the engine's
+// real GetPeerNetworkResourceFirewallRules — the permitting policy,
+// protocol and port are the rule's, never an arbitrary pols[0]. A
+// resource the focus is excluded from only by posture surfaces as a
+// distinct posture_blocked edge.
+
+func nrAccount(includePolicyB bool, postureFails bool) *types.Account {
+	pA := &nbpeer.Peer{ID: "pA", IP: net.IP{10, 0, 0, 1}, Key: "kA", Name: "alice",
+		Meta: nbpeer.PeerSystemMeta{WtVersion: "99.0.0"}}
+	if postureFails {
+		pA.Meta.WtVersion = "1.0.0"
+	}
+	pR := &nbpeer.Peer{ID: "pR", IP: net.IP{10, 0, 0, 9}, Key: "kR", Name: "router"}
+
+	policies := []*types.Policy{
+		{ // policyA: source group gA — does NOT contain the focus.
+			ID: "policyA", Enabled: true,
+			Rules: []*types.PolicyRule{{
+				ID: "rA", PolicyID: "policyA", Enabled: true,
+				Sources:             []string{"gA"},
+				DestinationResource: types.Resource{ID: "res1", Type: "Host"},
+				Protocol:            types.PolicyRuleProtocolTCP, Ports: []string{"22"},
+				Action: types.PolicyTrafficActionAccept,
+			}},
+		},
+	}
+	if includePolicyB {
+		policies = append(policies, &types.Policy{ // focus permitted ONLY here
+			ID: "policyB", Enabled: true,
+			Rules: []*types.PolicyRule{{
+				ID: "rB", PolicyID: "policyB", Enabled: true,
+				Sources:             []string{"gB"},
+				DestinationResource: types.Resource{ID: "res1", Type: "Host"},
+				Protocol:            types.PolicyRuleProtocolTCP, Ports: []string{"443"},
+				Action: types.PolicyTrafficActionAccept,
+			}},
+		})
+	} else {
+		policies = append(policies, &types.Policy{ // posture-gated only
+			ID: "policyC", Enabled: true,
+			SourcePostureChecks: []string{"pc1"},
+			Rules: []*types.PolicyRule{{
+				ID: "rC", PolicyID: "policyC", Enabled: true,
+				Sources:             []string{"gB"},
+				DestinationResource: types.Resource{ID: "res1", Type: "Host"},
+				Protocol:            types.PolicyRuleProtocolTCP, Ports: []string{"8443"},
+				Action: types.PolicyTrafficActionAccept,
+			}},
+		})
+	}
+
+	return &types.Account{
+		Id:    "acc1",
+		Peers: map[string]*nbpeer.Peer{"pA": pA, "pR": pR},
+		Groups: map[string]*types.Group{
+			"all": {ID: "all", Name: "All", Peers: []string{"pA", "pR"}},
+			"gA":  {ID: "gA", Name: "gA", Peers: []string{}},
+			"gB":  {ID: "gB", Name: "gB", Peers: []string{"pA"}},
+		},
+		Networks: []*networkTypes.Network{
+			{ID: "net1", AccountID: "acc1", Name: "net1"},
+		},
+		NetworkRouters: []*routerTypes.NetworkRouter{
+			{ID: "rt1", NetworkID: "net1", AccountID: "acc1", Peer: "pR", Enabled: true, Metric: 100},
+		},
+		NetworkResources: []*resourceTypes.NetworkResource{
+			{ID: "res1", AccountID: "acc1", NetworkID: "net1",
+				Address: "10.50.0.0/24", Prefix: netip.MustParsePrefix("10.50.0.0/24"),
+				Type: resourceTypes.NetworkResourceType("subnet"), Enabled: true},
+		},
+		PostureChecks: []*posture.Checks{
+			{ID: "pc1", Name: "min-nb", Checks: posture.ChecksDefinition{
+				NBVersionCheck: &posture.NBVersionCheck{MinVersion: "99.0.0"}}},
+		},
+		Policies: policies,
+	}
+}
+
+func nrEdge(g *GraphDTO) *Edge {
+	for i := range g.Edges {
+		if len(g.Edges[i].To) >= 3 && g.Edges[i].To[:3] == "nr:" {
+			return &g.Edges[i]
+		}
+	}
+	return nil
+}
+
+func TestBuildGraph_NetworkResource_CorrectPolicyNotPolsZero(t *testing.T) {
+	acc := nrAccount(true, false) // policyA first, focus permitted only by policyB
+	validated := map[string]struct{}{"pA": {}, "pR": {}}
+
+	g, err := BuildGraph(context.Background(), acc, Focus{Type: FocusPeer, ID: "pA"}, validated)
+	require.NoError(t, err)
+
+	e := nrEdge(g)
+	require.NotNil(t, e, "focus is permitted on res1 via policyB")
+	require.Equal(t, PermitPolicy, e.PermitSource)
+	require.Equal(t, "policyB", e.PolicyID, "must be the permitting policy, NOT pols[0]=policyA")
+	require.Equal(t, EdgeEnforced, e.State)
+	require.Equal(t, []string{"443"}, e.Ports, "port from the real firewall rule, not hardcoded")
+	require.NotEmpty(t, e.SourceRanges)
+}
+
+func TestBuildGraph_NetworkResource_PostureBlocked(t *testing.T) {
+	acc := nrAccount(false, true) // only posture-gated policyC; focus fails posture
+	validated := map[string]struct{}{"pA": {}, "pR": {}}
+
+	g, err := BuildGraph(context.Background(), acc, Focus{Type: FocusPeer, ID: "pA"}, validated)
+	require.NoError(t, err)
+
+	e := nrEdge(g)
+	require.NotNil(t, e, "posture-blocked resource must still surface as an edge")
+	require.Equal(t, EdgePostureBlocked, e.State)
+	require.Equal(t, "policyC", e.PolicyID)
+	require.Equal(t, "min-nb", e.Meta["postureCheck"])
+}

--- a/management/server/controlcenter/posture.go
+++ b/management/server/controlcenter/posture.go
@@ -52,7 +52,7 @@ func (b *graphBuilder) addPostureBlocked(ctx context.Context, acc *types.Account
 			if _, ok := src[focusID]; ok {
 				if d := admissionDenial(ctx, acc, focusID, pol.SourcePostureChecks, postureMap); d != nil {
 					for other := range dst {
-						b.addBlockedEdge(acc, focusID, other, focusID, outDir, pol, r, validatedPeers, d)
+						b.addBlockedEdge(acc, focusID, other, outDir, pol, r, validatedPeers, d)
 					}
 				}
 			}
@@ -65,7 +65,7 @@ func (b *graphBuilder) addPostureBlocked(ctx context.Context, acc *types.Account
 						continue
 					}
 					if d := admissionDenial(ctx, acc, other, pol.SourcePostureChecks, postureMap); d != nil {
-						b.addBlockedEdge(acc, focusID, other, other, inDir, pol, r, validatedPeers, d)
+						b.addBlockedEdge(acc, focusID, other, inDir, pol, r, validatedPeers, d)
 					}
 				}
 			}
@@ -78,11 +78,20 @@ func (b *graphBuilder) addPostureBlocked(ctx context.Context, acc *types.Account
 // gated the same way the engine gates: the non-compliant endpoint must
 // still be a validated mesh peer (a non-validated peer is "not in the
 // mesh", not "posture-blocked"). Never downgrades an enforced edge.
-func (b *graphBuilder) addBlockedEdge(acc *types.Account, focusID, otherID, blockedPeerID string, dir EdgeDirection, pol *types.Policy, r *types.PolicyRule, validatedPeers map[string]struct{}, d *types.AdmissionDenial) {
+func (b *graphBuilder) addBlockedEdge(acc *types.Account, focusID, otherID string, dir EdgeDirection, pol *types.Policy, r *types.PolicyRule, validatedPeers map[string]struct{}, d *types.AdmissionDenial) {
 	if focusID == otherID {
 		return
 	}
-	if _, ok := validatedPeers[blockedPeerID]; !ok {
+	// The engine gates BOTH endpoints on validation
+	// (getAllPeersFromGroups + the GetPeerNetworkMap entry check). If
+	// either endpoint is unvalidated the pair is unreachable
+	// regardless of posture, so posture is NOT the sole remaining
+	// blocker and a posture_blocked edge here would be a lie
+	// (Finding 3).
+	if _, ok := validatedPeers[focusID]; !ok {
+		return
+	}
+	if _, ok := validatedPeers[otherID]; !ok {
 		return
 	}
 	if acc.GetPeer(focusID) == nil || acc.GetPeer(otherID) == nil {

--- a/management/server/controlcenter/posture.go
+++ b/management/server/controlcenter/posture.go
@@ -1,0 +1,166 @@
+package controlcenter
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/openzro/openzro/management/server/posture"
+	"github.com/openzro/openzro/management/server/types"
+)
+
+// addPostureBlocked is the ADR-0017 D1.2 explanatory pass. The
+// enforcement engine silently drops a source peer that fails posture
+// (getAllPeersFromGroups continues past it), so "no policy" and
+// "policy permits but posture blocks" are indistinguishable in the
+// enforced output. This pass re-walks the same enabled policies and
+// reuses the same posture evaluation (types.EvaluateAdmission — the
+// structured form that also NAMES the failing check) to emit a
+// distinct posture_blocked edge. It makes no access decisions; it
+// annotates the ones the engine already made (it never overwrites an
+// enforced edge for the same peer/policy).
+func (b *graphBuilder) addPostureBlocked(ctx context.Context, acc *types.Account, focusID string, validatedPeers map[string]struct{}) {
+	postureMap := map[string]*posture.Checks{}
+	for _, pc := range acc.PostureChecks {
+		if pc != nil {
+			postureMap[pc.ID] = pc
+		}
+	}
+	if len(postureMap) == 0 {
+		return
+	}
+
+	for _, pol := range acc.Policies {
+		if !pol.Enabled || len(pol.SourcePostureChecks) == 0 {
+			continue
+		}
+		for _, r := range pol.Rules {
+			if r == nil || !r.Enabled {
+				continue
+			}
+			src := groupMembers(acc, r.Sources)
+			dst := groupMembers(acc, r.Destinations)
+
+			outDir := DirectionOut
+			inDir := DirectionIn
+			if r.Bidirectional {
+				outDir, inDir = DirectionBidirectional, DirectionBidirectional
+			}
+
+			// focus is a source: it cannot reach the destinations it
+			// would otherwise reach because IT is non-compliant.
+			// Edge is focus-anchored (From=focus), traffic OUT.
+			if _, ok := src[focusID]; ok {
+				if d := admissionDenial(ctx, acc, focusID, pol.SourcePostureChecks, postureMap); d != nil {
+					for other := range dst {
+						b.addBlockedEdge(acc, focusID, other, focusID, outDir, pol, r, validatedPeers, d)
+					}
+				}
+			}
+			// focus is a destination: a source peer that would reach
+			// it is non-compliant. Edge is focus-anchored (From=focus),
+			// traffic IN.
+			if _, ok := dst[focusID]; ok {
+				for other := range src {
+					if other == focusID {
+						continue
+					}
+					if d := admissionDenial(ctx, acc, other, pol.SourcePostureChecks, postureMap); d != nil {
+						b.addBlockedEdge(acc, focusID, other, other, inDir, pol, r, validatedPeers, d)
+					}
+				}
+			}
+		}
+	}
+}
+
+// addBlockedEdge emits (or merges) a focus-anchored posture_blocked
+// edge (From=focus, To=other — same convention as the enforced pass),
+// gated the same way the engine gates: the non-compliant endpoint must
+// still be a validated mesh peer (a non-validated peer is "not in the
+// mesh", not "posture-blocked"). Never downgrades an enforced edge.
+func (b *graphBuilder) addBlockedEdge(acc *types.Account, focusID, otherID, blockedPeerID string, dir EdgeDirection, pol *types.Policy, r *types.PolicyRule, validatedPeers map[string]struct{}, d *types.AdmissionDenial) {
+	if focusID == otherID {
+		return
+	}
+	if _, ok := validatedPeers[blockedPeerID]; !ok {
+		return
+	}
+	if acc.GetPeer(focusID) == nil || acc.GetPeer(otherID) == nil {
+		return
+	}
+	if p := acc.GetPeer(otherID); p != nil {
+		b.addNode(p.ID, NodePeer, peerLabel(p))
+	}
+
+	from, to := focusID, otherID
+	key := from + "|" + to + "|" + pol.ID + "|" + string(r.Protocol)
+	if e, ok := b.edgeAgg[key]; ok {
+		if e.State == EdgeEnforced {
+			return // never downgrade an enforced edge
+		}
+		mergeDirectionValue(e, dir)
+		for _, port := range rulePorts(r) {
+			if !contains(e.Ports, port) {
+				e.Ports = append(e.Ports, port)
+			}
+		}
+		return
+	}
+	b.edgeAgg[key] = &Edge{
+		From: from, To: to,
+		PermitSource: PermitPolicy,
+		PolicyID:     pol.ID,
+		PolicyName:   pol.Name,
+		Protocol:     string(r.Protocol),
+		Ports:        rulePorts(r),
+		Direction:    dir,
+		State:        EdgePostureBlocked,
+		Meta: map[string]string{
+			"postureCheck":     d.PostureCheckName,
+			"postureCheckId":   d.PostureCheckID,
+			"postureCheckType": d.CheckType,
+			"postureReason":    d.Reason,
+		},
+	}
+}
+
+func admissionDenial(ctx context.Context, acc *types.Account, peerID string, ids []string, postureMap map[string]*posture.Checks) *types.AdmissionDenial {
+	p := acc.GetPeer(peerID)
+	if p == nil {
+		return nil
+	}
+	return types.EvaluateAdmission(ctx, p, ids, postureMap)
+}
+
+// groupMembers is the union of peer IDs across the given group IDs
+// (the engine's source/destination membership, posture aside).
+func groupMembers(acc *types.Account, groupIDs []string) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, gid := range groupIDs {
+		g := acc.Groups[gid]
+		if g == nil {
+			continue
+		}
+		for _, pid := range g.Peers {
+			out[pid] = struct{}{}
+		}
+	}
+	return out
+}
+
+func rulePorts(r *types.PolicyRule) []string {
+	ports := append([]string(nil), r.Ports...)
+	for _, pr := range r.PortRanges {
+		ports = append(ports, fmt.Sprintf("%d-%d", pr.Start, pr.End))
+	}
+	return ports
+}
+
+func mergeDirectionValue(e *Edge, d EdgeDirection) {
+	switch {
+	case e.Direction == "":
+		e.Direction = d
+	case e.Direction != d:
+		e.Direction = DirectionBidirectional
+	}
+}

--- a/management/server/controlcenter/posture_test.go
+++ b/management/server/controlcenter/posture_test.go
@@ -1,0 +1,102 @@
+package controlcenter
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	nbpeer "github.com/openzro/openzro/management/server/peer"
+	"github.com/openzro/openzro/management/server/posture"
+	"github.com/openzro/openzro/management/server/types"
+)
+
+// C3 / ADR-0017 D1.2: a policy-permitted pair the engine drops *only*
+// because of posture must surface as a distinct posture_blocked edge
+// (named by the failing check), never collapsed into "no edge".
+
+func postureAccount(focusWtVersion string) *types.Account {
+	pA := &nbpeer.Peer{ID: "pA", IP: net.IP{10, 0, 0, 1}, Name: "alice",
+		Meta: nbpeer.PeerSystemMeta{WtVersion: focusWtVersion}}
+	pB := &nbpeer.Peer{ID: "pB", IP: net.IP{10, 0, 0, 2}, Name: "bob",
+		Meta: nbpeer.PeerSystemMeta{WtVersion: "99.0.0"}}
+	return &types.Account{
+		Id:    "acc1",
+		Peers: map[string]*nbpeer.Peer{"pA": pA, "pB": pB},
+		Groups: map[string]*types.Group{
+			"all": {ID: "all", Name: "All", Peers: []string{"pA", "pB"}},
+			"g1":  {ID: "g1", Name: "src", Peers: []string{"pA"}},
+			"g2":  {ID: "g2", Name: "dst", Peers: []string{"pB"}},
+		},
+		PostureChecks: []*posture.Checks{
+			{ID: "pc1", Name: "min-nb", Checks: posture.ChecksDefinition{
+				NBVersionCheck: &posture.NBVersionCheck{MinVersion: "99.0.0"}}},
+		},
+		Policies: []*types.Policy{
+			{
+				ID: "pol1", Name: "allow-ssh", Enabled: true,
+				SourcePostureChecks: []string{"pc1"},
+				Rules: []*types.PolicyRule{
+					{
+						ID: "r1", Enabled: true,
+						Action:       types.PolicyTrafficActionAccept,
+						Sources:      []string{"g1"},
+						Destinations: []string{"g2"},
+						Protocol:     types.PolicyRuleProtocolTCP,
+						Ports:        []string{"22"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestBuildGraph_PostureBlocked_FocusNonCompliant(t *testing.T) {
+	acc := postureAccount("1.0.0") // pA fails the min-nb check
+	validated := map[string]struct{}{"pA": {}, "pB": {}}
+
+	g, err := BuildGraph(context.Background(), acc, Focus{Type: FocusPeer, ID: "pA"}, validated)
+	require.NoError(t, err)
+
+	require.Len(t, g.Edges, 1)
+	e := g.Edges[0]
+	require.Equal(t, "pA", e.From)
+	require.Equal(t, "pB", e.To)
+	require.Equal(t, EdgePostureBlocked, e.State)
+	require.Equal(t, PermitPolicy, e.PermitSource)
+	require.Equal(t, "pol1", e.PolicyID)
+	require.Equal(t, "tcp", e.Protocol)
+	require.Equal(t, []string{"22"}, e.Ports)
+	require.Equal(t, "min-nb", e.Meta["postureCheck"])
+	require.Equal(t, "pc1", e.Meta["postureCheckId"])
+	// pB must still be a node so the blocked edge has both endpoints.
+	require.Contains(t, g.Nodes, Node{ID: "pB", Kind: NodePeer, Label: "bob"})
+}
+
+func TestBuildGraph_PostureCompliant_EnforcedNotBlocked(t *testing.T) {
+	acc := postureAccount("99.0.0") // pA passes
+	validated := map[string]struct{}{"pA": {}, "pB": {}}
+
+	g, err := BuildGraph(context.Background(), acc, Focus{Type: FocusPeer, ID: "pA"}, validated)
+	require.NoError(t, err)
+	require.Len(t, g.Edges, 1)
+	require.Equal(t, EdgeEnforced, g.Edges[0].State)
+}
+
+func TestBuildGraph_PostureBlocked_FocusIsDestination(t *testing.T) {
+	acc := postureAccount("1.0.0") // pA (a source) fails posture
+	// flip: focus is pB (a destination); pA is a source that fails posture.
+	validated := map[string]struct{}{"pA": {}, "pB": {}}
+
+	g, err := BuildGraph(context.Background(), acc, Focus{Type: FocusPeer, ID: "pB"}, validated)
+	require.NoError(t, err)
+	require.Len(t, g.Edges, 1)
+	e := g.Edges[0]
+	// focus-anchored convention (same as the enforced pass): From is
+	// always the focus; Direction encodes that pA would reach pB (IN).
+	require.Equal(t, "pB", e.From)
+	require.Equal(t, "pA", e.To)
+	require.Equal(t, EdgePostureBlocked, e.State)
+	require.Equal(t, DirectionIn, e.Direction)
+}

--- a/management/server/controlcenter/posture_test.go
+++ b/management/server/controlcenter/posture_test.go
@@ -116,3 +116,16 @@ func TestBuildGraph_PostureBlocked_OtherEndpointUnvalidated(t *testing.T) {
 			"no posture_blocked when the other endpoint is unvalidated")
 	}
 }
+
+// #50-r2 F1: an unvalidated focus reaches nothing in the dataplane
+// (GetPeerNetworkMap early-returns empty) — the graph must say the
+// same: focus node only, no fabricated edges.
+func TestBuildGraph_UnvalidatedFocus_EmptyReach(t *testing.T) {
+	acc := postureAccount("1.0.0")             // pA fails posture
+	validated := map[string]struct{}{"pB": {}} // pA (focus) NOT validated
+
+	g, err := BuildGraph(context.Background(), acc, Focus{Type: FocusPeer, ID: "pA"}, validated)
+	require.NoError(t, err)
+	require.Empty(t, g.Edges, "unvalidated focus reaches nothing")
+	require.Equal(t, []Node{{ID: "pA", Kind: NodeFocus, Label: "alice"}}, g.Nodes)
+}

--- a/management/server/controlcenter/posture_test.go
+++ b/management/server/controlcenter/posture_test.go
@@ -100,3 +100,19 @@ func TestBuildGraph_PostureBlocked_FocusIsDestination(t *testing.T) {
 	require.Equal(t, EdgePostureBlocked, e.State)
 	require.Equal(t, DirectionIn, e.Direction)
 }
+
+// Finding 3: if the OTHER endpoint is not validated, the pair is
+// unreachable regardless of posture — posture is not the sole
+// remaining blocker, so no posture_blocked edge may be emitted.
+func TestBuildGraph_PostureBlocked_OtherEndpointUnvalidated(t *testing.T) {
+	acc := postureAccount("1.0.0") // pA (source) fails posture
+	// focus pB (destination) is NOT validated; only pA is.
+	validated := map[string]struct{}{"pA": {}}
+
+	g, err := BuildGraph(context.Background(), acc, Focus{Type: FocusPeer, ID: "pB"}, validated)
+	require.NoError(t, err)
+	for _, e := range g.Edges {
+		require.NotEqual(t, EdgePostureBlocked, e.State,
+			"no posture_blocked when the other endpoint is unvalidated")
+	}
+}

--- a/management/server/controlcenter/route.go
+++ b/management/server/controlcenter/route.go
@@ -109,7 +109,7 @@ func (b *graphBuilder) addRouteReach(ctx context.Context, acc *types.Account, fo
 		if r.Peer == focusPeer.Key {
 			b.addNode(nodeID, NodeRoute, routeLabel(r))
 			b.addRouteEdge(focusID, nodeID, &Edge{
-				PermitSource: PermitRouteDefault,
+				PermitSource: PermitRouterLocal,
 				Protocol:     string(types.PolicyRuleProtocolALL),
 				Direction:    DirectionOut,
 				State:        EdgeEnforced,

--- a/management/server/controlcenter/route.go
+++ b/management/server/controlcenter/route.go
@@ -99,34 +99,95 @@ func (b *graphBuilder) addRouteReach(ctx context.Context, acc *types.Account, fo
 		// decision (reuses the same posture eval) — it does not
 		// re-decide enforced reach, which stays strictly real-rule.
 		if !permitted && len(r.AccessControlGroups) > 0 {
-			b.addRoutePostureBlocked(ctx, acc, focusID, r, nodeID)
+			b.addPolicyPostureBlocked(ctx, acc, focusID,
+				types.GetAllRoutePoliciesFromGroups(acc, r.AccessControlGroups),
+				nodeID, NodeRoute, routeLabel(r))
 		}
 	}
 
-	// Network-resource routes are already permission-resolved by the
-	// producer (it only returns resources the focus is entitled to), so
-	// no distribution∩permission step is needed — label the permit
-	// source from the resource's policy when there is one.
+	// Network-resource routes: same distribution ∩ real-permission
+	// principle as classic routes (Finding 1). The permitting policy /
+	// protocol / port come from the engine's real
+	// GetPeerNetworkResourceFirewallRules — NOT an arbitrary pols[0].
 	resourcePolicies := acc.GetResourcePoliciesMap()
-	_, nrRoutes, _ := acc.GetNetworkResourcesRoutesToSync(ctx, focusID, resourcePolicies, acc.GetResourceRoutersMap())
-	for _, r := range nrRoutes {
+	routers := acc.GetResourceRoutersMap()
+
+	// From every router's view, index the real nr firewall rules by
+	// RouteID and remember a route per resource ID (so a stable
+	// node id/label exists even when the focus is dropped from
+	// distribution by posture — same shape as the peer D1.2 pass).
+	nrRuleIdx := map[route.ID][]*types.RouteFirewallRule{}
+	nrRouteByResource := map[string]*route.Route{}
+	for _, p := range acc.Peers {
+		if p == nil {
+			continue
+		}
+		isRouter, nrR, _ := acc.GetNetworkResourcesRoutesToSync(ctx, p.ID, resourcePolicies, routers)
+		if !isRouter || len(nrR) == 0 {
+			continue
+		}
+		for _, rr := range nrR {
+			if rr != nil {
+				nrRouteByResource[string(rr.GetResourceID())] = rr
+			}
+		}
+		for _, fr := range acc.GetPeerNetworkResourceFirewallRules(ctx, p, validatedPeers, nrR, resourcePolicies) {
+			nrRuleIdx[fr.RouteID] = append(nrRuleIdx[fr.RouteID], fr)
+		}
+	}
+
+	// Enforced: of the resources distributed to the focus, an edge
+	// exists only where a real nr firewall rule covers the focus IP.
+	permittedRes := map[string]struct{}{}
+	_, focusNR, _ := acc.GetNetworkResourcesRoutesToSync(ctx, focusID, resourcePolicies, routers)
+	for _, r := range focusNR {
 		if r == nil {
 			continue
 		}
 		nodeID := "nr:" + string(r.ID)
-		b.addNode(nodeID, NodeNetworkResource, routeLabel(r))
-		e := &Edge{
-			PermitSource: PermitRouteDefault,
-			Protocol:     string(types.PolicyRuleProtocolALL),
-			Direction:    DirectionOut,
-			State:        EdgeEnforced,
+		for _, fr := range nrRuleIdx[r.ID] {
+			if !ipInAnyRange(focusPeer.IP, fr.SourceRanges) {
+				continue
+			}
+			permittedRes[string(r.GetResourceID())] = struct{}{}
+			e := &Edge{
+				Protocol:     fr.Protocol,
+				Ports:        routeFirewallPorts(fr),
+				SourceRanges: fr.SourceRanges,
+				Direction:    DirectionOut,
+				State:        EdgeEnforced,
+			}
+			if fr.PolicyID == "" {
+				e.PermitSource = PermitRouteDefault
+			} else {
+				e.PermitSource = PermitPolicy
+				e.PolicyID = fr.PolicyID
+				if pol := policyByID(acc, fr.PolicyID); pol != nil {
+					e.PolicyName = pol.Name
+				}
+			}
+			b.addNode(nodeID, NodeNetworkResource, routeLabel(r))
+			b.addRouteEdge(focusID, nodeID, e)
 		}
-		if pols := resourcePolicies[string(r.GetResourceID())]; len(pols) > 0 && pols[0] != nil {
-			e.PermitSource = PermitPolicy
-			e.PolicyID = pols[0].ID
-			e.PolicyName = pols[0].Name
+	}
+
+	// Explanatory (D1.2 for resources): the distribution producer also
+	// drops a posture-failing client, so iterate resources directly —
+	// a resource the focus would source but for posture surfaces as a
+	// distinct posture_blocked edge.
+	for _, res := range acc.NetworkResources {
+		if res == nil || !res.Enabled {
+			continue
 		}
-		b.addRouteEdge(focusID, nodeID, e)
+		if _, ok := permittedRes[res.ID]; ok {
+			continue
+		}
+		rr := nrRouteByResource[res.ID]
+		if rr == nil {
+			continue
+		}
+		b.addPolicyPostureBlocked(ctx, acc, focusID,
+			resourcePolicies[res.ID], "nr:"+string(rr.ID), NodeNetworkResource, routeLabel(rr))
 	}
 }
 
@@ -183,14 +244,16 @@ func routeLabel(r *route.Route) string {
 	return string(r.NetID)
 }
 
-// addRoutePostureBlocked emits a posture_blocked edge for a route the
-// focus would be a permitted source on but for posture. Annotator
-// only: reuses the same posture evaluation, makes no enforced-reach
-// decision (that stays strictly real-rule based).
-func (b *graphBuilder) addRoutePostureBlocked(ctx context.Context, acc *types.Account, focusID string, r *route.Route, nodeID string) {
+// addPolicyPostureBlocked emits a posture_blocked edge to a route or
+// network-resource node the focus would be a permitted source on but
+// for posture. Shared by the classic-route and network-resource paths
+// (Findings 1 & 2). Annotator only: reuses the same posture
+// evaluation, makes no enforced-reach decision (that stays strictly
+// real-rule based).
+func (b *graphBuilder) addPolicyPostureBlocked(ctx context.Context, acc *types.Account, focusID string, policies []*types.Policy, nodeID string, kind NodeKind, label string) {
 	postureMap := postureChecksMap(acc)
-	for _, pol := range types.GetAllRoutePoliciesFromGroups(acc, r.AccessControlGroups) {
-		if !pol.Enabled || len(pol.SourcePostureChecks) == 0 {
+	for _, pol := range policies {
+		if pol == nil || !pol.Enabled || len(pol.SourcePostureChecks) == 0 {
 			continue
 		}
 		for _, rule := range pol.Rules {
@@ -204,7 +267,7 @@ func (b *graphBuilder) addRoutePostureBlocked(ctx context.Context, acc *types.Ac
 			if d == nil {
 				continue
 			}
-			b.addNode(nodeID, NodeRoute, routeLabel(r))
+			b.addNode(nodeID, kind, label)
 			b.addRouteEdge(focusID, nodeID, &Edge{
 				PermitSource: PermitPolicy,
 				PolicyID:     pol.ID,

--- a/management/server/controlcenter/route.go
+++ b/management/server/controlcenter/route.go
@@ -116,6 +116,25 @@ func (b *graphBuilder) addRouteReach(ctx context.Context, acc *types.Account, fo
 	// RouteID and remember a route per resource ID (so a stable
 	// node id/label exists even when the focus is dropped from
 	// distribution by posture — same shape as the peer D1.2 pass).
+	// A network resource is ONE logical target. Its node id is the
+	// resource id (not the per-router route id "<resID>:<peerID>"),
+	// and the label comes from the resource itself — so HA routers
+	// collapse to a single deterministic node (#50-r2 F2).
+	nrLabelByRes := map[string]string{}
+	for _, res := range acc.NetworkResources {
+		if res == nil {
+			continue
+		}
+		switch {
+		case res.Name != "":
+			nrLabelByRes[res.ID] = res.Name
+		case res.Address != "":
+			nrLabelByRes[res.ID] = res.Address
+		default:
+			nrLabelByRes[res.ID] = res.Prefix.String()
+		}
+	}
+
 	nrRuleIdx := map[route.ID][]*types.RouteFirewallRule{}
 	nrRouteByResource := map[string]*route.Route{}
 	for _, p := range acc.Peers {
@@ -144,12 +163,13 @@ func (b *graphBuilder) addRouteReach(ctx context.Context, acc *types.Account, fo
 		if r == nil {
 			continue
 		}
-		nodeID := "nr:" + string(r.ID)
+		resID := string(r.GetResourceID())
+		nodeID := "nr:" + resID
 		for _, fr := range nrRuleIdx[r.ID] {
 			if !ipInAnyRange(focusPeer.IP, fr.SourceRanges) {
 				continue
 			}
-			permittedRes[string(r.GetResourceID())] = struct{}{}
+			permittedRes[resID] = struct{}{}
 			e := &Edge{
 				Protocol:     fr.Protocol,
 				Ports:        routeFirewallPorts(fr),
@@ -166,7 +186,7 @@ func (b *graphBuilder) addRouteReach(ctx context.Context, acc *types.Account, fo
 					e.PolicyName = pol.Name
 				}
 			}
-			b.addNode(nodeID, NodeNetworkResource, routeLabel(r))
+			b.addNode(nodeID, NodeNetworkResource, nrLabelByRes[resID])
 			b.addRouteEdge(focusID, nodeID, e)
 		}
 	}
@@ -182,12 +202,11 @@ func (b *graphBuilder) addRouteReach(ctx context.Context, acc *types.Account, fo
 		if _, ok := permittedRes[res.ID]; ok {
 			continue
 		}
-		rr := nrRouteByResource[res.ID]
-		if rr == nil {
-			continue
+		if nrRouteByResource[res.ID] == nil {
+			continue // no router actually serves it — unreachable, posture aside
 		}
 		b.addPolicyPostureBlocked(ctx, acc, focusID,
-			resourcePolicies[res.ID], "nr:"+string(rr.ID), NodeNetworkResource, routeLabel(rr))
+			resourcePolicies[res.ID], "nr:"+res.ID, NodeNetworkResource, nrLabelByRes[res.ID])
 	}
 }
 

--- a/management/server/controlcenter/route.go
+++ b/management/server/controlcenter/route.go
@@ -1,0 +1,161 @@
+package controlcenter
+
+import (
+	"context"
+	"strings"
+
+	nbpeer "github.com/openzro/openzro/management/server/peer"
+	"github.com/openzro/openzro/management/server/posture"
+	"github.com/openzro/openzro/management/server/types"
+	"github.com/openzro/openzro/route"
+)
+
+// addRouteReach is ADR-0017 D1.1 for route edges: a route edge is the
+// COMPOSITION of distribution (GetRoutesToSync — does the route reach
+// the focus at all) and permission (is the focus an allowed source on
+// that route, or does the route default-permit). A route synced to the
+// focus but not permitted by any access-control policy is NOT drawn as
+// reachable (the route_test.go:1934 invariant) — it produces neither
+// an edge nor an orphan node.
+//
+// Clean-room (BSD-3): reuses openZro's own GetRoutesToSync /
+// GetAllRoutePoliciesFromGroups / GetNetworkResourcesRoutesToSync;
+// no parallel policy walker, no upstream NetBird code.
+func (b *graphBuilder) addRouteReach(ctx context.Context, acc *types.Account, focusID string, reachable []*nbpeer.Peer, validatedPeers map[string]struct{}) {
+	postureMap := postureChecksMap(acc)
+
+	// Distribution: the classic routes the focus actually receives.
+	for _, r := range acc.GetRoutesToSync(ctx, focusID, reachable) {
+		if r == nil || !r.Enabled {
+			continue
+		}
+		nodeID := "route:" + string(r.ID)
+
+		if len(r.AccessControlGroups) == 0 {
+			b.addNode(nodeID, NodeRoute, routeLabel(r))
+			b.addRouteEdge(focusID, nodeID, &Edge{
+				PermitSource: PermitRouteDefault,
+				Protocol:     string(types.PolicyRuleProtocolALL),
+				SourceRanges: []string{defaultSourceRange(r)},
+				Direction:    DirectionOut,
+				State:        EdgeEnforced,
+			})
+			continue
+		}
+
+		// Permission: a route policy whose rule destination is one of
+		// the route's AccessControlGroups and whose source includes the
+		// focus. Posture on that policy can downgrade it to blocked.
+		for _, pol := range types.GetAllRoutePoliciesFromGroups(acc, r.AccessControlGroups) {
+			if !pol.Enabled {
+				continue
+			}
+			for _, rule := range pol.Rules {
+				if rule == nil || !rule.Enabled {
+					continue
+				}
+				src := groupMembers(acc, rule.Sources)
+				if _, ok := src[focusID]; !ok {
+					continue
+				}
+				e := &Edge{
+					PermitSource: PermitPolicy,
+					PolicyID:     pol.ID,
+					PolicyName:   pol.Name,
+					Protocol:     string(rule.Protocol),
+					Ports:        rulePorts(rule),
+					Direction:    DirectionOut,
+					State:        EdgeEnforced,
+				}
+				if len(pol.SourcePostureChecks) > 0 {
+					if d := admissionDenial(ctx, acc, focusID, pol.SourcePostureChecks, postureMap); d != nil {
+						e.State = EdgePostureBlocked
+						e.Meta = map[string]string{
+							"postureCheck":     d.PostureCheckName,
+							"postureCheckId":   d.PostureCheckID,
+							"postureCheckType": d.CheckType,
+							"postureReason":    d.Reason,
+						}
+					}
+				}
+				b.addNode(nodeID, NodeRoute, routeLabel(r))
+				b.addRouteEdge(focusID, nodeID, e)
+			}
+		}
+	}
+
+	// Network-resource routes are already permission-resolved by the
+	// producer (it only returns resources the focus is entitled to), so
+	// no distribution∩permission step is needed — label the permit
+	// source from the resource's policy when there is one.
+	resourcePolicies := acc.GetResourcePoliciesMap()
+	_, nrRoutes, _ := acc.GetNetworkResourcesRoutesToSync(ctx, focusID, resourcePolicies, acc.GetResourceRoutersMap())
+	for _, r := range nrRoutes {
+		if r == nil {
+			continue
+		}
+		nodeID := "nr:" + string(r.ID)
+		b.addNode(nodeID, NodeNetworkResource, routeLabel(r))
+		e := &Edge{
+			PermitSource: PermitRouteDefault,
+			Protocol:     string(types.PolicyRuleProtocolALL),
+			Direction:    DirectionOut,
+			State:        EdgeEnforced,
+		}
+		if pols := resourcePolicies[string(r.GetResourceID())]; len(pols) > 0 && pols[0] != nil {
+			e.PermitSource = PermitPolicy
+			e.PolicyID = pols[0].ID
+			e.PolicyName = pols[0].Name
+		}
+		b.addRouteEdge(focusID, nodeID, e)
+	}
+}
+
+// addRouteEdge inserts a focus→route edge, de-duped by
+// from|to|policyID|protocol, never downgrading an enforced edge.
+func (b *graphBuilder) addRouteEdge(from, to string, e *Edge) {
+	e.From = from
+	e.To = to
+	key := from + "|" + to + "|" + e.PolicyID + "|" + e.Protocol
+	if existing, ok := b.edgeAgg[key]; ok {
+		if existing.State == EdgeEnforced {
+			return
+		}
+		if e.State == EdgeEnforced {
+			b.edgeAgg[key] = e
+		}
+		return
+	}
+	b.edgeAgg[key] = e
+}
+
+func routeLabel(r *route.Route) string {
+	if r.Network.IsValid() {
+		return r.Network.String()
+	}
+	if len(r.Domains) > 0 {
+		ds := make([]string, 0, len(r.Domains))
+		for _, d := range r.Domains {
+			ds = append(ds, string(d))
+		}
+		return strings.Join(ds, ",")
+	}
+	return string(r.NetID)
+}
+
+func defaultSourceRange(r *route.Route) string {
+	if r.Network.IsValid() && r.Network.Addr().Is6() {
+		return "::/0"
+	}
+	return "0.0.0.0/0"
+}
+
+func postureChecksMap(acc *types.Account) map[string]*posture.Checks {
+	m := map[string]*posture.Checks{}
+	for _, pc := range acc.PostureChecks {
+		if pc != nil {
+			m[pc.ID] = pc
+		}
+	}
+	return m
+}

--- a/management/server/controlcenter/route.go
+++ b/management/server/controlcenter/route.go
@@ -7,6 +7,7 @@ import (
 	"net/netip"
 	"strings"
 
+	routerTypes "github.com/openzro/openzro/management/server/networks/routers/types"
 	nbpeer "github.com/openzro/openzro/management/server/peer"
 	"github.com/openzro/openzro/management/server/posture"
 	"github.com/openzro/openzro/management/server/types"
@@ -24,24 +25,74 @@ import (
 // Clean-room (BSD-3): reuses openZro's own GetRoutesToSync /
 // GetAllRoutePoliciesFromGroups / GetNetworkResourcesRoutesToSync;
 // no parallel policy walker, no upstream NetBird code.
-func (b *graphBuilder) addRouteReach(ctx context.Context, acc *types.Account, focusID string, reachable []*nbpeer.Peer, validatedPeers map[string]struct{}) {
-	focusPeer := acc.GetPeer(focusID)
-	if focusPeer == nil {
-		return
+// routeIndex holds the account-invariant route/network-resource
+// firewall-rule indices. They do NOT depend on the focus, so they are
+// built ONCE per BuildGraph and shared across every Group-focus member
+// instead of O(members × peers) recomputation (#50-r2 F3).
+type routeIndex struct {
+	ruleIdx          map[route.ID][]*types.RouteFirewallRule // classic, by RouteID
+	nrRuleIdx        map[route.ID][]*types.RouteFirewallRule // network-resource, by RouteID
+	nrRouteByRes     map[string]*route.Route                 // resourceID → a serving route (existence)
+	nrLabelByRes     map[string]string                       // resourceID → display label
+	resourcePolicies map[string][]*types.Policy
+	routers          map[string]map[string]*routerTypes.NetworkRouter
+}
+
+func newRouteIndex(ctx context.Context, acc *types.Account, validatedPeers map[string]struct{}) *routeIndex {
+	idx := &routeIndex{
+		ruleIdx:          map[route.ID][]*types.RouteFirewallRule{},
+		nrRuleIdx:        map[route.ID][]*types.RouteFirewallRule{},
+		nrRouteByRes:     map[string]*route.Route{},
+		nrLabelByRes:     map[string]string{},
+		resourcePolicies: acc.GetResourcePoliciesMap(),
+		routers:          acc.GetResourceRoutersMap(),
 	}
 
-	// Permission is materialised at the ROUTER, not re-derived here:
-	// index every routing peer's real RouteFirewallRules by RouteID.
-	// A rule's SourceRanges are the client IPs it actually permits
-	// (or 0.0.0.0/0 for a route default-permit, PolicyID == "").
-	ruleIdx := map[route.ID][]*types.RouteFirewallRule{}
+	for _, res := range acc.NetworkResources {
+		if res == nil {
+			continue
+		}
+		switch {
+		case res.Name != "":
+			idx.nrLabelByRes[res.ID] = res.Name
+		case res.Address != "":
+			idx.nrLabelByRes[res.ID] = res.Address
+		default:
+			idx.nrLabelByRes[res.ID] = res.Prefix.String()
+		}
+	}
+
+	// Permission is materialised at the ROUTER: index every routing
+	// peer's real Route/NetworkResource firewall rules by RouteID. A
+	// rule's SourceRanges are the client IPs it actually permits (or
+	// 0.0.0.0/0 for a route default-permit, PolicyID == "").
 	for _, p := range acc.Peers {
 		if p == nil {
 			continue
 		}
 		for _, fr := range acc.GetPeerRoutesFirewallRules(ctx, p.ID, validatedPeers) {
-			ruleIdx[fr.RouteID] = append(ruleIdx[fr.RouteID], fr)
+			idx.ruleIdx[fr.RouteID] = append(idx.ruleIdx[fr.RouteID], fr)
 		}
+		isRouter, nrR, _ := acc.GetNetworkResourcesRoutesToSync(ctx, p.ID, idx.resourcePolicies, idx.routers)
+		if !isRouter || len(nrR) == 0 {
+			continue
+		}
+		for _, rr := range nrR {
+			if rr != nil {
+				idx.nrRouteByRes[string(rr.GetResourceID())] = rr
+			}
+		}
+		for _, fr := range acc.GetPeerNetworkResourceFirewallRules(ctx, p, validatedPeers, nrR, idx.resourcePolicies) {
+			idx.nrRuleIdx[fr.RouteID] = append(idx.nrRuleIdx[fr.RouteID], fr)
+		}
+	}
+	return idx
+}
+
+func (b *graphBuilder) addRouteReach(ctx context.Context, acc *types.Account, focusID string, reachable []*nbpeer.Peer, validatedPeers map[string]struct{}, idx *routeIndex) {
+	focusPeer := acc.GetPeer(focusID)
+	if focusPeer == nil {
+		return
 	}
 
 	// Distribution ∩ permission: of the routes the focus receives, an
@@ -67,7 +118,7 @@ func (b *graphBuilder) addRouteReach(ctx context.Context, acc *types.Account, fo
 		}
 
 		permitted := false
-		for _, fr := range ruleIdx[r.ID] {
+		for _, fr := range idx.ruleIdx[r.ID] {
 			if !ipInAnyRange(focusPeer.IP, fr.SourceRanges) {
 				continue
 			}
@@ -106,66 +157,19 @@ func (b *graphBuilder) addRouteReach(ctx context.Context, acc *types.Account, fo
 	}
 
 	// Network-resource routes: same distribution ∩ real-permission
-	// principle as classic routes (Finding 1). The permitting policy /
-	// protocol / port come from the engine's real
-	// GetPeerNetworkResourceFirewallRules — NOT an arbitrary pols[0].
-	resourcePolicies := acc.GetResourcePoliciesMap()
-	routers := acc.GetResourceRoutersMap()
-
-	// From every router's view, index the real nr firewall rules by
-	// RouteID and remember a route per resource ID (so a stable
-	// node id/label exists even when the focus is dropped from
-	// distribution by posture — same shape as the peer D1.2 pass).
-	// A network resource is ONE logical target. Its node id is the
-	// resource id (not the per-router route id "<resID>:<peerID>"),
-	// and the label comes from the resource itself — so HA routers
-	// collapse to a single deterministic node (#50-r2 F2).
-	nrLabelByRes := map[string]string{}
-	for _, res := range acc.NetworkResources {
-		if res == nil {
-			continue
-		}
-		switch {
-		case res.Name != "":
-			nrLabelByRes[res.ID] = res.Name
-		case res.Address != "":
-			nrLabelByRes[res.ID] = res.Address
-		default:
-			nrLabelByRes[res.ID] = res.Prefix.String()
-		}
-	}
-
-	nrRuleIdx := map[route.ID][]*types.RouteFirewallRule{}
-	nrRouteByResource := map[string]*route.Route{}
-	for _, p := range acc.Peers {
-		if p == nil {
-			continue
-		}
-		isRouter, nrR, _ := acc.GetNetworkResourcesRoutesToSync(ctx, p.ID, resourcePolicies, routers)
-		if !isRouter || len(nrR) == 0 {
-			continue
-		}
-		for _, rr := range nrR {
-			if rr != nil {
-				nrRouteByResource[string(rr.GetResourceID())] = rr
-			}
-		}
-		for _, fr := range acc.GetPeerNetworkResourceFirewallRules(ctx, p, validatedPeers, nrR, resourcePolicies) {
-			nrRuleIdx[fr.RouteID] = append(nrRuleIdx[fr.RouteID], fr)
-		}
-	}
-
-	// Enforced: of the resources distributed to the focus, an edge
-	// exists only where a real nr firewall rule covers the focus IP.
+	// principle as classic routes (Finding 1). Indices were built once
+	// per BuildGraph (idx); only the focus distribution is per-focus.
+	// A network resource is ONE logical target — node id is the
+	// resource id, label from the resource (#50-r2 F2).
 	permittedRes := map[string]struct{}{}
-	_, focusNR, _ := acc.GetNetworkResourcesRoutesToSync(ctx, focusID, resourcePolicies, routers)
+	_, focusNR, _ := acc.GetNetworkResourcesRoutesToSync(ctx, focusID, idx.resourcePolicies, idx.routers)
 	for _, r := range focusNR {
 		if r == nil {
 			continue
 		}
 		resID := string(r.GetResourceID())
 		nodeID := "nr:" + resID
-		for _, fr := range nrRuleIdx[r.ID] {
+		for _, fr := range idx.nrRuleIdx[r.ID] {
 			if !ipInAnyRange(focusPeer.IP, fr.SourceRanges) {
 				continue
 			}
@@ -186,7 +190,7 @@ func (b *graphBuilder) addRouteReach(ctx context.Context, acc *types.Account, fo
 					e.PolicyName = pol.Name
 				}
 			}
-			b.addNode(nodeID, NodeNetworkResource, nrLabelByRes[resID])
+			b.addNode(nodeID, NodeNetworkResource, idx.nrLabelByRes[resID])
 			b.addRouteEdge(focusID, nodeID, e)
 		}
 	}
@@ -202,11 +206,11 @@ func (b *graphBuilder) addRouteReach(ctx context.Context, acc *types.Account, fo
 		if _, ok := permittedRes[res.ID]; ok {
 			continue
 		}
-		if nrRouteByResource[res.ID] == nil {
+		if idx.nrRouteByRes[res.ID] == nil {
 			continue // no router actually serves it — unreachable, posture aside
 		}
 		b.addPolicyPostureBlocked(ctx, acc, focusID,
-			resourcePolicies[res.ID], "nr:"+res.ID, NodeNetworkResource, nrLabelByRes[res.ID])
+			idx.resourcePolicies[res.ID], "nr:"+res.ID, NodeNetworkResource, idx.nrLabelByRes[res.ID])
 	}
 }
 

--- a/management/server/controlcenter/route.go
+++ b/management/server/controlcenter/route.go
@@ -2,6 +2,9 @@ package controlcenter
 
 import (
 	"context"
+	"fmt"
+	"net"
+	"net/netip"
 	"strings"
 
 	nbpeer "github.com/openzro/openzro/management/server/peer"
@@ -22,65 +25,81 @@ import (
 // GetAllRoutePoliciesFromGroups / GetNetworkResourcesRoutesToSync;
 // no parallel policy walker, no upstream NetBird code.
 func (b *graphBuilder) addRouteReach(ctx context.Context, acc *types.Account, focusID string, reachable []*nbpeer.Peer, validatedPeers map[string]struct{}) {
-	postureMap := postureChecksMap(acc)
+	focusPeer := acc.GetPeer(focusID)
+	if focusPeer == nil {
+		return
+	}
 
-	// Distribution: the classic routes the focus actually receives.
+	// Permission is materialised at the ROUTER, not re-derived here:
+	// index every routing peer's real RouteFirewallRules by RouteID.
+	// A rule's SourceRanges are the client IPs it actually permits
+	// (or 0.0.0.0/0 for a route default-permit, PolicyID == "").
+	ruleIdx := map[route.ID][]*types.RouteFirewallRule{}
+	for _, p := range acc.Peers {
+		if p == nil {
+			continue
+		}
+		for _, fr := range acc.GetPeerRoutesFirewallRules(ctx, p.ID, validatedPeers) {
+			ruleIdx[fr.RouteID] = append(ruleIdx[fr.RouteID], fr)
+		}
+	}
+
+	// Distribution ∩ permission: of the routes the focus receives, an
+	// edge exists only where a real route firewall rule permits the
+	// focus's IP. A synced-but-unpermitted route yields no edge/node.
 	for _, r := range acc.GetRoutesToSync(ctx, focusID, reachable) {
 		if r == nil || !r.Enabled {
 			continue
 		}
 		nodeID := "route:" + string(r.ID)
 
-		if len(r.AccessControlGroups) == 0 {
+		// The focus itself serves this route — as the router it reaches
+		// the routed network by definition (its own gateway).
+		if r.Peer == focusPeer.Key {
 			b.addNode(nodeID, NodeRoute, routeLabel(r))
 			b.addRouteEdge(focusID, nodeID, &Edge{
 				PermitSource: PermitRouteDefault,
 				Protocol:     string(types.PolicyRuleProtocolALL),
-				SourceRanges: []string{defaultSourceRange(r)},
 				Direction:    DirectionOut,
 				State:        EdgeEnforced,
 			})
 			continue
 		}
 
-		// Permission: a route policy whose rule destination is one of
-		// the route's AccessControlGroups and whose source includes the
-		// focus. Posture on that policy can downgrade it to blocked.
-		for _, pol := range types.GetAllRoutePoliciesFromGroups(acc, r.AccessControlGroups) {
-			if !pol.Enabled {
+		permitted := false
+		for _, fr := range ruleIdx[r.ID] {
+			if !ipInAnyRange(focusPeer.IP, fr.SourceRanges) {
 				continue
 			}
-			for _, rule := range pol.Rules {
-				if rule == nil || !rule.Enabled {
-					continue
-				}
-				src := groupMembers(acc, rule.Sources)
-				if _, ok := src[focusID]; !ok {
-					continue
-				}
-				e := &Edge{
-					PermitSource: PermitPolicy,
-					PolicyID:     pol.ID,
-					PolicyName:   pol.Name,
-					Protocol:     string(rule.Protocol),
-					Ports:        rulePorts(rule),
-					Direction:    DirectionOut,
-					State:        EdgeEnforced,
-				}
-				if len(pol.SourcePostureChecks) > 0 {
-					if d := admissionDenial(ctx, acc, focusID, pol.SourcePostureChecks, postureMap); d != nil {
-						e.State = EdgePostureBlocked
-						e.Meta = map[string]string{
-							"postureCheck":     d.PostureCheckName,
-							"postureCheckId":   d.PostureCheckID,
-							"postureCheckType": d.CheckType,
-							"postureReason":    d.Reason,
-						}
-					}
-				}
-				b.addNode(nodeID, NodeRoute, routeLabel(r))
-				b.addRouteEdge(focusID, nodeID, e)
+			permitted = true
+			e := &Edge{
+				Protocol:     fr.Protocol,
+				Ports:        routeFirewallPorts(fr),
+				SourceRanges: fr.SourceRanges,
+				Direction:    DirectionOut,
+				State:        EdgeEnforced,
 			}
+			if fr.PolicyID == "" {
+				e.PermitSource = PermitRouteDefault
+			} else {
+				e.PermitSource = PermitPolicy
+				e.PolicyID = fr.PolicyID
+				if pol := policyByID(acc, fr.PolicyID); pol != nil {
+					e.PolicyName = pol.Name
+				}
+			}
+			b.addNode(nodeID, NodeRoute, routeLabel(r))
+			b.addRouteEdge(focusID, nodeID, e)
+		}
+
+		// Explanatory (D1.2 for routes): the focus is absent from every
+		// real rule's SourceRanges. If it WOULD be a permitted source
+		// but for posture, surface a distinct posture_blocked edge
+		// instead of silently dropping it. This annotates the engine's
+		// decision (reuses the same posture eval) — it does not
+		// re-decide enforced reach, which stays strictly real-rule.
+		if !permitted && len(r.AccessControlGroups) > 0 {
+			b.addRoutePostureBlocked(ctx, acc, focusID, r, nodeID)
 		}
 	}
 
@@ -111,22 +130,43 @@ func (b *graphBuilder) addRouteReach(ctx context.Context, acc *types.Account, fo
 	}
 }
 
-// addRouteEdge inserts a focus→route edge, de-duped by
-// from|to|policyID|protocol, never downgrading an enforced edge.
+// addRouteEdge inserts a focus→route edge keyed by
+// from|to|policyID|protocol. When the key already exists it MERGES
+// ports and source ranges instead of dropping the new rule (two
+// firewall rules of the same policy/protocol differing only by port
+// — e.g. TCP 80 and TCP 443 — must both survive, Finding 2). An
+// enforced edge is never downgraded to posture_blocked; a
+// posture_blocked edge is upgraded if real reach is found.
 func (b *graphBuilder) addRouteEdge(from, to string, e *Edge) {
 	e.From = from
 	e.To = to
 	key := from + "|" + to + "|" + e.PolicyID + "|" + e.Protocol
-	if existing, ok := b.edgeAgg[key]; ok {
-		if existing.State == EdgeEnforced {
-			return
-		}
-		if e.State == EdgeEnforced {
-			b.edgeAgg[key] = e
-		}
+	existing, ok := b.edgeAgg[key]
+	if !ok {
+		b.edgeAgg[key] = e
 		return
 	}
-	b.edgeAgg[key] = e
+	if existing.State == EdgeEnforced && e.State != EdgeEnforced {
+		return // never downgrade
+	}
+	if existing.State != EdgeEnforced && e.State == EdgeEnforced {
+		// upgrade to the enforced edge, then carry merged ports below.
+		e.Ports = unionStrings(e.Ports, existing.Ports)
+		e.SourceRanges = unionStrings(e.SourceRanges, existing.SourceRanges)
+		b.edgeAgg[key] = e
+		return
+	}
+	existing.Ports = unionStrings(existing.Ports, e.Ports)
+	existing.SourceRanges = unionStrings(existing.SourceRanges, e.SourceRanges)
+}
+
+func unionStrings(a, b []string) []string {
+	for _, v := range b {
+		if !contains(a, v) {
+			a = append(a, v)
+		}
+	}
+	return a
 }
 
 func routeLabel(r *route.Route) string {
@@ -143,11 +183,82 @@ func routeLabel(r *route.Route) string {
 	return string(r.NetID)
 }
 
-func defaultSourceRange(r *route.Route) string {
-	if r.Network.IsValid() && r.Network.Addr().Is6() {
-		return "::/0"
+// addRoutePostureBlocked emits a posture_blocked edge for a route the
+// focus would be a permitted source on but for posture. Annotator
+// only: reuses the same posture evaluation, makes no enforced-reach
+// decision (that stays strictly real-rule based).
+func (b *graphBuilder) addRoutePostureBlocked(ctx context.Context, acc *types.Account, focusID string, r *route.Route, nodeID string) {
+	postureMap := postureChecksMap(acc)
+	for _, pol := range types.GetAllRoutePoliciesFromGroups(acc, r.AccessControlGroups) {
+		if !pol.Enabled || len(pol.SourcePostureChecks) == 0 {
+			continue
+		}
+		for _, rule := range pol.Rules {
+			if rule == nil || !rule.Enabled {
+				continue
+			}
+			if _, ok := groupMembers(acc, rule.Sources)[focusID]; !ok {
+				continue
+			}
+			d := admissionDenial(ctx, acc, focusID, pol.SourcePostureChecks, postureMap)
+			if d == nil {
+				continue
+			}
+			b.addNode(nodeID, NodeRoute, routeLabel(r))
+			b.addRouteEdge(focusID, nodeID, &Edge{
+				PermitSource: PermitPolicy,
+				PolicyID:     pol.ID,
+				PolicyName:   pol.Name,
+				Protocol:     string(rule.Protocol),
+				Ports:        rulePorts(rule),
+				Direction:    DirectionOut,
+				State:        EdgePostureBlocked,
+				Meta: map[string]string{
+					"postureCheck":     d.PostureCheckName,
+					"postureCheckId":   d.PostureCheckID,
+					"postureCheckType": d.CheckType,
+					"postureReason":    d.Reason,
+				},
+			})
+		}
 	}
-	return "0.0.0.0/0"
+}
+
+func ipInAnyRange(ip net.IP, ranges []string) bool {
+	addr, ok := netip.AddrFromSlice(ip)
+	if !ok {
+		return false
+	}
+	addr = addr.Unmap()
+	for _, cidr := range ranges {
+		p, err := netip.ParsePrefix(cidr)
+		if err != nil {
+			continue
+		}
+		if p.Contains(addr) {
+			return true
+		}
+	}
+	return false
+}
+
+func routeFirewallPorts(fr *types.RouteFirewallRule) []string {
+	if fr.Port != 0 {
+		return []string{fmt.Sprintf("%d", fr.Port)}
+	}
+	if fr.PortRange.Start != 0 || fr.PortRange.End != 0 {
+		return []string{fmt.Sprintf("%d-%d", fr.PortRange.Start, fr.PortRange.End)}
+	}
+	return nil
+}
+
+func policyByID(acc *types.Account, id string) *types.Policy {
+	for _, p := range acc.Policies {
+		if p != nil && p.ID == id {
+			return p
+		}
+	}
+	return nil
 }
 
 func postureChecksMap(acc *types.Account) map[string]*posture.Checks {

--- a/management/server/controlcenter/route_test.go
+++ b/management/server/controlcenter/route_test.go
@@ -144,3 +144,32 @@ func TestBuildGraph_SelfRouter_RouterLocalPermitSource(t *testing.T) {
 		"self-router reach must be router_local, not route_default_permit")
 	require.Empty(t, e2.PolicyID)
 }
+
+// #50-r3: a group holding a router AND a client over the same
+// default-permit route must NOT collapse — router_local and
+// route_default_permit are distinct reach causes and each keeps its
+// own "k of n".
+func TestBuildGraph_GroupFocus_RouterLocalVsDefaultNotCollapsed(t *testing.T) {
+	acc := routeAccount() // group "all" = {pA client, pR router}; pR serves r1 (no ACG)
+	validated := map[string]struct{}{"pA": {}, "pR": {}}
+
+	g, err := BuildGraph(context.Background(), acc, Focus{Type: FocusGroup, ID: "all"}, validated)
+	require.NoError(t, err)
+
+	var r1 []Edge
+	for _, e := range g.Edges {
+		if e.To == "route:r1" {
+			r1 = append(r1, e)
+		}
+	}
+	require.Len(t, r1, 2, "router_local and route_default_permit must stay separate")
+
+	bySrc := map[PermitSource]Edge{}
+	for _, e := range r1 {
+		bySrc[e.PermitSource] = e
+	}
+	require.Contains(t, bySrc, PermitRouterLocal)
+	require.Contains(t, bySrc, PermitRouteDefault)
+	require.Equal(t, "1 of 2 members", bySrc[PermitRouterLocal].Meta["reachedBy"])
+	require.Equal(t, "1 of 2 members", bySrc[PermitRouteDefault].Meta["reachedBy"])
+}

--- a/management/server/controlcenter/route_test.go
+++ b/management/server/controlcenter/route_test.go
@@ -50,18 +50,28 @@ func routeAccount() *types.Account {
 			{
 				ID: "polPeer", Name: "clients-to-router", Enabled: true,
 				Rules: []*types.PolicyRule{{
-					ID: "rp", Enabled: true, Action: types.PolicyTrafficActionAccept,
+					ID: "rp", PolicyID: "polPeer", Enabled: true, Action: types.PolicyTrafficActionAccept,
 					Sources: []string{"gClients"}, Destinations: []string{"gRouter"},
 					Protocol: types.PolicyRuleProtocolALL,
 				}},
 			},
 			{
+				// Same policy + protocol, TWO rules (ports 80 and 443):
+				// the real firewall emits two RouteFirewallRules; both
+				// ports must survive into one merged edge (Finding 2).
 				ID: "P2", Name: "route2-access", Enabled: true,
-				Rules: []*types.PolicyRule{{
-					ID: "r2rule", Enabled: true, Action: types.PolicyTrafficActionAccept,
-					Sources: []string{"gClients"}, Destinations: []string{"gACL2"},
-					Protocol: types.PolicyRuleProtocolALL,
-				}},
+				Rules: []*types.PolicyRule{
+					{
+						ID: "r2a", PolicyID: "P2", Enabled: true, Action: types.PolicyTrafficActionAccept,
+						Sources: []string{"gClients"}, Destinations: []string{"gACL2"},
+						Protocol: types.PolicyRuleProtocolTCP, Ports: []string{"80"},
+					},
+					{
+						ID: "r2b", PolicyID: "P2", Enabled: true, Action: types.PolicyTrafficActionAccept,
+						Sources: []string{"gClients"}, Destinations: []string{"gACL2"},
+						Protocol: types.PolicyRuleProtocolTCP, Ports: []string{"443"},
+					},
+				},
 			},
 		},
 	}
@@ -92,12 +102,18 @@ func TestBuildGraph_RouteReach_CompositionAndDefaultPermit(t *testing.T) {
 	require.Equal(t, DirectionOut, e1.Direction)
 	require.Contains(t, g.Nodes, Node{ID: "route:r1", Kind: NodeRoute, Label: "10.10.0.0/24"})
 
-	// r2: permitted via policy P2.
+	// r2: permitted via policy P2, built from the REAL route firewall
+	// rules — both ports (80 and 443) must survive into one edge, and
+	// the effective SourceRanges must be populated (Finding 2).
 	e2 := edgeTo(g, "route:r2")
 	require.NotNil(t, e2, "policy-permitted route must be reachable")
 	require.Equal(t, PermitPolicy, e2.PermitSource)
 	require.Equal(t, "P2", e2.PolicyID)
+	require.Equal(t, "route2-access", e2.PolicyName)
 	require.Equal(t, EdgeEnforced, e2.State)
+	require.ElementsMatch(t, []string{"80", "443"}, e2.Ports,
+		"both rules' ports must merge, not be dropped by dedup")
+	require.NotEmpty(t, e2.SourceRanges, "effective SourceRanges must come from the firewall rule")
 
 	// r3: distributed to pA but NO permitting policy => NOT reachable.
 	require.Nil(t, edgeTo(g, "route:r3"), "synced-but-unpermitted route must NOT be an edge")

--- a/management/server/controlcenter/route_test.go
+++ b/management/server/controlcenter/route_test.go
@@ -127,3 +127,20 @@ func nodeIDs(g *GraphDTO) []string {
 	}
 	return ids
 }
+
+// #50-r2 semantic note: when the focus IS the router serving a route
+// (even one with AccessControlGroups), the edge is router_local —
+// honest infrastructure-local reach, NOT route_default_permit.
+func TestBuildGraph_SelfRouter_RouterLocalPermitSource(t *testing.T) {
+	acc := routeAccount() // pR serves r1 (no ACG) and r2 (ACG gACL2)
+	validated := map[string]struct{}{"pA": {}, "pR": {}}
+
+	g, err := BuildGraph(context.Background(), acc, Focus{Type: FocusPeer, ID: "pR"}, validated)
+	require.NoError(t, err)
+
+	e2 := edgeTo(g, "route:r2") // r2 has AccessControlGroups
+	require.NotNil(t, e2, "the router reaches the network it serves")
+	require.Equal(t, PermitRouterLocal, e2.PermitSource,
+		"self-router reach must be router_local, not route_default_permit")
+	require.Empty(t, e2.PolicyID)
+}

--- a/management/server/controlcenter/route_test.go
+++ b/management/server/controlcenter/route_test.go
@@ -1,0 +1,113 @@
+package controlcenter
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	nbpeer "github.com/openzro/openzro/management/server/peer"
+	"github.com/openzro/openzro/management/server/types"
+	"github.com/openzro/openzro/route"
+)
+
+// C4 / ADR-0017 D1.1: a route edge is the COMPOSITION of distribution
+// (GetRoutesToSync) and permission. A route synced to the focus but
+// not permitted is NOT drawn reachable (the route_test.go:1934
+// invariant). No AccessControlGroups => route_default_permit, no chip.
+
+func routeAccount() *types.Account {
+	pA := &nbpeer.Peer{ID: "pA", IP: net.IP{10, 0, 0, 1}, Key: "kA", Name: "alice"}
+	pR := &nbpeer.Peer{ID: "pR", IP: net.IP{10, 0, 0, 9}, Key: "kR", Name: "router"}
+	mk := func(id, cidr string, acg []string) *route.Route {
+		return &route.Route{
+			ID:                  route.ID(id),
+			Network:             netip.MustParsePrefix(cidr),
+			Peer:                "pR",
+			Groups:              []string{"gClients"},
+			Enabled:             true,
+			AccessControlGroups: acg,
+		}
+	}
+	return &types.Account{
+		Id:    "acc1",
+		Peers: map[string]*nbpeer.Peer{"pA": pA, "pR": pR},
+		Groups: map[string]*types.Group{
+			"all":      {ID: "all", Name: "All", Peers: []string{"pA", "pR"}},
+			"gClients": {ID: "gClients", Name: "clients", Peers: []string{"pA"}},
+			"gRouter":  {ID: "gRouter", Name: "routers", Peers: []string{"pR"}},
+			"gACL2":    {ID: "gACL2", Name: "acl2", Peers: []string{}},
+			"gACL3":    {ID: "gACL3", Name: "acl3", Peers: []string{}},
+		},
+		Routes: map[route.ID]*route.Route{
+			"r1": mk("r1", "10.10.0.0/24", nil),               // default permit
+			"r2": mk("r2", "10.20.0.0/24", []string{"gACL2"}), // permitted via P2
+			"r3": mk("r3", "10.30.0.0/24", []string{"gACL3"}), // distributed, NOT permitted
+		},
+		Policies: []*types.Policy{
+			{
+				ID: "polPeer", Name: "clients-to-router", Enabled: true,
+				Rules: []*types.PolicyRule{{
+					ID: "rp", Enabled: true, Action: types.PolicyTrafficActionAccept,
+					Sources: []string{"gClients"}, Destinations: []string{"gRouter"},
+					Protocol: types.PolicyRuleProtocolALL,
+				}},
+			},
+			{
+				ID: "P2", Name: "route2-access", Enabled: true,
+				Rules: []*types.PolicyRule{{
+					ID: "r2rule", Enabled: true, Action: types.PolicyTrafficActionAccept,
+					Sources: []string{"gClients"}, Destinations: []string{"gACL2"},
+					Protocol: types.PolicyRuleProtocolALL,
+				}},
+			},
+		},
+	}
+}
+
+func edgeTo(g *GraphDTO, to string) *Edge {
+	for i := range g.Edges {
+		if g.Edges[i].To == to {
+			return &g.Edges[i]
+		}
+	}
+	return nil
+}
+
+func TestBuildGraph_RouteReach_CompositionAndDefaultPermit(t *testing.T) {
+	acc := routeAccount()
+	validated := map[string]struct{}{"pA": {}, "pR": {}}
+
+	g, err := BuildGraph(context.Background(), acc, Focus{Type: FocusPeer, ID: "pA"}, validated)
+	require.NoError(t, err)
+
+	// r1: no AccessControlGroups => route_default_permit, no policy chip.
+	e1 := edgeTo(g, "route:r1")
+	require.NotNil(t, e1, "default-permit route must be reachable")
+	require.Equal(t, PermitRouteDefault, e1.PermitSource)
+	require.Empty(t, e1.PolicyID)
+	require.Equal(t, EdgeEnforced, e1.State)
+	require.Equal(t, DirectionOut, e1.Direction)
+	require.Contains(t, g.Nodes, Node{ID: "route:r1", Kind: NodeRoute, Label: "10.10.0.0/24"})
+
+	// r2: permitted via policy P2.
+	e2 := edgeTo(g, "route:r2")
+	require.NotNil(t, e2, "policy-permitted route must be reachable")
+	require.Equal(t, PermitPolicy, e2.PermitSource)
+	require.Equal(t, "P2", e2.PolicyID)
+	require.Equal(t, EdgeEnforced, e2.State)
+
+	// r3: distributed to pA but NO permitting policy => NOT reachable.
+	require.Nil(t, edgeTo(g, "route:r3"), "synced-but-unpermitted route must NOT be an edge")
+	require.NotContains(t, nodeIDs(g), "route:r3", "unpermitted route must not be an orphan node")
+}
+
+func nodeIDs(g *GraphDTO) []string {
+	ids := make([]string, 0, len(g.Nodes))
+	for _, n := range g.Nodes {
+		ids = append(ids, n.ID)
+	}
+	return ids
+}

--- a/management/server/http/handler.go
+++ b/management/server/http/handler.go
@@ -26,6 +26,7 @@ import (
 	activityExportersHandler "github.com/openzro/openzro/management/server/http/handlers/activity_exporters"
 	admissionBypassHandler "github.com/openzro/openzro/management/server/http/handlers/admission_bypass"
 	authProvidersHandler "github.com/openzro/openzro/management/server/http/handlers/auth_providers"
+	controlCenterHandler "github.com/openzro/openzro/management/server/http/handlers/control_center"
 	"github.com/openzro/openzro/management/server/http/handlers/dns"
 	"github.com/openzro/openzro/management/server/http/handlers/events"
 	flowExportsHandler "github.com/openzro/openzro/management/server/http/handlers/flow_exports"
@@ -119,6 +120,7 @@ func NewAPIHandler(
 	networks.AddEndpoints(networksManager, resourceManager, routerManager, groupsManager, accountManager, router)
 	network_events.AddEndpoints(permissionsManager, flowEventsStore, router)
 	flowExportsHandler.AddEndpoints(permissionsManager, flowExportsStore, flowExportsManager, router)
+	controlCenterHandler.AddEndpoints(accountManager, permissionsManager, router)
 	mdmProvidersHandler.AddEndpoints(permissionsManager, mdmStore, mdmManager, router)
 	activityExportersHandler.AddEndpoints(permissionsManager, activityExportersStore, activityExportersManager, router)
 	admissionBypassHandler.AddEndpoints(permissionsManager, admissionBypassStore, accountManager, admissionBypassEmitter, router)

--- a/management/server/http/handlers/control_center/handler.go
+++ b/management/server/http/handlers/control_center/handler.go
@@ -12,6 +12,7 @@
 package control_center
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/gorilla/mux"
@@ -77,12 +78,16 @@ func (h *Handler) getGraph(w http.ResponseWriter, r *http.Request) {
 	// id outside that account simply does not resolve.
 	graph, err := h.accountManager.GetAccessGraph(r.Context(), userAuth.AccountId, view, vars["id"])
 	if err != nil {
-		if _, ok := status.FromError(err); ok {
+		switch {
+		case errors.Is(err, controlcenter.ErrFocusNotFound):
+			util.WriteErrorResponse(err.Error(), http.StatusNotFound, w)
+		case errors.Is(err, controlcenter.ErrUnsupportedFocus):
+			util.WriteErrorResponse(err.Error(), http.StatusBadRequest, w)
+		default:
+			// status errors map themselves; anything else is a real
+			// failure (500), NOT silently a 404 (Finding 5).
 			util.WriteError(r.Context(), err, w)
-			return
 		}
-		// adapter error (focus not found in this account) — 404.
-		util.WriteErrorResponse(err.Error(), http.StatusNotFound, w)
 		return
 	}
 

--- a/management/server/http/handlers/control_center/handler.go
+++ b/management/server/http/handlers/control_center/handler.go
@@ -1,0 +1,90 @@
+// Package control_center exposes the admin-only, read-only Control
+// Center access-graph API (openZro #39, ADR-0017 Phase 1):
+//
+//	GET /api/control-center/{view}/{id}   view ∈ {peer, group}
+//
+// The graph is derived server-side from the enforcement engine
+// (never re-derived client-side). The endpoint is gated to full
+// account admins — RBAC tightened from the ADR's "Admin /
+// Network-Admin" to admin-only (modules.Settings + operations.Update,
+// same posture as the flow-exports handler) per owner decision
+// 2026-05-17: the access graph is a sensitive audit surface.
+package control_center
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+
+	"github.com/openzro/openzro/management/server/account"
+	nbcontext "github.com/openzro/openzro/management/server/context"
+	"github.com/openzro/openzro/management/server/controlcenter"
+	"github.com/openzro/openzro/management/server/http/util"
+	"github.com/openzro/openzro/management/server/permissions"
+	"github.com/openzro/openzro/management/server/permissions/modules"
+	"github.com/openzro/openzro/management/server/permissions/operations"
+	"github.com/openzro/openzro/management/server/status"
+)
+
+// Handler is a thin adapter: it authenticates, enforces admin RBAC,
+// validates the view, and delegates to the manager. It makes no
+// access decisions of its own.
+type Handler struct {
+	accountManager account.Manager
+	permissions    permissions.Manager
+}
+
+func AddEndpoints(accountManager account.Manager, permissionsManager permissions.Manager, router *mux.Router) {
+	h := &Handler{accountManager: accountManager, permissions: permissionsManager}
+	router.HandleFunc("/control-center/{view}/{id}", h.getGraph).Methods(http.MethodGet, http.MethodOptions)
+}
+
+// requireAdmin blocks anyone without Update on the Settings module —
+// the same admin gate the flow-exports handler uses. The access graph
+// exposes the whole tenant's reachability and is admin-only.
+func (h *Handler) requireAdmin(r *http.Request, accountID, userID string) error {
+	allowed, err := h.permissions.ValidateUserPermissions(
+		r.Context(), accountID, userID, modules.Settings, operations.Update)
+	if err != nil {
+		return status.NewPermissionValidationError(err)
+	}
+	if !allowed {
+		return status.NewPermissionDeniedError()
+	}
+	return nil
+}
+
+func (h *Handler) getGraph(w http.ResponseWriter, r *http.Request) {
+	userAuth, err := nbcontext.GetUserAuthFromContext(r.Context())
+	if err != nil {
+		util.WriteError(r.Context(), err, w)
+		return
+	}
+	if err := h.requireAdmin(r, userAuth.AccountId, userAuth.UserId); err != nil {
+		util.WriteError(r.Context(), err, w)
+		return
+	}
+
+	vars := mux.Vars(r)
+	view := vars["view"]
+	if view != string(controlcenter.FocusPeer) && view != string(controlcenter.FocusGroup) {
+		util.WriteErrorResponse("unsupported view: must be 'peer' or 'group'", http.StatusBadRequest, w)
+		return
+	}
+
+	// accountID is the caller's authenticated account (NOT a path
+	// param), so a tenant can only ever query its own graph. A focus
+	// id outside that account simply does not resolve.
+	graph, err := h.accountManager.GetAccessGraph(r.Context(), userAuth.AccountId, view, vars["id"])
+	if err != nil {
+		if _, ok := status.FromError(err); ok {
+			util.WriteError(r.Context(), err, w)
+			return
+		}
+		// adapter error (focus not found in this account) — 404.
+		util.WriteErrorResponse(err.Error(), http.StatusNotFound, w)
+		return
+	}
+
+	util.WriteJSONObject(r.Context(), w, graph)
+}

--- a/management/server/http/handlers/control_center/handler_test.go
+++ b/management/server/http/handlers/control_center/handler_test.go
@@ -1,0 +1,106 @@
+package control_center
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+
+	nbcontext "github.com/openzro/openzro/management/server/context"
+	"github.com/openzro/openzro/management/server/controlcenter"
+	"github.com/openzro/openzro/management/server/mock_server"
+	"github.com/openzro/openzro/management/server/permissions"
+)
+
+func newFixture(t *testing.T, allowAdmin bool, graphFn func(ctx context.Context, accountID, view, focusID string) (*controlcenter.GraphDTO, error)) *mux.Router {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	perms := permissions.NewMockManager(ctrl)
+	perms.EXPECT().
+		ValidateUserPermissions(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(allowAdmin, nil).
+		AnyTimes()
+
+	am := &mock_server.MockAccountManager{GetAccessGraphFunc: graphFn}
+
+	r := mux.NewRouter()
+	AddEndpoints(am, perms, r)
+	return r
+}
+
+func withAuth(req *http.Request) *http.Request {
+	return nbcontext.SetUserAuthInRequest(req, nbcontext.UserAuth{
+		AccountId: "acct1", UserId: "u1",
+	})
+}
+
+func TestControlCenter_HappyPath(t *testing.T) {
+	var gotAccount, gotView, gotID string
+	r := newFixture(t, true, func(_ context.Context, accountID, view, focusID string) (*controlcenter.GraphDTO, error) {
+		gotAccount, gotView, gotID = accountID, view, focusID
+		return &controlcenter.GraphDTO{
+			Focus: controlcenter.Focus{Type: controlcenter.FocusPeer, ID: "p1"},
+			Nodes: []controlcenter.Node{{ID: "p1", Kind: controlcenter.NodeFocus, Label: "alice"}},
+		}, nil
+	})
+
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, withAuth(httptest.NewRequest(http.MethodGet, "/control-center/peer/p1", nil)))
+
+	require.Equal(t, http.StatusOK, rr.Code)
+	// accountID is the caller's auth account, not a path param (tenant scoping).
+	require.Equal(t, "acct1", gotAccount)
+	require.Equal(t, "peer", gotView)
+	require.Equal(t, "p1", gotID)
+
+	var g controlcenter.GraphDTO
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &g))
+	require.Equal(t, controlcenter.FocusPeer, g.Focus.Type)
+}
+
+func TestControlCenter_ForbiddenWhenNotAdmin(t *testing.T) {
+	r := newFixture(t, false, func(context.Context, string, string, string) (*controlcenter.GraphDTO, error) {
+		t.Fatal("manager must not be reached when RBAC denies")
+		return nil, nil
+	})
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, withAuth(httptest.NewRequest(http.MethodGet, "/control-center/peer/p1", nil)))
+	require.Equal(t, http.StatusForbidden, rr.Code)
+}
+
+func TestControlCenter_BadView(t *testing.T) {
+	r := newFixture(t, true, func(context.Context, string, string, string) (*controlcenter.GraphDTO, error) {
+		t.Fatal("manager must not be reached for an invalid view")
+		return nil, nil
+	})
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, withAuth(httptest.NewRequest(http.MethodGet, "/control-center/bogus/x", nil)))
+	require.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+func TestControlCenter_UnknownFocusIs404(t *testing.T) {
+	r := newFixture(t, true, func(context.Context, string, string, string) (*controlcenter.GraphDTO, error) {
+		return nil, fmt.Errorf("focus peer %q not found", "ghost")
+	})
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, withAuth(httptest.NewRequest(http.MethodGet, "/control-center/peer/ghost", nil)))
+	require.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+func TestControlCenter_Unauthenticated(t *testing.T) {
+	r := newFixture(t, true, func(context.Context, string, string, string) (*controlcenter.GraphDTO, error) {
+		return nil, nil
+	})
+	rr := httptest.NewRecorder()
+	// no withAuth → no UserAuth in context.
+	r.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/control-center/peer/p1", nil))
+	require.NotEqual(t, http.StatusOK, rr.Code)
+}

--- a/management/server/http/handlers/control_center/handler_test.go
+++ b/management/server/http/handlers/control_center/handler_test.go
@@ -88,11 +88,23 @@ func TestControlCenter_BadView(t *testing.T) {
 
 func TestControlCenter_UnknownFocusIs404(t *testing.T) {
 	r := newFixture(t, true, func(context.Context, string, string, string) (*controlcenter.GraphDTO, error) {
-		return nil, fmt.Errorf("focus peer %q not found", "ghost")
+		return nil, fmt.Errorf("focus peer %q: %w", "ghost", controlcenter.ErrFocusNotFound)
 	})
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, withAuth(httptest.NewRequest(http.MethodGet, "/control-center/peer/ghost", nil)))
 	require.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+// Finding 5: a generic (non-typed, non-status) error must NOT be
+// silently reported as 404 — that trap is now closed.
+func TestControlCenter_GenericErrorIsNot404(t *testing.T) {
+	r := newFixture(t, true, func(context.Context, string, string, string) (*controlcenter.GraphDTO, error) {
+		return nil, fmt.Errorf("database exploded")
+	})
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, withAuth(httptest.NewRequest(http.MethodGet, "/control-center/peer/p1", nil)))
+	require.NotEqual(t, http.StatusNotFound, rr.Code)
+	require.GreaterOrEqual(t, rr.Code, 500)
 }
 
 func TestControlCenter_Unauthenticated(t *testing.T) {

--- a/management/server/mock_server/account_mock.go
+++ b/management/server/mock_server/account_mock.go
@@ -14,6 +14,7 @@ import (
 	"github.com/openzro/openzro/management/server/account"
 	"github.com/openzro/openzro/management/server/activity"
 	nbcontext "github.com/openzro/openzro/management/server/context"
+	"github.com/openzro/openzro/management/server/controlcenter"
 	"github.com/openzro/openzro/management/server/idp"
 	nbpeer "github.com/openzro/openzro/management/server/peer"
 	"github.com/openzro/openzro/management/server/posture"
@@ -30,34 +31,35 @@ type MockAccountManager struct {
 	GetAccountFunc               func(ctx context.Context, accountID string) (*types.Account, error)
 	CreateSetupKeyFunc           func(ctx context.Context, accountId string, keyName string, keyType types.SetupKeyType,
 		expiresIn time.Duration, autoGroups []string, usageLimit int, userID string, ephemeral bool, allowExtraDNSLabels bool) (*types.SetupKey, error)
-	GetSetupKeyFunc                       func(ctx context.Context, accountID, userID, keyID string) (*types.SetupKey, error)
-	AccountExistsFunc                     func(ctx context.Context, accountID string) (bool, error)
-	GetAccountIDByUserIdFunc              func(ctx context.Context, userId, domain string) (string, error)
-	GetUserFromUserAuthFunc               func(ctx context.Context, userAuth nbcontext.UserAuth) (*types.User, error)
-	ListUsersFunc                         func(ctx context.Context, accountID string) ([]*types.User, error)
-	GetPeersFunc                          func(ctx context.Context, accountID, userID, nameFilter, ipFilter string) ([]*nbpeer.Peer, error)
-	MarkPeerConnectedFunc                 func(ctx context.Context, peerKey string, connected bool, realIP net.IP, streamID string) error
-	SyncAndMarkPeerFunc                   func(ctx context.Context, accountID string, peerPubKey string, meta nbpeer.PeerSystemMeta, realIP net.IP, streamID string) (*nbpeer.Peer, *types.NetworkMap, []*posture.Checks, error)
-	DeletePeerFunc                        func(ctx context.Context, accountID, peerKey, userID string) error
-	GetNetworkMapFunc                     func(ctx context.Context, peerKey string) (*types.NetworkMap, error)
-	GetPeerNetworkFunc                    func(ctx context.Context, peerKey string) (*types.Network, error)
-	AddPeerFunc                           func(ctx context.Context, setupKey string, userId string, peer *nbpeer.Peer) (*nbpeer.Peer, *types.NetworkMap, []*posture.Checks, error)
-	GetGroupFunc                          func(ctx context.Context, accountID, groupID, userID string) (*types.Group, error)
-	GetAllGroupsFunc                      func(ctx context.Context, accountID, userID string) ([]*types.Group, error)
-	GetGroupByNameFunc                    func(ctx context.Context, accountID, groupName string) (*types.Group, error)
-	SaveGroupFunc                         func(ctx context.Context, accountID, userID string, group *types.Group, create bool) error
-	SaveGroupsFunc                        func(ctx context.Context, accountID, userID string, groups []*types.Group, create bool) error
-	DeleteGroupFunc                       func(ctx context.Context, accountID, userId, groupID string) error
-	DeleteGroupsFunc                      func(ctx context.Context, accountId, userId string, groupIDs []string) error
-	GroupAddPeerFunc                      func(ctx context.Context, accountID, groupID, peerID string) error
-	GroupDeletePeerFunc                   func(ctx context.Context, accountID, groupID, peerID string) error
-	GetPeerGroupsFunc                     func(ctx context.Context, accountID, peerID string) ([]*types.Group, error)
-	DeleteRuleFunc                        func(ctx context.Context, accountID, ruleID, userID string) error
-	GetPolicyFunc                         func(ctx context.Context, accountID, policyID, userID string) (*types.Policy, error)
-	SavePolicyFunc                        func(ctx context.Context, accountID, userID string, policy *types.Policy, create bool) (*types.Policy, error)
-	DeletePolicyFunc                      func(ctx context.Context, accountID, policyID, userID string) error
-	ListPoliciesFunc                      func(ctx context.Context, accountID, userID string) ([]*types.Policy, error)
-	GetUsersFromAccountFunc               func(ctx context.Context, accountID, userID string) (map[string]*types.UserInfo, error)
+	GetSetupKeyFunc          func(ctx context.Context, accountID, userID, keyID string) (*types.SetupKey, error)
+	AccountExistsFunc        func(ctx context.Context, accountID string) (bool, error)
+	GetAccountIDByUserIdFunc func(ctx context.Context, userId, domain string) (string, error)
+	GetUserFromUserAuthFunc  func(ctx context.Context, userAuth nbcontext.UserAuth) (*types.User, error)
+	ListUsersFunc            func(ctx context.Context, accountID string) ([]*types.User, error)
+	GetPeersFunc             func(ctx context.Context, accountID, userID, nameFilter, ipFilter string) ([]*nbpeer.Peer, error)
+	MarkPeerConnectedFunc    func(ctx context.Context, peerKey string, connected bool, realIP net.IP, streamID string) error
+	SyncAndMarkPeerFunc      func(ctx context.Context, accountID string, peerPubKey string, meta nbpeer.PeerSystemMeta, realIP net.IP, streamID string) (*nbpeer.Peer, *types.NetworkMap, []*posture.Checks, error)
+	DeletePeerFunc           func(ctx context.Context, accountID, peerKey, userID string) error
+	GetNetworkMapFunc        func(ctx context.Context, peerKey string) (*types.NetworkMap, error)
+	GetAccessGraphFunc       func(ctx context.Context, accountID, view, focusID string) (*controlcenter.GraphDTO, error)
+	GetPeerNetworkFunc       func(ctx context.Context, peerKey string) (*types.Network, error)
+	AddPeerFunc              func(ctx context.Context, setupKey string, userId string, peer *nbpeer.Peer) (*nbpeer.Peer, *types.NetworkMap, []*posture.Checks, error)
+	GetGroupFunc             func(ctx context.Context, accountID, groupID, userID string) (*types.Group, error)
+	GetAllGroupsFunc         func(ctx context.Context, accountID, userID string) ([]*types.Group, error)
+	GetGroupByNameFunc       func(ctx context.Context, accountID, groupName string) (*types.Group, error)
+	SaveGroupFunc            func(ctx context.Context, accountID, userID string, group *types.Group, create bool) error
+	SaveGroupsFunc           func(ctx context.Context, accountID, userID string, groups []*types.Group, create bool) error
+	DeleteGroupFunc          func(ctx context.Context, accountID, userId, groupID string) error
+	DeleteGroupsFunc         func(ctx context.Context, accountId, userId string, groupIDs []string) error
+	GroupAddPeerFunc         func(ctx context.Context, accountID, groupID, peerID string) error
+	GroupDeletePeerFunc      func(ctx context.Context, accountID, groupID, peerID string) error
+	GetPeerGroupsFunc        func(ctx context.Context, accountID, peerID string) ([]*types.Group, error)
+	DeleteRuleFunc           func(ctx context.Context, accountID, ruleID, userID string) error
+	GetPolicyFunc            func(ctx context.Context, accountID, policyID, userID string) (*types.Policy, error)
+	SavePolicyFunc           func(ctx context.Context, accountID, userID string, policy *types.Policy, create bool) (*types.Policy, error)
+	DeletePolicyFunc         func(ctx context.Context, accountID, policyID, userID string) error
+	ListPoliciesFunc         func(ctx context.Context, accountID, userID string) ([]*types.Policy, error)
+	GetUsersFromAccountFunc  func(ctx context.Context, accountID, userID string) (map[string]*types.UserInfo, error)
 
 	SCIMCreateUserFunc     func(ctx context.Context, accountID, callerID string, input account.SCIMUserInput) (*types.User, error)
 	SCIMReplaceUserFunc    func(ctx context.Context, accountID, callerID, userID string, input account.SCIMUserInput) (*types.User, error)
@@ -66,14 +68,14 @@ type MockAccountManager struct {
 	SCIMListUsersFunc      func(ctx context.Context, accountID, callerID, userNameFilter string, startIndex, count int) ([]*types.User, int, error)
 	SCIMGetUserFunc        func(ctx context.Context, accountID, callerID, userID string) (*types.User, error)
 
-	SCIMCreateGroupFunc       func(ctx context.Context, accountID, callerID, displayName string, memberUserIDs []string) (*types.Group, error)
-	SCIMReplaceGroupFunc      func(ctx context.Context, accountID, callerID, groupID, displayName string, memberUserIDs []string) (*types.Group, error)
-	SCIMRenameGroupFunc       func(ctx context.Context, accountID, callerID, groupID, newName string) (*types.Group, error)
-	SCIMAddGroupMemberFunc    func(ctx context.Context, accountID, callerID, groupID, userID string) error
-	SCIMRemoveGroupMemberFunc func(ctx context.Context, accountID, callerID, groupID, userID string) error
-	SCIMDeleteGroupFunc       func(ctx context.Context, accountID, callerID, groupID string) error
-	SCIMListGroupsFunc        func(ctx context.Context, accountID, callerID, displayNameFilter string, startIndex, count int) ([]*types.Group, int, error)
-	SCIMGetGroupFunc          func(ctx context.Context, accountID, callerID, groupID string) (*types.Group, []string, error)
+	SCIMCreateGroupFunc                   func(ctx context.Context, accountID, callerID, displayName string, memberUserIDs []string) (*types.Group, error)
+	SCIMReplaceGroupFunc                  func(ctx context.Context, accountID, callerID, groupID, displayName string, memberUserIDs []string) (*types.Group, error)
+	SCIMRenameGroupFunc                   func(ctx context.Context, accountID, callerID, groupID, newName string) (*types.Group, error)
+	SCIMAddGroupMemberFunc                func(ctx context.Context, accountID, callerID, groupID, userID string) error
+	SCIMRemoveGroupMemberFunc             func(ctx context.Context, accountID, callerID, groupID, userID string) error
+	SCIMDeleteGroupFunc                   func(ctx context.Context, accountID, callerID, groupID string) error
+	SCIMListGroupsFunc                    func(ctx context.Context, accountID, callerID, displayNameFilter string, startIndex, count int) ([]*types.Group, int, error)
+	SCIMGetGroupFunc                      func(ctx context.Context, accountID, callerID, groupID string) (*types.Group, []string, error)
 	UpdatePeerMetaFunc                    func(ctx context.Context, peerID string, meta nbpeer.PeerSystemMeta) error
 	UpdatePeerFunc                        func(ctx context.Context, accountID, userID string, peer *nbpeer.Peer) (*nbpeer.Peer, error)
 	CreateRouteFunc                       func(ctx context.Context, accountID string, prefix netip.Prefix, networkType route.NetworkType, domains domain.List, peer string, peerGroups []string, description string, netID route.NetID, masquerade bool, metric int, groups, accessControlGroupIDs []string, enabled bool, userID string, keepRoute bool) (*route.Route, error)
@@ -419,6 +421,14 @@ func (am *MockAccountManager) GetNetworkMap(ctx context.Context, peerKey string)
 		return am.GetNetworkMapFunc(ctx, peerKey)
 	}
 	return nil, status.Errorf(codes.Unimplemented, "method GetNetworkMap is not implemented")
+}
+
+// GetAccessGraph mock implementation of GetAccessGraph from server.AccountManager interface
+func (am *MockAccountManager) GetAccessGraph(ctx context.Context, accountID, view, focusID string) (*controlcenter.GraphDTO, error) {
+	if am.GetAccessGraphFunc != nil {
+		return am.GetAccessGraphFunc(ctx, accountID, view, focusID)
+	}
+	return nil, status.Errorf(codes.Unimplemented, "method GetAccessGraph is not implemented")
 }
 
 // GetPeerNetwork mock implementation of GetPeerNetwork from server.AccountManager interface


### PR DESCRIPTION
## Summary

Phase 1 of #39 / ADR-0017: the **read-only, server-side** access-graph
backend. 8 granular TDD commits; pure adapter (C1–C5) + integration
(C6–C8). No dashboard yet (Phase 2). Every commit: test-first,
`gofmt`/`go vet`/`go build ./...`/`-race` green, clean-room attested
(designed against openZro's own enforcement engine + ADR-0017; no
upstream NetBird `management/` consulted or ported).

| C | Commit | What |
|---|--------|------|
| C1 | `0e1e8c73` | DTO envelope + ADR-pinned enums |
| C2 | `cf7ff214` | peer↔peer reach via `GetPeerConnectionResources` |
| C3 | `2ce9f339` | D1.2 posture-blocked pass (reuses `EvaluateAdmission` to name the failing check) |
| C4 | `2161a9e2` | D1.1 route reach = **distribution ∩ permission** (synced ≠ reachable; `route_default_permit` no chip) |
| C5 | `940eaa66` | group focus = **union** + "k of n members" + per-member posture |
| C6 | `127263e9` | manager seam `GetAccessGraph` + `account.Manager` iface + mock |
| C7 | `2e6fcd18` | `GET /api/control-center/{view}/{id}` + admin RBAC + route reg |
| C8 | `a10ca8db` | wire-contract pin test |

## Two deliberate deviations (flagged for review)

1. **RBAC tightened.** ADR-0017 says "Admin / Network-Admin"; per your
   2026-05-17 decision the endpoint is **admin-only** (`modules.Settings`
   + `operations.Update`, same gate as `flow_exports`) — the access
   graph is a sensitive audit surface. Documented in the handler
   package doc + C7 commit.
2. **OpenAPI spec-omitted.** ADR phase plan said "openapi.yml + regen
   via generate.sh". This codebase already omits its admin endpoints
   from `openapi.yml` (`flow_exports`/`network_events`/`events` are all
   code-registered but absent from the spec + its 2140-line
   `types.gen.go`). Matching that precedent and avoiding a full
   regeneration of a large generated file, the endpoint is likewise
   spec-omitted; its wire shape is pinned by C8's contract test
   instead. (C8 commit explains.)

## Design notes

- **D1.1 is a composition, not either pole.** A route synced to a peer
  is *not* proof its traffic is permitted; route edges = distribution
  (`GetRoutesToSync`) ∩ router-side permission
  (`GetPeerRoutesFirewallRules`/`getDefaultPermit`). The
  `route_test.go:1934` "synced ≠ reachable" invariant is pinned in C4's
  test.
- **D1.2 annotates, never re-decides.** The posture pass reuses the
  same posture evaluation; bool helper for the binary `posture_blocked`
  state, `AdmissionDenial`-shaped structured eval to name the failing
  check. No parallel policy walker.
- Tenant scoping is structural: `accountID` is the caller's
  authenticated account, never a path param.

## Test plan

- [ ] `go build ./...` green (run in CI; verified locally).
- [ ] `go test -race ./management/server/controlcenter/ ./management/server/http/handlers/control_center/` green.
- [ ] `go test ./management/server/ -run TestGetAccessGraph_ManagerSeam` green.
- [ ] Reviewer sanity-checks the D1.1 composition + D1.2 reuse against `management/server/types/account.go` line refs in the ADR.

Refs #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)