### PR TITLE
feat(controlcenter): peer node meta.ip for visual pass (#39)

### DIFF
--- a/management/server/controlcenter/build.go
+++ b/management/server/controlcenter/build.go
@@ -35,7 +35,7 @@ func buildPeerFocus(ctx context.Context, acc *types.Account, focus Focus, valida
 
 	g := &GraphDTO{Focus: focus}
 	b := newGraphBuilder(g)
-	b.addNode(focusPeer.ID, NodeFocus, peerLabel(focusPeer))
+	b.addPeerNode(focusPeer, NodeFocus)
 
 	// Mirror the dataplane: GetPeerNetworkMap early-returns an empty
 	// map when the focus is not validated (account.go:262). An
@@ -75,6 +75,22 @@ func (b *graphBuilder) addNode(id string, kind NodeKind, label string) {
 	b.nodes[id] = Node{ID: id, Kind: kind, Label: label}
 }
 
+// addPeerNode is addNode for a peer (focus or reachable): it also
+// carries the peer IP in meta so the dashboard can show it as the
+// node's secondary line (route/network_resource already expose their
+// CIDR via the label). meta is the existing freeform node field — an
+// additive, non-breaking contract use.
+func (b *graphBuilder) addPeerNode(p *nbpeer.Peer, kind NodeKind) {
+	if _, ok := b.nodes[p.ID]; ok {
+		return
+	}
+	n := Node{ID: p.ID, Kind: kind, Label: peerLabel(p)}
+	if ip := p.IP.String(); ip != "" && ip != "<nil>" {
+		n.Meta = map[string]string{"ip": ip}
+	}
+	b.nodes[p.ID] = n
+}
+
 // addPeerReach turns the enforcement output (reachable peers + the
 // firewall rules that permit them) into peer nodes + enforced edges.
 func (b *graphBuilder) addPeerReach(acc *types.Account, fromID string, reachable []*nbpeer.Peer, fwRules []*types.FirewallRule) {
@@ -85,7 +101,7 @@ func (b *graphBuilder) addPeerReach(acc *types.Account, fromID string, reachable
 		if p == nil {
 			continue
 		}
-		b.addNode(p.ID, NodePeer, peerLabel(p))
+		b.addPeerNode(p, NodePeer)
 		ipToPeer[p.IP.String()] = p
 	}
 

--- a/management/server/controlcenter/build_test.go
+++ b/management/server/controlcenter/build_test.go
@@ -54,8 +54,8 @@ func TestBuildGraph_PeerToPeer_Enforced(t *testing.T) {
 	require.Equal(t, Focus{Type: FocusPeer, ID: "pA"}, g.Focus)
 
 	// focus node + the one reachable peer node.
-	require.Contains(t, g.Nodes, Node{ID: "pA", Kind: NodeFocus, Label: "alice"})
-	require.Contains(t, g.Nodes, Node{ID: "pB", Kind: NodePeer, Label: "bob"})
+	require.Contains(t, g.Nodes, Node{ID: "pA", Kind: NodeFocus, Label: "alice", Meta: map[string]string{"ip": "10.0.0.1"}})
+	require.Contains(t, g.Nodes, Node{ID: "pB", Kind: NodePeer, Label: "bob", Meta: map[string]string{"ip": "10.0.0.2"}})
 
 	require.Len(t, g.Edges, 1)
 	e := g.Edges[0]
@@ -78,11 +78,29 @@ func TestBuildGraph_NoPolicy_NoEdge(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, g.Edges)
 	// only the focus node; no reachable peer => no peer node.
-	require.Equal(t, []Node{{ID: "pA", Kind: NodeFocus, Label: "alice"}}, g.Nodes)
+	require.Equal(t, []Node{{ID: "pA", Kind: NodeFocus, Label: "alice", Meta: map[string]string{"ip": "10.0.0.1"}}}, g.Nodes)
 }
 
 func TestBuildGraph_UnknownFocusPeer(t *testing.T) {
 	acc := twoPeerAccount(true, true)
 	_, err := BuildGraph(context.Background(), acc, Focus{Type: FocusPeer, ID: "ghost"}, nil)
 	require.Error(t, err)
+}
+
+// Visual pass: peer nodes (focus + reachable) carry their IP in
+// meta.ip so the dashboard can render it as the node's secondary
+// line. route/network_resource expose CIDR via the label instead.
+func TestBuildGraph_PeerNodesCarryMetaIP(t *testing.T) {
+	acc := twoPeerAccount(true, true)
+	validated := map[string]struct{}{"pA": {}, "pB": {}}
+
+	g, err := BuildGraph(context.Background(), acc, Focus{Type: FocusPeer, ID: "pA"}, validated)
+	require.NoError(t, err)
+
+	byID := map[string]Node{}
+	for _, n := range g.Nodes {
+		byID[n.ID] = n
+	}
+	require.Equal(t, "10.0.0.1", byID["pA"].Meta["ip"], "focus peer node carries its IP")
+	require.Equal(t, "10.0.0.2", byID["pB"].Meta["ip"], "reachable peer node carries its IP")
 }

--- a/management/server/controlcenter/group.go
+++ b/management/server/controlcenter/group.go
@@ -66,7 +66,16 @@ func buildGroupFocus(ctx context.Context, acc *types.Account, focus Focus, valid
 			if kind == NodeFocus {
 				kind = NodePeer
 			}
-			toNodes[nd.ID] = Node{ID: nd.ID, Kind: kind, Label: nd.Label}
+			// Preserve nd.Meta: the per-member temp graph already
+			// computed peer meta.ip via addPeerNode; rebuilding the
+			// aggregated node without it would strip the IP from every
+			// target under a group focus (#54 review).
+			toNodes[nd.ID] = Node{
+				ID:    nd.ID,
+				Kind:  kind,
+				Label: nd.Label,
+				Meta:  nd.Meta,
+			}
 		}
 
 		for _, e := range tmp.Edges {

--- a/management/server/controlcenter/group_test.go
+++ b/management/server/controlcenter/group_test.go
@@ -79,6 +79,18 @@ func TestBuildGraph_GroupFocus_UnionAllCompliant(t *testing.T) {
 	require.True(t, ok, "all 3 members reach pX")
 	require.Equal(t, "group:team", e.From)
 	require.Equal(t, "3 of 3 members", e.Meta["reachedBy"])
+
+	// #54 review: the group-focus aggregation must preserve the
+	// per-member node meta, so target peer nodes keep their IP.
+	var pX *Node
+	for i := range g.Nodes {
+		if g.Nodes[i].ID == "pX" {
+			pX = &g.Nodes[i]
+		}
+	}
+	require.NotNil(t, pX)
+	require.Equal(t, "10.0.0.9", pX.Meta["ip"],
+		"group focus must not strip peer meta.ip")
 }
 
 func TestBuildGraph_GroupFocus_PostureSplitsUnion(t *testing.T) {

--- a/management/server/controlcenter/posture.go
+++ b/management/server/controlcenter/posture.go
@@ -98,7 +98,7 @@ func (b *graphBuilder) addBlockedEdge(acc *types.Account, focusID, otherID strin
 		return
 	}
 	if p := acc.GetPeer(otherID); p != nil {
-		b.addNode(p.ID, NodePeer, peerLabel(p))
+		b.addPeerNode(p, NodePeer)
 	}
 
 	from, to := focusID, otherID

--- a/management/server/controlcenter/posture_test.go
+++ b/management/server/controlcenter/posture_test.go
@@ -71,7 +71,7 @@ func TestBuildGraph_PostureBlocked_FocusNonCompliant(t *testing.T) {
 	require.Equal(t, "min-nb", e.Meta["postureCheck"])
 	require.Equal(t, "pc1", e.Meta["postureCheckId"])
 	// pB must still be a node so the blocked edge has both endpoints.
-	require.Contains(t, g.Nodes, Node{ID: "pB", Kind: NodePeer, Label: "bob"})
+	require.Contains(t, g.Nodes, Node{ID: "pB", Kind: NodePeer, Label: "bob", Meta: map[string]string{"ip": "10.0.0.2"}})
 }
 
 func TestBuildGraph_PostureCompliant_EnforcedNotBlocked(t *testing.T) {
@@ -127,5 +127,5 @@ func TestBuildGraph_UnvalidatedFocus_EmptyReach(t *testing.T) {
 	g, err := BuildGraph(context.Background(), acc, Focus{Type: FocusPeer, ID: "pA"}, validated)
 	require.NoError(t, err)
 	require.Empty(t, g.Edges, "unvalidated focus reaches nothing")
-	require.Equal(t, []Node{{ID: "pA", Kind: NodeFocus, Label: "alice"}}, g.Nodes)
+	require.Equal(t, []Node{{ID: "pA", Kind: NodeFocus, Label: "alice", Meta: map[string]string{"ip": "10.0.0.1"}}}, g.Nodes)
 }


### PR DESCRIPTION
## Summary

Backend half of the Control Center **visual pass** (#39; owner-chosen "info-dense kind cards"). The chosen node card shows a secondary line — peer IP. Route/network_resource already expose their CIDR via the node `label`; a peer/group node previously only had `id/kind/label`.

`addPeerNode` now sets the **existing freeform** `node.meta` with `{"ip": <peer IP>}` for focus + reachable + posture-blocked peer nodes. Additive, non-breaking: `meta` is already optional in the wire contract (pinned by `contract_test.go`); route/nr/group-focus nodes unchanged.

1 commit off `main`. Owner authorizes merge (as #48–#53).

## Verification

- TDD: new `TestBuildGraph_PeerNodesCarryMetaIP`; updated the 5 pre-existing exact-Node assertions (build/posture) that pinned the pre-meta shape.
- `gofmt`/`go vet`/`go build ./management/...`/`-race` (controlcenter) + manager-seam e2e green.
- Clean-room (BSD-3): ADR-0017; no upstream NetBird `management/` consulted or ported.

## Test plan

- [ ] CI `go test ./management/server/controlcenter` green.
- [ ] Reviewer confirms `meta.ip` is additive (contract test still green; route/nr/group nodes unchanged).
- [ ] Frontend (V-FE PR) consumes `meta.ip` for the node secondary line.

Refs #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)
