### PR TITLE
feat(dashboard): Control Center visual pass — info-dense node cards (#39)

### DIFF
--- a/dashboard/src/modules/control-center/ControlCenterGraphCanvas.tsx
+++ b/dashboard/src/modules/control-center/ControlCenterGraphCanvas.tsx
@@ -8,11 +8,22 @@ import {
   type Edge,
   EdgeLabelRenderer,
   type EdgeProps,
+  Handle,
   MarkerType,
   type Node,
+  type NodeProps,
   Position,
   ReactFlow,
 } from "@xyflow/react";
+import {
+  Crosshair,
+  Database,
+  type LucideIcon,
+  Network,
+  ScrollText,
+  Server,
+  Users,
+} from "lucide-react";
 import React, { useMemo } from "react";
 import {
   ControlCenterEdge,
@@ -26,17 +37,88 @@ import {
 // labelled with its permit source (+ policy / protocol). Clicking a
 // policy-backed edge (P5) opens the policy editor.
 
-const NODE_W = 190;
-const NODE_H = 44;
+const NODE_W = 208;
+const NODE_H = 58;
 
-const KIND_CLASS: Record<NodeKind, string> = {
-  focus: "border-oz2-acc bg-oz2-acc/10 text-oz2-text font-semibold",
-  peer: "border-oz2-border-strong bg-oz2-surface text-oz2-text",
-  group: "border-oz2-border-strong bg-oz2-surface text-oz2-text",
-  policy: "border-oz2-border-strong bg-oz2-bg-sunken text-oz2-text-muted",
-  route: "border-oz2-border-strong bg-oz2-surface text-oz2-text",
-  network_resource: "border-oz2-border-strong bg-oz2-surface text-oz2-text",
+const KIND_ICON: Record<NodeKind, LucideIcon> = {
+  focus: Crosshair,
+  peer: Server,
+  group: Users,
+  policy: ScrollText,
+  route: Network,
+  network_resource: Database,
 };
+
+const KIND_LABEL: Record<NodeKind, string> = {
+  focus: "Focus",
+  peer: "Peer",
+  group: "Group",
+  policy: "Policy",
+  route: "Route",
+  network_resource: "Network resource",
+};
+
+// Info-dense kind card (ADR-0017 visual pass, owner-chosen). Violet
+// accent only (brand: no non-violet accents). Focus is emphasised;
+// peer/group are clickable foci (cursor cue). Secondary line = the
+// peer/route IP/CIDR (meta.ip, or the label already is the CIDR for
+// routes) falling back to the humanised kind.
+function CCNode({ data }: NodeProps) {
+  const d = data as {
+    label: string;
+    kind: NodeKind;
+    secondary: string;
+    switchable: boolean;
+  };
+  const Icon = KIND_ICON[d.kind] ?? Server;
+  const isFocus = d.kind === "focus";
+
+  return (
+    <div
+      style={{ width: NODE_W, height: NODE_H }}
+      className={`flex items-center gap-2 overflow-hidden rounded-oz2-input border bg-oz2-surface pr-3 ${
+        isFocus
+          ? "border-oz2-acc ring-1 ring-oz2-acc"
+          : "border-oz2-border-strong"
+      } ${d.switchable ? "cursor-pointer" : ""}`}
+    >
+      <Handle
+        type="target"
+        position={Position.Left}
+        isConnectable={false}
+        className="!h-1.5 !w-1.5 !min-w-0 !border-0 !bg-oz2-border-strong"
+      />
+      <span
+        className={`flex h-full w-9 shrink-0 items-center justify-center ${
+          isFocus
+            ? "bg-oz2-acc/15 text-oz2-acc"
+            : "bg-oz2-bg-sunken text-oz2-text-muted"
+        }`}
+        aria-hidden
+      >
+        <Icon size={15} />
+      </span>
+      <span className="flex min-w-0 flex-col">
+        <span
+          className={`truncate text-xs ${
+            isFocus ? "font-semibold" : ""
+          } text-oz2-text`}
+        >
+          {d.label}
+        </span>
+        <span className="truncate text-[10px] uppercase tracking-wide text-oz2-text-faint">
+          {d.secondary}
+        </span>
+      </span>
+      <Handle
+        type="source"
+        position={Position.Right}
+        isConnectable={false}
+        className="!h-1.5 !w-1.5 !min-w-0 !border-0 !bg-oz2-border-strong"
+      />
+    </div>
+  );
+}
 
 function edgeLabel(e: ControlCenterEdge): string {
   const src =
@@ -61,7 +143,9 @@ function layout(graph: ControlCenterGraph): {
   edges: Edge[];
 } {
   const g = new Dagre.graphlib.Graph();
-  g.setGraph({ rankdir: "LR", nodesep: 24, ranksep: 90 });
+  // Generous rank spacing so the edge label pills sit in the gap
+  // between columns instead of overlapping the cards.
+  g.setGraph({ rankdir: "LR", nodesep: 40, ranksep: 170 });
   g.setDefaultEdgeLabel(() => ({}));
 
   for (const n of graph.nodes) {
@@ -74,18 +158,17 @@ function layout(graph: ControlCenterGraph): {
 
   const nodes: Node[] = graph.nodes.map((n) => {
     const p = g.node(n.id);
-    // peer/group target nodes are valid v1 foci → clicking one
-    // re-centres the graph on it (Phase 3). Cue it with a pointer.
+    // peer/group nodes are valid v1 foci → clicking one re-centres
+    // the graph on it (Phase 3).
     const switchable = n.kind === "peer" || n.kind === "group";
+    // Secondary line: peer/focus carry meta.ip; routes/resources put
+    // their CIDR in the label already, so fall back to the kind.
+    const secondary = n.meta?.ip || KIND_LABEL[n.kind] || "";
     return {
       id: n.id,
+      type: "cc",
       position: { x: (p?.x ?? 0) - NODE_W / 2, y: (p?.y ?? 0) - NODE_H / 2 },
-      data: { label: n.label || n.id, kind: n.kind },
-      sourcePosition: Position.Right,
-      targetPosition: Position.Left,
-      className: `rounded-oz2-input border px-3 py-2 text-xs ${
-        KIND_CLASS[n.kind] ?? KIND_CLASS.peer
-      }${switchable ? " cursor-pointer" : ""}`,
+      data: { label: n.label || n.id, kind: n.kind, secondary, switchable },
       width: NODE_W,
       height: NODE_H,
     };
@@ -169,10 +252,16 @@ function ParallelEdge({
       <BaseEdge path={path} markerEnd={markerEnd} style={style} />
       <EdgeLabelRenderer>
         <div
-          className={`pointer-events-none absolute -translate-x-1/2 -translate-y-1/2 rounded bg-oz2-surface px-1.5 py-0.5 text-[10px] ${
-            d.blocked ? "text-oz2-err" : "text-oz2-text-muted"
+          className={`pointer-events-none absolute truncate rounded-full border bg-oz2-surface px-2 py-0.5 text-[10px] ${
+            d.blocked
+              ? "border-oz2-err/40 text-oz2-err"
+              : "border-oz2-border-strong text-oz2-text-muted"
           }`}
-          style={{ transform: `translate(-50%,-50%) translate(${mx}px,${my}px)` }}
+          style={{
+            transform: `translate(-50%,-50%) translate(${mx}px,${my}px)`,
+            maxWidth: 150,
+          }}
+          title={d.label}
         >
           {d.label}
         </div>
@@ -192,12 +281,14 @@ export default function ControlCenterGraphCanvas({
 }) {
   const { nodes, edges } = useMemo(() => layout(graph), [graph]);
   const edgeTypes = useMemo(() => ({ parallel: ParallelEdge }), []);
+  const nodeTypes = useMemo(() => ({ cc: CCNode }), []);
 
   return (
     <div className="h-[68vh] w-full overflow-hidden rounded-oz2-card border border-oz2-border-strong">
       <ReactFlow
         nodes={nodes}
         edges={edges}
+        nodeTypes={nodeTypes}
         edgeTypes={edgeTypes}
         fitView
         nodesDraggable={false}


### PR DESCRIPTION
## Summary

The Control Center **visual pass** (#39; owner-chosen "info-dense kind cards"). 1 commit off `main` (which has V-BE `meta.ip` from #54). Owner authorizes merge.

The Phase-2/3 canvas rendered React Flow **default** nodes — the big white boxes with unreadable text in the screenshot the owner shared (RF's `dist/style.css` overrode the `oz2` className), with edge labels sprawling over the cards. Replaced with a custom `CCNode`:

- Fixed-size card (size via **inline style** — Tailwind arbitrary classes built from runtime values do **not** work; that was a real bug in the first draft), `oz2-surface` bg, per-kind lucide icon in a tinted gutter, primary label + secondary line (peer/focus `meta.ip` from V-BE; routes carry CIDR in the label; else humanised kind). Focus card emphasised (violet ring). peer/group keep the click-to-focus pointer. **Violet-only** accents (brand).
- Explicit `Handle`s (custom nodes need them for edges to attach).
- Edge label → compact rounded-full bordered **pill**, truncated (`maxWidth` + `title`) so it stops overlapping nodes; `posture_blocked` tinted err.
- dagre `ranksep` 90→170 / `nodesep` 24→40 so pills sit in the column gap.

## Verification (honest)

- `next lint` clean; **`tsc --noEmit` exit 0** (whole dashboard typechecks, incl. this file). The only real compile error (lucide `LucideIcon` typing) was found and fixed.
- **`next build` is environmentally flaky in this dev env** — a *different unrelated* page-data race each run (`/team/*`, `/favicon.ico`, `routes-manifest`); Codex hit the same `.next`-regeneration race. It is **not** this code. **CI is the authoritative build.**
- **NOT browser-verified** — no Cypress/browser here (#52). The owner must eyeball the rendered result; happy to iterate from a screenshot.

## Test plan

- [ ] CI `next build` green (authoritative).
- [ ] Owner eyeballs `/control-center`: cards (icon + label + IP/CIDR), focus emphasised, readable text on themed bg, edge pills in the gap (not over cards), posture_blocked distinct.
- [ ] Iterate on spacing/typography from the owner's screenshot if needed.

Refs #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)
