### PR TITLE
docs(adr): Control Center v2 topology redesign — ADR-0017 amendment (#39)

### DIFF
--- a/docs/adr/0017-control-center-access-graph.md
+++ b/docs/adr/0017-control-center-access-graph.md
@@ -394,3 +394,56 @@ value and de-risks the resolver contract for the v2 widening.
   route-only cost. Verdict: acceptable; the standing
   no-new-charting-lib concern (shared-bundle bloat) does not
   materialise because the libs never enter the shared baseline.
+
+- **2026-05-18 — Topology v2 redesign (owner-decided; supersedes the
+  v1 generic graph).** A Claude-Design hifi handoff
+  (`design_handoff_topology/`) reframes Control Center from the v1
+  peer-centric reach graph into a **4-column access map**:
+  `User (+email) → Peers → Policies → Resources/Networks`, with
+  fan-in/fan-out cubic-Bézier edges, an animated "flow", hover
+  isolation (2-hop), tabs (Peer/User/Group/Networks), footer legend.
+  The owner judged this the target. Scope/decision deltas:
+
+  - **D1 — projection changes (not just a reskin).** The current
+    `GraphDTO` is peer-centric: focus ∈ {peer,group}; it emits
+    `focus/peer/route/network_resource` nodes and carries policy only
+    as edge metadata — there is **no User entity, no email, no Policy
+    as a column node, no User→Peer relation** (verified in
+    `controlcenter/*.go` on main). The handoff needs a NEW
+    server-side, enforcement-faithful **user-centric columnar
+    projection** (`User{peerIds}` → `Policy{peerIds,resourceIds}` →
+    `Resource`). D1's "derive from the enforcement engine, never
+    re-derive in TS" principle is UNCHANGED; the *shape* is new. This
+    is a substantial backend phase, not a frontend tweak — the single
+    biggest cost in this redesign.
+  - **D2 — xyflow KEPT, dagre DROPPED (no reversal to hand-built
+    SVG).** Verified: xyflow can render the handoff (explicit-position
+    custom nodes, custom Bézier edge type with gradient stroke +
+    `stroke-dashoffset` flow keyframe, `<Background variant=dots>`,
+    hover state). dagre's layered auto-layout actively fights a fixed
+    4-column design, so it is replaced by the handoff's deterministic
+    layout (fixed X per column-kind + `distributeY(count)`). The
+    `@xyflow/react` dependency and its ADR-sanctioned exception stand;
+    `@dagrejs/dagre` is removed once unused. #51/#53/#55 are reused,
+    not discarded (lighter than a ground-up SVG rebuild — owner-chosen
+    over the SVG option).
+  - **D3 — v1 scope extended.** Users + Networks (deferred to "v2" in
+    the original D3) are now in scope as root-column tabs alongside
+    Peer/Group.
+  - **Brand exception (sanctioned).** Edges are coloured by status —
+    **green = allowed, red = posture_blocked** — a deliberate owner
+    override of `dashboard/CLAUDE.md`'s violet-only / "no green
+    checkmarks; success-error use violet variants" rule AND of the
+    handoff's own violet-flow palette. Recorded here as a sanctioned
+    exception (same mechanism as the xyflow charting-lib exception),
+    scoped to the topology edges only. Rationale: the operator
+    anchored on NetBird's green semaphore; the audit signal
+    (reachable vs blocked) is judged worth the palette break.
+
+  This is **Control Center v2**, tracked under #39 (kept open as the
+  umbrella). Phasing: T0 = this amendment (gate); T1 = backend
+  user-centric projection + API; T2 = xyflow columnar layout (dagre
+  out); T3 = the 4 kind cards; T4 = Bézier-flow edges (green/red);
+  T5 = hover-isolation + footer/legend/tabs + dot-grid chrome.
+  Cypress still deferred (#52). Each phase: own PR, Codex review,
+  owner-authorised merge — same cadence as v1.


### PR DESCRIPTION
## Summary

**Phase-0 gate** for **Control Center v2** (topology redesign). Doc-only — one dated amendment appended to ADR-0017; **no v2 code lands before this merges** (same discipline as the original Control Center Phase 0). Owner authorises merge.

The Claude-Design hifi handoff (`design_handoff_topology/`) reframes Control Center from the v1 peer-centric reach graph into a **4-column access map** — `User (+email) → Peers → Policies → Resources/Networks` — with fan-in/fan-out Bézier edges, an animated "flow", hover-isolation (2-hop), root-column tabs, footer legend. Owner judged this the target.

## Decision deltas recorded

- **D1 — new projection (not a reskin).** Verified in `controlcenter/*.go` on `main`: the current `GraphDTO` is peer-centric (focus ∈ {peer,group}; emits `focus/peer/route/network_resource`; policy is edge metadata only — **no User, no email, no Policy-as-node, no User→Peer**). v2 needs a NEW server-side, enforcement-faithful **user-centric columnar projection**. D1's "derive from the engine, never re-derive in TS" principle is unchanged; the shape is new. **This is a substantial backend phase — the biggest cost.**
- **D2 — xyflow KEPT, dagre DROPPED.** Verified xyflow can render the handoff (explicit-position custom nodes; custom Bézier edge w/ gradient + `stroke-dashoffset` flow; dots bg; hover state). dagre's auto-layout fights a fixed 4-column design → replaced by the handoff's deterministic layout. `@xyflow/react` + its sanctioned exception stand; `@dagrejs/dagre` removed when unused. Reuse #51/#53/#55 (owner chose this over a ground-up SVG rebuild).
- **D3 — scope extended.** Users + Networks (originally deferred to "v2") now in scope as root-column tabs.
- **Sanctioned brand exception.** Edges coloured **green = allowed / red = posture_blocked** — deliberate owner override of the violet-only brand rule AND the handoff's own violet palette, scoped to topology edges (same exception mechanism as the xyflow charting-lib exception). Rationale recorded.

## Phasing (under #39, kept open as umbrella)

T0 = this amendment (gate) · T1 = backend user-centric projection + API · T2 = xyflow columnar layout (dagre out) · T3 = the 4 kind cards · T4 = Bézier-flow edges (green/red) · T5 = hover-isolation + footer/legend/tabs + dot-grid chrome. Each phase: own PR, Codex review, owner-authorised merge — same cadence as v1. Cypress still deferred (#52). #55 (v1 card polish on the xyflow canvas) is superseded by T2–T4.

## Test plan

- [ ] N/A — documentation only.
- [ ] Reviewer sanity-checks the D1 "no User/Policy-node today" claim against `management/server/controlcenter/*.go`.

Refs #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)
