### PR TITLE
feat: Control Center Phase 3 — functional polish (#39)

### DIFF
--- a/dashboard/src/modules/control-center/ControlCenterGraphCanvas.tsx
+++ b/dashboard/src/modules/control-center/ControlCenterGraphCanvas.tsx
@@ -43,7 +43,15 @@ function edgeLabel(e: ControlCenterEdge): string {
     e.permitSource === "policy"
       ? e.policyName || "policy"
       : e.permitSource;
-  const proto = e.protocol && e.protocol !== "all" ? ` · ${e.protocol}` : "";
+  // protocol/ports on the edge (ADR-0017 Phase 3): e.g. "tcp/22,443",
+  // "tcp", "22,443", or nothing for an all-protocol no-port rule.
+  const protoPorts = [
+    e.protocol && e.protocol !== "all" ? e.protocol : "",
+    e.ports && e.ports.length ? e.ports.join(",") : "",
+  ]
+    .filter(Boolean)
+    .join("/");
+  const proto = protoPorts ? ` · ${protoPorts}` : "";
   const blocked = e.state === "posture_blocked" ? " · blocked" : "";
   return `${src}${proto}${blocked}`;
 }
@@ -66,15 +74,18 @@ function layout(graph: ControlCenterGraph): {
 
   const nodes: Node[] = graph.nodes.map((n) => {
     const p = g.node(n.id);
+    // peer/group target nodes are valid v1 foci → clicking one
+    // re-centres the graph on it (Phase 3). Cue it with a pointer.
+    const switchable = n.kind === "peer" || n.kind === "group";
     return {
       id: n.id,
       position: { x: (p?.x ?? 0) - NODE_W / 2, y: (p?.y ?? 0) - NODE_H / 2 },
-      data: { label: n.label || n.id },
+      data: { label: n.label || n.id, kind: n.kind },
       sourcePosition: Position.Right,
       targetPosition: Position.Left,
       className: `rounded-oz2-input border px-3 py-2 text-xs ${
         KIND_CLASS[n.kind] ?? KIND_CLASS.peer
-      }`,
+      }${switchable ? " cursor-pointer" : ""}`,
       width: NODE_W,
       height: NODE_H,
     };
@@ -173,9 +184,11 @@ function ParallelEdge({
 export default function ControlCenterGraphCanvas({
   graph,
   onEdgeClick,
+  onFocusNode,
 }: {
   graph: ControlCenterGraph;
   onEdgeClick?: (policyId: string) => void;
+  onFocusNode?: (view: "peer" | "group", id: string) => void;
 }) {
   const { nodes, edges } = useMemo(() => layout(graph), [graph]);
   const edgeTypes = useMemo(() => ({ parallel: ParallelEdge }), []);
@@ -191,6 +204,14 @@ export default function ControlCenterGraphCanvas({
         nodesConnectable={false}
         edgesFocusable={!!onEdgeClick}
         proOptions={{ hideAttribution: true }}
+        onNodeClick={(_, node) => {
+          const kind = (node.data as { kind?: string } | undefined)?.kind;
+          // Only peer/group nodes are valid v1 foci; clicking the
+          // current focus or a route/resource/policy node is a no-op.
+          if (onFocusNode && (kind === "peer" || kind === "group")) {
+            onFocusNode(kind, node.id);
+          }
+        }}
         onEdgeClick={(_, edge) => {
           const pid = (edge.data as { policyId?: string } | undefined)
             ?.policyId;

--- a/dashboard/src/modules/control-center/ControlCenterView.tsx
+++ b/dashboard/src/modules/control-center/ControlCenterView.tsx
@@ -81,6 +81,15 @@ export default function ControlCenterView() {
     syncUrl(view, f);
   };
 
+  // Click-to-switch-focus (Phase 3): clicking a peer/group node in the
+  // graph re-centres on it (URL synced → graph refetches on the new
+  // focus, same path as the selector).
+  const onFocusNode = (v: FocusType, id: string) => {
+    setView(v);
+    setFocusId(id);
+    syncUrl(v, id);
+  };
+
   return (
     <div className="flex h-full flex-col gap-4 p-6">
       <div>
@@ -122,6 +131,7 @@ export default function ControlCenterView() {
         focusId={focusId}
         isLoading={isLoading}
         graph={graph}
+        onFocusNode={onFocusNode}
         onPolicyOpen={(policyId) => {
           // Round-trip (F1): tell the editor to return to THIS focus,
           // not the access-control list, so the audit loop closes.
@@ -144,12 +154,14 @@ function ControlCenterBody({
   focusId,
   isLoading,
   graph,
+  onFocusNode,
   onPolicyOpen,
 }: {
   view: FocusType;
   focusId: string;
   isLoading: boolean;
   graph?: ControlCenterGraph;
+  onFocusNode: (v: FocusType, id: string) => void;
   onPolicyOpen: (policyId: string) => void;
 }) {
   if (focusId === "") {
@@ -199,7 +211,11 @@ function ControlCenterBody({
   // kept as the accessible / no-graph fallback in a <details>.
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-3">
-      <ControlCenterGraphCanvas graph={graph} onEdgeClick={onPolicyOpen} />
+      <ControlCenterGraphCanvas
+        graph={graph}
+        onEdgeClick={onPolicyOpen}
+        onFocusNode={onFocusNode}
+      />
       <details className="text-sm text-oz2-text-muted">
         <summary className="cursor-pointer select-none">
           Reachable, as a list ({graph.edges.length})


### PR DESCRIPTION
## Summary

Phase 3 of #39 / ADR-0017 — the **functional** polish. 1 commit off `main` (which has Phase 1 backend + Phase 2 dashboard). Owner authorizes merge (as #48/#49/#50/#51).

Per owner scoping (2026-05-18): Phase 3 = functional polish only. **Cypress E2E is explicitly deferred** to its own dashboard test-infra initiative — filed as #52 (the repo has spec files but no OIDC mock / no `cypress:run` / no CI lane; building that harness is far larger than #39 and arguably its own ADR). The **visual/aesthetic pass is a separate later discussion** (owner: functionally approved but "visual ainda está muito feio") — not in this PR.

| Item | What |
|---|---|
| Click-to-switch-focus | Peer/group target nodes carry their `kind` + a pointer cue; clicking one re-centres the graph on it via the same URL-synced path as the selector (refetch on the new focus). Focus / route / network_resource / policy nodes are no-ops (not valid v1 foci). |
| Port/protocol edge labels | `edgeLabel` now folds `e.ports[]` in with the protocol (`tcp/22,443`, `tcp`, `22,443`, or nothing for an all-protocol no-port rule) — the DTO already carries them. |

## Verification

- `next lint` clean; clean `next build` exit 0 — `/control-center` 74.1 kB / 319 kB, shared unchanged 103 kB.
- A first build hit the known flaky `.next` page-data race on an unrelated `/team/*` route (Codex saw it too); gone on clean rebuild.
- **Build-verified, not browser-verified** (no Cypress harness — #52). Manual QA path below.

## Test plan

- [ ] CI `next build` green.
- [ ] Manual: admin on `/control-center`, pick a focus, click a peer/group node → graph re-centres on it (URL `?view=&focus=` updates, graph refetches).
- [ ] Manual: edges show protocol/ports; `posture_blocked` distinct; policy-edge → editor round-trip returns to the same focus.
- [ ] #52: Cypress harness + E2E (separate initiative).

## Follow-ups

- #52 — dashboard E2E test-infra (Cypress OIDC-bypass + intercept harness + CI lane).
- Visual/aesthetic pass — separate owner-led discussion (post-Phase-3).
- v2 scope (Users + inverse-Networks focus) — per ADR-0017 D3.

Refs #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)
