### PR TITLE
feat(dashboard): v2 columnar topology canvas — T2 (#39)

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2.0.0",
       "dependencies": {
         "@axa-fr/react-oidc": "^7.22.18",
-        "@dagrejs/dagre": "^1.1.5",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-collapsible": "^1.1.12",
@@ -188,24 +187,6 @@
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
-      }
-    },
-    "node_modules/@dagrejs/dagre": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-1.1.8.tgz",
-      "integrity": "sha512-5SEDlndt4W/LaVzPYJW+bSmSEZc9EzTf8rJ20WCKvjS5EAZAN0b+x0Yww7VMT4R3Wootkg+X9bUfUxazYw6Blw==",
-      "license": "MIT",
-      "dependencies": {
-        "@dagrejs/graphlib": "2.2.4"
-      }
-    },
-    "node_modules/@dagrejs/graphlib": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-2.2.4.tgz",
-      "integrity": "sha512-mepCf/e9+SKYy1d02/UkvSy6+6MoyXhVxP8lLDfA7BPE1X1d4dR0sZznmbM8/XVJ1GPM+Svnx7Xj6ZweByWUkw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">17.0.0"
       }
     },
     "node_modules/@emnapi/runtime": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -14,8 +14,6 @@
   },
   "dependencies": {
     "@axa-fr/react-oidc": "^7.22.18",
-    "@dagrejs/dagre": "^1.1.5",
-    "@xyflow/react": "^12.8.4",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-collapsible": "^1.1.12",
@@ -43,6 +41,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "@types/react-window": "^1.8.8",
+    "@xyflow/react": "^12.8.4",
     "autoprefixer": "^10",
     "chart.js": "^4.4.8",
     "chroma-js": "^3.1.2",

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -514,3 +514,54 @@ p {
 .animate-bg-scroll-faster {
     animation: bg-scroll 1.8s linear infinite;
 }
+
+/* ─── Control Center v2 topology canvas (ADR-0017 2026-05-18b) ───
+   Scoped to .oz-cc-* so it can't leak. The dot grid + soft centre
+   glow replace xyflow's plain background and cue "infinite canvas"
+   while staying brand-aligned; the flow dash is the "live traffic"
+   signal on policy edges. */
+.oz-cc-grid {
+    background-color: var(--ozv2-bg);
+    background-image:
+        radial-gradient(
+            circle at 50% 45%,
+            color-mix(in oklab, var(--ozv2-acc) 6%, transparent),
+            transparent 60%
+        ),
+        radial-gradient(
+            color-mix(in oklab, var(--ozv2-acc) 14%, transparent) 1px,
+            transparent 1px
+        );
+    background-size: 100% 100%, 24px 24px;
+}
+
+@keyframes oz-cc-dash-flow {
+    to {
+        stroke-dashoffset: -200;
+    }
+}
+
+.oz-cc-flow {
+    animation: oz-cc-dash-flow var(--oz-cc-flow-speed, 4.5s) linear infinite;
+}
+
+.oz-cc-scroll::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+}
+.oz-cc-scroll::-webkit-scrollbar-thumb {
+    background: var(--ozv2-border);
+    border-radius: 99px;
+}
+.oz-cc-scroll::-webkit-scrollbar-thumb:hover {
+    background: var(--ozv2-border-strong);
+}
+.oz-cc-scroll::-webkit-scrollbar-track {
+    background: transparent;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .oz-cc-flow {
+        animation-play-state: paused;
+    }
+}

--- a/dashboard/src/interfaces/ControlCenter.ts
+++ b/dashboard/src/interfaces/ControlCenter.ts
@@ -6,15 +6,19 @@
 // contract_test.go and this file is its TS counterpart. Keep the two
 // in lockstep (see ADR-0017 + project memory).
 
-export type FocusType = "peer" | "group";
+// v2 topology: one view, four focus tabs (ADR-0017 2026-05-18b).
+// Policy is always the middle pivot column.
+export type FocusType = "peer" | "user" | "group" | "network";
 
 export type NodeKind =
   | "focus"
   | "policy"
   | "group"
   | "peer"
+  | "user"
   | "route"
-  | "network_resource";
+  | "network_resource"
+  | "network";
 
 export type EdgeState = "enforced" | "posture_blocked";
 
@@ -34,6 +38,10 @@ export interface ControlCenterNode {
   id: string;
   kind: NodeKind;
   label: string;
+  // v2 columnar projection stamps meta.column ∈
+  // focus|peers|policies|resources|groups so the canvas can lane the
+  // node. Also: peer→ip/os, user→email, policy→port, resource→
+  // sub/resourceKind.
   meta?: Record<string, string>;
 }
 

--- a/dashboard/src/interfaces/ControlCenter.ts
+++ b/dashboard/src/interfaces/ControlCenter.ts
@@ -24,8 +24,14 @@ export type EdgeState = "enforced" | "posture_blocked";
 
 // router_local: the focus IS the router serving the route (gateway
 // reach), distinct from route_default_permit (ADR-0017 amendment
-// 2026-05-17). All three values must be handled.
-export type PermitSource = "policy" | "route_default_permit" | "router_local";
+// 2026-05-17). identity: a structural ownership edge (v2 User→Peer),
+// not a policy permit — no policyId (ADR-0017 2026-05-18c). All
+// values must be handled.
+export type PermitSource =
+  | "policy"
+  | "route_default_permit"
+  | "router_local"
+  | "identity";
 
 export type EdgeDirection = "in" | "out" | "bidirectional";
 

--- a/dashboard/src/layouts/V2DashboardLayout.tsx
+++ b/dashboard/src/layouts/V2DashboardLayout.tsx
@@ -289,6 +289,9 @@ function breadcrumbForPath(path: string | null): OzBreadcrumbSegment[] {
   if (path === "/access-control" || path.startsWith("/access-control/")) {
     return [{ label: "Security" }, { label: "Access Control" }];
   }
+  if (path === "/control-center" || path.startsWith("/control-center")) {
+    return [{ label: "Security" }, { label: "Control Center" }];
+  }
   if (path === "/posture-checks" || path.startsWith("/posture-checks/")) {
     return [{ label: "Security" }, { label: "Posture Checks" }];
   }

--- a/dashboard/src/modules/control-center/ControlCenterFlowEdge.tsx
+++ b/dashboard/src/modules/control-center/ControlCenterFlowEdge.tsx
@@ -65,19 +65,33 @@ export function CCFlowEdge({
           transition: "opacity .25s, stroke-width .25s",
         }}
       />
-      {d.emphasis && d.label && (
-        <EdgeLabelRenderer>
-          <div
-            className="font-mono pointer-events-none absolute rounded bg-oz2-surface
-              px-1.5 py-0.5 text-[10px] text-oz2-text-muted shadow-oz2-sm"
-            style={{
-              transform: `translate(-50%,-50%) translate(${mx}px,${my}px)`,
-            }}
-          >
-            {d.label}
-          </div>
-        </EdgeLabelRenderer>
-      )}
+      {(() => {
+        // reachedBy ("k of n members") is ALWAYS shown so partial
+        // reach is never mistaken for full; proto/ports enriches it
+        // only on hover. One badge, no overlap.
+        const parts = [
+          d.reachedBy,
+          d.emphasis && d.label ? d.label : "",
+        ].filter(Boolean);
+        if (parts.length === 0) return null;
+        return (
+          <EdgeLabelRenderer>
+            <div
+              className={`font-mono pointer-events-none absolute rounded
+                bg-oz2-surface px-1.5 py-0.5 text-[10px] shadow-oz2-sm ${
+                  d.blocked ? "text-oz2-err" : "text-oz2-text-muted"
+                }`}
+              style={{
+                transform: `translate(-50%,-50%) translate(${mx}px,${my}px)`,
+                opacity: d.dimmed ? 0.07 : 1,
+                transition: "opacity .25s",
+              }}
+            >
+              {parts.join(" · ")}
+            </div>
+          </EdgeLabelRenderer>
+        );
+      })()}
     </>
   );
 }

--- a/dashboard/src/modules/control-center/ControlCenterFlowEdge.tsx
+++ b/dashboard/src/modules/control-center/ControlCenterFlowEdge.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import {
+  BaseEdge,
+  EdgeLabelRenderer,
+  type EdgeProps,
+} from "@xyflow/react";
+import React from "react";
+import type { CCFlowEdgeData } from "./controlCenterLayout";
+
+// v2 topology edge. Cubic Bézier with horizontal-pull control points
+// (the hifi handoff's bezierPath, curve 0.55). OWNER OVERRIDE of the
+// brand palette (ADR-0017 2026-05-18b, sanctioned exception): edges
+// are coloured by enforcement STATE — green = enforced (allowed),
+// red = posture_blocked — not the design's violet gradient, because
+// the audit signal is the whole point of this view. Policy edges get
+// the animated "live traffic" dash; a structural User→Peer edge is
+// solid.
+
+const CURVE = 0.55;
+
+function bezier(x1: number, y1: number, x2: number, y2: number): string {
+  const dx = x2 - x1;
+  const cx1 = x1 + dx * CURVE;
+  const cx2 = x2 - dx * CURVE;
+  return `M ${x1} ${y1} C ${cx1} ${y1}, ${cx2} ${y2}, ${x2} ${y2}`;
+}
+
+interface RenderEdgeData extends CCFlowEdgeData {
+  dimmed?: boolean;
+  emphasis?: boolean;
+}
+
+export function CCFlowEdge({
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  data,
+}: EdgeProps) {
+  // xyflow types edge data as Record<string, unknown> — third-party
+  // boundary (CLAUDE.md sanctioned `as` exception).
+  const d = (data ?? {}) as unknown as RenderEdgeData;
+  const path = bezier(sourceX, sourceY, targetX, targetY);
+  const color = d.blocked ? "var(--ozv2-err)" : "var(--ozv2-ok)";
+  const opacity = d.dimmed ? 0.07 : 1;
+  const width = d.emphasis ? 2.2 : 1.6;
+
+  const flowClass = d.structural ? "" : "oz-cc-flow";
+  const dash = d.structural ? undefined : "2 8";
+
+  const mx = (sourceX + targetX) / 2;
+  const my = (sourceY + targetY) / 2;
+
+  return (
+    <>
+      <BaseEdge
+        path={path}
+        className={flowClass}
+        style={{
+          stroke: color,
+          strokeWidth: width,
+          strokeDasharray: dash,
+          opacity,
+          transition: "opacity .25s, stroke-width .25s",
+        }}
+      />
+      {d.emphasis && d.label && (
+        <EdgeLabelRenderer>
+          <div
+            className="font-mono pointer-events-none absolute rounded bg-oz2-surface
+              px-1.5 py-0.5 text-[10px] text-oz2-text-muted shadow-oz2-sm"
+            style={{
+              transform: `translate(-50%,-50%) translate(${mx}px,${my}px)`,
+            }}
+          >
+            {d.label}
+          </div>
+        </EdgeLabelRenderer>
+      )}
+    </>
+  );
+}
+
+export const CC_EDGE_TYPES = { cc: CCFlowEdge };

--- a/dashboard/src/modules/control-center/ControlCenterGraphCanvas.tsx
+++ b/dashboard/src/modules/control-center/ControlCenterGraphCanvas.tsx
@@ -2,7 +2,7 @@
 
 import "@xyflow/react/dist/style.css";
 import { type Edge, type Node, ReactFlow } from "@xyflow/react";
-import { RefreshCw } from "lucide-react";
+import { RefreshCw, Search } from "lucide-react";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import type {
   ControlCenterGraph,
@@ -74,22 +74,121 @@ function Legend() {
   );
 }
 
+// FocusPicker is the inline selector anchored to the focus card
+// (NetBird pattern, owner-confirmed 2026-05-18): a search field over
+// a scrollable list. It opens against the card — NOT the header — so
+// the affordance is where the click is.
+function FocusPicker({
+  x,
+  y,
+  cardH,
+  width,
+  stageH,
+  options,
+  currentId,
+  onPick,
+  onClose,
+}: {
+  x: number;
+  y: number;
+  cardH: number;
+  width: number;
+  stageH: number;
+  options: { id: string; label: string }[];
+  currentId: string;
+  onPick: (id: string) => void;
+  onClose: () => void;
+}) {
+  const [q, setQ] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => inputRef.current?.focus(), []);
+
+  const filtered = q
+    ? options.filter((o) =>
+        o.label.toLowerCase().includes(q.toLowerCase()),
+      )
+    : options;
+
+  // Anchor below the card; flip above when the lower half wouldn't
+  // fit a usable list.
+  const openUp = y + cardH > stageH * 0.55;
+  const pos = openUp
+    ? { left: x, bottom: stageH - y + 6 }
+    : { left: x, top: y + cardH + 6 };
+
+  return (
+    <>
+      <div
+        className="absolute inset-0 z-30"
+        onClick={onClose}
+        aria-hidden
+      />
+      <div
+        className="oz-cc-scroll absolute z-40 flex max-h-[300px] flex-col
+          overflow-hidden rounded-oz2-input border border-oz2-border
+          bg-oz2-surface shadow-oz2-lg"
+        style={{ ...pos, width: Math.max(width, 240) }}
+      >
+        <div className="flex items-center gap-2 border-b border-oz2-border-soft px-3 py-2">
+          <Search className="h-3.5 w-3.5 shrink-0 text-oz2-text-faint" />
+          <input
+            ref={inputRef}
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Search…"
+            className="w-full bg-transparent text-xs text-oz2-text
+              placeholder:text-oz2-text-faint focus:outline-none"
+          />
+        </div>
+        <ul className="oz-cc-scroll min-h-0 flex-1 overflow-auto py-1">
+          {filtered.length === 0 && (
+            <li className="px-3 py-2 text-xs text-oz2-text-faint">
+              No matches
+            </li>
+          )}
+          {filtered.map((o) => (
+            <li key={o.id}>
+              <button
+                type="button"
+                onClick={() => onPick(o.id)}
+                className={`flex w-full items-center truncate px-3 py-1.5
+                  text-left text-xs transition-colors hover:bg-oz2-hover ${
+                    o.id === currentId
+                      ? "bg-oz2-acc-soft text-oz2-acc-text"
+                      : "text-oz2-text-2"
+                  }`}
+              >
+                {o.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </>
+  );
+}
+
 export default function ControlCenterGraphCanvas({
   graph,
   onEdgeClick,
   onFocusNode,
   onRefresh,
-  onOpenPicker,
+  focusOptions,
+  focusId,
+  onPickFocus,
 }: {
   graph: ControlCenterGraph;
   onEdgeClick?: (policyId: string) => void;
   onFocusNode?: (view: FocusType, id: string) => void;
   onRefresh?: () => void;
-  onOpenPicker?: () => void;
+  focusOptions: { id: string; label: string }[];
+  focusId: string;
+  onPickFocus: (id: string) => void;
 }) {
   const wrapRef = useRef<HTMLDivElement>(null);
   const [size, setSize] = useState({ w: 0, h: 0 });
   const [hovered, setHovered] = useState<string | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
 
   useEffect(() => {
     const el = wrapRef.current;
@@ -117,6 +216,10 @@ export default function ControlCenterGraphCanvas({
         ? reachableFrom(hovered, laid.adjOut, laid.adjIn)
         : null,
     [hovered, laid],
+  );
+  const focusNode = useMemo(
+    () => laid?.nodes.find((n) => n.data.column === "focus") ?? null,
+    [laid],
   );
 
   const nodes: Node[] = useMemo(
@@ -197,10 +300,16 @@ export default function ControlCenterGraphCanvas({
               column?: string;
             };
             // The focus card is the picker affordance: clicking it
-            // (or its chevron) opens the focus selector to swap the
-            // inspected entity — same as NetBird's focus dropdown.
+            // (or its chevron) opens an inline selector anchored to
+            // the card to swap the inspected entity.
             if (d.kind === "focus" || d.column === "focus") {
-              onOpenPicker?.();
+              setPickerOpen((v) => !v);
+              return;
+            }
+            // A policy card opens that policy in the editor (same
+            // round-trip as clicking a policy-backed edge).
+            if (d.kind === "policy" && onEdgeClick) {
+              onEdgeClick(node.id.replace(/^policy:/, ""));
               return;
             }
             if (
@@ -218,6 +327,23 @@ export default function ControlCenterGraphCanvas({
           }}
         />
       </div>
+
+      {pickerOpen && focusNode && (
+        <FocusPicker
+          x={focusNode.position.x}
+          y={focusNode.position.y}
+          cardH={focusNode.height}
+          width={focusNode.width}
+          stageH={size.h}
+          options={focusOptions}
+          currentId={focusId}
+          onPick={(id) => {
+            setPickerOpen(false);
+            onPickFocus(id);
+          }}
+          onClose={() => setPickerOpen(false)}
+        />
+      )}
 
       <div
         className="absolute inset-x-0 bottom-0 z-10 flex items-center

--- a/dashboard/src/modules/control-center/ControlCenterGraphCanvas.tsx
+++ b/dashboard/src/modules/control-center/ControlCenterGraphCanvas.tsx
@@ -64,7 +64,11 @@ function Legend() {
   );
   return (
     <div className="flex items-center gap-4 text-[11px] text-oz2-text-muted">
-      <Item cls="bg-oz2-ok" label="Enforced" />
+      {/* "Policy-permitted", not "Enforced": v2 is a policy
+          topology, green means the policy grants it and posture
+          doesn't block — not a live reachability claim (ADR-0017
+          2026-05-18c). */}
+      <Item cls="bg-oz2-ok" label="Policy-permitted" />
       <Item cls="bg-oz2-err" label="Posture-blocked" />
       <span className="flex items-center gap-1.5">
         <span className="h-0.5 w-5 rounded-full border-t border-dashed border-oz2-text-faint" />

--- a/dashboard/src/modules/control-center/ControlCenterGraphCanvas.tsx
+++ b/dashboard/src/modules/control-center/ControlCenterGraphCanvas.tsx
@@ -1,183 +1,76 @@
 "use client";
 
 import "@xyflow/react/dist/style.css";
-import Dagre from "@dagrejs/dagre";
-import {
-  Background,
-  BaseEdge,
-  type Edge,
-  EdgeLabelRenderer,
-  type EdgeProps,
-  MarkerType,
-  type Node,
-  Position,
-  ReactFlow,
-} from "@xyflow/react";
-import React, { useMemo } from "react";
-import {
-  ControlCenterEdge,
+import { type Edge, type Node, ReactFlow } from "@xyflow/react";
+import { RefreshCw } from "lucide-react";
+import React, { useMemo, useState } from "react";
+import type {
   ControlCenterGraph,
-  NodeKind,
+  FocusType,
 } from "@/interfaces/ControlCenter";
+import { CC_EDGE_TYPES } from "./ControlCenterFlowEdge";
+import {
+  type ColumnHeader,
+  columnHeaders,
+  layoutGraph,
+  reachableFrom,
+  STAGE_H,
+  STAGE_W,
+} from "./controlCenterLayout";
+import { CC_NODE_TYPES } from "./ControlCenterNodes";
 
-// ADR-0017 Phase 2, P4 — the xyflow canvas. Read-only; dagre lays the
-// graph out left→right. Posture-blocked edges are visually distinct
-// from enforced (never collapsed into "no edge"). Each edge is
-// labelled with its permit source (+ policy / protocol). Clicking a
-// policy-backed edge (P5) opens the policy editor.
+// ADR-0017 2026-05-18b — the v2 columnar canvas. Replaces the v1
+// dagre reach graph: a fixed 1500×760 stage, four focus tabs,
+// Policy always the middle pivot column, edges coloured by
+// enforcement state (green = enforced, red = posture_blocked —
+// owner-sanctioned brand exception). The stage is pan/zoom-locked;
+// the wrapper scrolls horizontally on narrow viewports, matching the
+// hifi handoff.
 
-const NODE_W = 190;
-const NODE_H = 44;
+const HEADER_H = 56;
+const FOOTER_H = 44;
 
-const KIND_CLASS: Record<NodeKind, string> = {
-  focus: "border-oz2-acc bg-oz2-acc/10 text-oz2-text font-semibold",
-  peer: "border-oz2-border-strong bg-oz2-surface text-oz2-text",
-  group: "border-oz2-border-strong bg-oz2-surface text-oz2-text",
-  policy: "border-oz2-border-strong bg-oz2-bg-sunken text-oz2-text-muted",
-  route: "border-oz2-border-strong bg-oz2-surface text-oz2-text",
-  network_resource: "border-oz2-border-strong bg-oz2-surface text-oz2-text",
-};
-
-function edgeLabel(e: ControlCenterEdge): string {
-  const src =
-    e.permitSource === "policy"
-      ? e.policyName || "policy"
-      : e.permitSource;
-  // protocol/ports on the edge (ADR-0017 Phase 3): e.g. "tcp/22,443",
-  // "tcp", "22,443", or nothing for an all-protocol no-port rule.
-  const protoPorts = [
-    e.protocol && e.protocol !== "all" ? e.protocol : "",
-    e.ports && e.ports.length ? e.ports.join(",") : "",
-  ]
-    .filter(Boolean)
-    .join("/");
-  const proto = protoPorts ? ` · ${protoPorts}` : "";
-  const blocked = e.state === "posture_blocked" ? " · blocked" : "";
-  return `${src}${proto}${blocked}`;
-}
-
-function layout(graph: ControlCenterGraph): {
-  nodes: Node[];
-  edges: Edge[];
-} {
-  const g = new Dagre.graphlib.Graph();
-  g.setGraph({ rankdir: "LR", nodesep: 24, ranksep: 90 });
-  g.setDefaultEdgeLabel(() => ({}));
-
-  for (const n of graph.nodes) {
-    g.setNode(n.id, { width: NODE_W, height: NODE_H });
-  }
-  for (const e of graph.edges) {
-    g.setEdge(e.from, e.to);
-  }
-  Dagre.layout(g);
-
-  const nodes: Node[] = graph.nodes.map((n) => {
-    const p = g.node(n.id);
-    // peer/group target nodes are valid v1 foci → clicking one
-    // re-centres the graph on it (Phase 3). Cue it with a pointer.
-    const switchable = n.kind === "peer" || n.kind === "group";
-    return {
-      id: n.id,
-      position: { x: (p?.x ?? 0) - NODE_W / 2, y: (p?.y ?? 0) - NODE_H / 2 },
-      data: { label: n.label || n.id, kind: n.kind },
-      sourcePosition: Position.Right,
-      targetPosition: Position.Left,
-      className: `rounded-oz2-input border px-3 py-2 text-xs ${
-        KIND_CLASS[n.kind] ?? KIND_CLASS.peer
-      }${switchable ? " cursor-pointer" : ""}`,
-      width: NODE_W,
-      height: NODE_H,
-    };
-  });
-
-  // Phase 1 deliberately preserves distinct relations with the same
-  // from/to (router_local vs route_default_permit, multi-cause
-  // posture_blocked, multi-policy). Number each within its (from,to)
-  // group so the custom edge fans them onto separate tracks instead
-  // of overlapping (#51 F3).
-  const parCount: Record<string, number> = {};
-  for (const e of graph.edges) {
-    const k = `${e.from}\u0000${e.to}`;
-    parCount[k] = (parCount[k] ?? 0) + 1;
-  }
-  const parSeen: Record<string, number> = {};
-
-  const edges: Edge[] = graph.edges.map((e, i) => {
-    const blocked = e.state === "posture_blocked";
-    const k = `${e.from}\u0000${e.to}`;
-    const parIndex = parSeen[k] ?? 0;
-    parSeen[k] = parIndex + 1;
-    return {
-      id: `e${i}-${e.from}-${e.to}`,
-      source: e.from,
-      target: e.to,
-      type: "parallel",
-      style: blocked
-        ? { stroke: "var(--ozv2-err)", strokeDasharray: "5 4" }
-        : { stroke: "var(--ozv2-acc)" },
-      markerEnd: { type: MarkerType.ArrowClosed },
-      data: {
-        policyId: e.policyId ?? "",
-        label: edgeLabel(e),
-        blocked,
-        parIndex,
-        parTotal: parCount[k],
-      },
-    };
-  });
-
-  return { nodes, edges };
-}
-
-// ParallelEdge fans edges that share a (source,target) onto separate
-// curved tracks (perpendicular offset by parallel index, centred on
-// zero) with the label on the same offset, so the parallel relations
-// the backend preserves are not visually collapsed (#51 F3).
-const PAR_GAP = 26;
-
-function ParallelEdge({
-  sourceX,
-  sourceY,
-  targetX,
-  targetY,
-  markerEnd,
-  style,
-  data,
-}: EdgeProps) {
-  const d = (data ?? {}) as {
-    label?: string;
-    blocked?: boolean;
-    parIndex?: number;
-    parTotal?: number;
-  };
-  const idx = d.parIndex ?? 0;
-  const total = d.parTotal ?? 1;
-  const offset = (idx - (total - 1) / 2) * PAR_GAP;
-
-  const dx = targetX - sourceX;
-  const dy = targetY - sourceY;
-  const len = Math.hypot(dx, dy) || 1;
-  const nx = -dy / len;
-  const ny = dx / len;
-  const mx = (sourceX + targetX) / 2 + nx * offset;
-  const my = (sourceY + targetY) / 2 + ny * offset;
-  const path = `M ${sourceX},${sourceY} Q ${mx},${my} ${targetX},${targetY}`;
-
+function ColumnHeaders({ cols }: { cols: ColumnHeader[] }) {
   return (
-    <>
-      <BaseEdge path={path} markerEnd={markerEnd} style={style} />
-      <EdgeLabelRenderer>
+    <div className="pointer-events-none absolute left-0 top-0 h-14 w-full">
+      {cols.map((c) => (
         <div
-          className={`pointer-events-none absolute -translate-x-1/2 -translate-y-1/2 rounded bg-oz2-surface px-1.5 py-0.5 text-[10px] ${
-            d.blocked ? "text-oz2-err" : "text-oz2-text-muted"
-          }`}
-          style={{ transform: `translate(-50%,-50%) translate(${mx}px,${my}px)` }}
+          key={c.id}
+          className="absolute flex items-center gap-2"
+          style={{ left: c.x, top: 20, width: c.width }}
         >
-          {d.label}
+          <span className="h-1.5 w-1.5 rounded-full bg-oz2-acc opacity-60" />
+          <span className="font-mono text-[10.5px] uppercase tracking-wide text-oz2-text-faint">
+            {c.label}
+          </span>
+          <span
+            className="font-mono rounded border border-oz2-border-soft bg-oz2-bg-soft
+              px-1.5 py-px text-[9.5px] text-oz2-text-muted"
+          >
+            {c.count}
+          </span>
         </div>
-      </EdgeLabelRenderer>
-    </>
+      ))}
+    </div>
+  );
+}
+
+function Legend() {
+  const Item = ({ cls, label }: { cls: string; label: string }) => (
+    <span className="flex items-center gap-1.5">
+      <span className={`h-0.5 w-5 rounded-full ${cls}`} />
+      <span>{label}</span>
+    </span>
+  );
+  return (
+    <div className="flex items-center gap-4 text-[11px] text-oz2-text-muted">
+      <Item cls="bg-oz2-ok" label="Enforced" />
+      <Item cls="bg-oz2-err" label="Posture-blocked" />
+      <span className="flex items-center gap-1.5">
+        <span className="h-0.5 w-5 rounded-full border-t border-dashed border-oz2-text-faint" />
+        <span>Policy flow</span>
+      </span>
+    </div>
   );
 }
 
@@ -185,41 +78,149 @@ export default function ControlCenterGraphCanvas({
   graph,
   onEdgeClick,
   onFocusNode,
+  onRefresh,
 }: {
   graph: ControlCenterGraph;
   onEdgeClick?: (policyId: string) => void;
-  onFocusNode?: (view: "peer" | "group", id: string) => void;
+  onFocusNode?: (view: FocusType, id: string) => void;
+  onRefresh?: () => void;
 }) {
-  const { nodes, edges } = useMemo(() => layout(graph), [graph]);
-  const edgeTypes = useMemo(() => ({ parallel: ParallelEdge }), []);
+  const laid = useMemo(() => layoutGraph(graph), [graph]);
+  const headers = useMemo(() => columnHeaders(graph), [graph]);
+  const [hovered, setHovered] = useState<string | null>(null);
+
+  const lit = useMemo(
+    () => (hovered ? reachableFrom(hovered, laid.adjacency) : null),
+    [hovered, laid.adjacency],
+  );
+
+  const nodes: Node[] = useMemo(
+    () =>
+      laid.nodes.map((n) => ({
+        id: n.id,
+        type: "cc",
+        position: n.position,
+        draggable: false,
+        selectable: !!n.data.switchable,
+        focusable: true,
+        ariaLabel: `${n.data.kind}: ${n.data.label}`,
+        style: { width: n.width, height: n.height },
+        data: {
+          ...n.data,
+          dimmed: !!lit && !lit.has(n.id),
+          emphasis: !!lit && lit.has(n.id),
+        },
+      })),
+    [laid.nodes, lit],
+  );
+
+  const edges: Edge[] = useMemo(
+    () =>
+      laid.edges.map((e) => {
+        const inLit = !!lit && lit.has(e.source) && lit.has(e.target);
+        return {
+          id: e.id,
+          source: e.source,
+          target: e.target,
+          type: "cc",
+          data: {
+            ...e.data,
+            dimmed: !!lit && !inLit,
+            emphasis: inLit,
+          },
+        };
+      }),
+    [laid.edges, lit],
+  );
 
   return (
-    <div className="h-[68vh] w-full overflow-hidden rounded-oz2-card border border-oz2-border-strong">
-      <ReactFlow
-        nodes={nodes}
-        edges={edges}
-        edgeTypes={edgeTypes}
-        fitView
-        nodesDraggable={false}
-        nodesConnectable={false}
-        edgesFocusable={!!onEdgeClick}
-        proOptions={{ hideAttribution: true }}
-        onNodeClick={(_, node) => {
-          const kind = (node.data as { kind?: string } | undefined)?.kind;
-          // Only peer/group nodes are valid v1 foci; clicking the
-          // current focus or a route/resource/policy node is a no-op.
-          if (onFocusNode && (kind === "peer" || kind === "group")) {
-            onFocusNode(kind, node.id);
-          }
-        }}
-        onEdgeClick={(_, edge) => {
-          const pid = (edge.data as { policyId?: string } | undefined)
-            ?.policyId;
-          if (pid && onEdgeClick) onEdgeClick(pid);
-        }}
+    <div
+      className="oz-cc-scroll relative w-full overflow-auto rounded-oz2-card
+        border border-oz2-border-strong bg-oz2-bg"
+      style={{ height: "72vh" }}
+    >
+      <div
+        className="relative"
+        style={{ width: STAGE_W, height: STAGE_H + HEADER_H + FOOTER_H }}
       >
-        <Background />
-      </ReactFlow>
+        <div className="oz-cc-grid pointer-events-none absolute inset-0" />
+        <span
+          className="font-mono absolute right-4 top-3 z-10 rounded-md bg-oz2-acc-soft
+            px-2 py-0.5 text-[10px] uppercase text-oz2-acc-text"
+        >
+          Beta
+        </span>
+        <ColumnHeaders cols={headers} />
+
+        <div
+          className="absolute left-0"
+          style={{ top: HEADER_H, width: STAGE_W, height: STAGE_H }}
+        >
+          <ReactFlow
+            nodes={nodes}
+            edges={edges}
+            nodeTypes={CC_NODE_TYPES}
+            edgeTypes={CC_EDGE_TYPES}
+            fitView={false}
+            defaultViewport={{ x: 0, y: 0, zoom: 1 }}
+            nodesDraggable={false}
+            nodesConnectable={false}
+            elementsSelectable={!!onEdgeClick}
+            panOnDrag={false}
+            panOnScroll={false}
+            zoomOnScroll={false}
+            zoomOnPinch={false}
+            zoomOnDoubleClick={false}
+            preventScrolling={false}
+            proOptions={{ hideAttribution: true }}
+            onNodeMouseEnter={(_, n) => setHovered(n.id)}
+            onNodeMouseLeave={() => setHovered(null)}
+            onNodeClick={(_, node) => {
+              const d = node.data as {
+                kind?: string;
+                switchable?: boolean;
+              };
+              if (
+                onFocusNode &&
+                d.switchable &&
+                (d.kind === "peer" || d.kind === "group")
+              ) {
+                onFocusNode(d.kind as FocusType, node.id);
+              }
+            }}
+            onEdgeClick={(_, edge) => {
+              const pid = (edge.data as { policyId?: string } | undefined)
+                ?.policyId;
+              if (pid && onEdgeClick) onEdgeClick(pid);
+            }}
+          />
+        </div>
+
+        <div
+          className="sticky bottom-0 left-0 flex items-center justify-between
+            border-t border-oz2-border bg-oz2-surface/80 px-4 backdrop-blur-md"
+          style={{ height: FOOTER_H }}
+        >
+          <Legend />
+          <div className="flex items-center gap-3 text-[11px] text-oz2-text-muted">
+            <span>
+              {graph.edges.length} connection
+              {graph.edges.length === 1 ? "" : "s"}
+            </span>
+            {onRefresh && (
+              <button
+                type="button"
+                onClick={onRefresh}
+                className="flex items-center gap-1.5 rounded-md border border-oz2-border
+                  px-2 py-1 text-oz2-text-2 transition-colors hover:bg-oz2-hover"
+              >
+                <RefreshCw className="h-3 w-3" />
+                Refresh
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/dashboard/src/modules/control-center/ControlCenterGraphCanvas.tsx
+++ b/dashboard/src/modules/control-center/ControlCenterGraphCanvas.tsx
@@ -258,18 +258,11 @@ export default function ControlCenterGraphCanvas({
   );
 
   return (
-    <div
-      ref={wrapRef}
-      className="oz-cc-scroll relative h-full w-full overflow-hidden
-        rounded-oz2-card border border-oz2-border-strong bg-oz2-bg"
-    >
+    // No own border/bg: the parent card shell (ControlCenterView)
+    // owns the frame and the top tab bar; this just fills the region
+    // below it.
+    <div ref={wrapRef} className="relative h-full w-full overflow-hidden">
       <div className="oz-cc-grid pointer-events-none absolute inset-0" />
-      <span
-        className="font-mono pointer-events-none absolute right-3 top-2.5 z-20
-          rounded-md bg-oz2-acc-soft px-2 py-0.5 text-[10px] uppercase text-oz2-acc-text"
-      >
-        Beta
-      </span>
 
       {ready && <ColumnHeaders cols={headers} />}
 

--- a/dashboard/src/modules/control-center/ControlCenterGraphCanvas.tsx
+++ b/dashboard/src/modules/control-center/ControlCenterGraphCanvas.tsx
@@ -3,7 +3,7 @@
 import "@xyflow/react/dist/style.css";
 import { type Edge, type Node, ReactFlow } from "@xyflow/react";
 import { RefreshCw } from "lucide-react";
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import type {
   ControlCenterGraph,
   FocusType,
@@ -12,40 +12,40 @@ import { CC_EDGE_TYPES } from "./ControlCenterFlowEdge";
 import {
   type ColumnHeader,
   columnHeaders,
+  FOOTER_BAND,
+  HEADER_BAND,
   layoutGraph,
   reachableFrom,
-  STAGE_H,
-  STAGE_W,
 } from "./controlCenterLayout";
 import { CC_NODE_TYPES } from "./ControlCenterNodes";
 
-// ADR-0017 2026-05-18b — the v2 columnar canvas. Replaces the v1
-// dagre reach graph: a fixed 1500×760 stage, four focus tabs,
-// Policy always the middle pivot column, edges coloured by
+// ADR-0017 2026-05-18b — the v2 columnar canvas. Full-bleed: the
+// stage spans the live container (ResizeObserver-measured), Policy
+// is always the middle pivot column, edges are coloured by
 // enforcement state (green = enforced, red = posture_blocked —
-// owner-sanctioned brand exception). The stage is pan/zoom-locked;
-// the wrapper scrolls horizontally on narrow viewports, matching the
-// hifi handoff.
-
-const HEADER_H = 56;
-const FOOTER_H = 44;
+// owner-sanctioned brand exception). Column labels sit in a top
+// band, legend + status in a bottom footer; both are overlays so
+// the graph itself uses 100% of the area.
 
 function ColumnHeaders({ cols }: { cols: ColumnHeader[] }) {
   return (
-    <div className="pointer-events-none absolute left-0 top-0 h-14 w-full">
+    <div
+      className="pointer-events-none absolute inset-x-0 top-0 z-10"
+      style={{ height: HEADER_BAND }}
+    >
       {cols.map((c) => (
         <div
           key={c.id}
-          className="absolute flex items-center gap-2"
-          style={{ left: c.x, top: 20, width: c.width }}
+          className="absolute flex items-center justify-center gap-2"
+          style={{ left: c.x, top: 12, width: c.width }}
         >
-          <span className="h-1.5 w-1.5 rounded-full bg-oz2-acc opacity-60" />
-          <span className="font-mono text-[10.5px] uppercase tracking-wide text-oz2-text-faint">
+          <span className="h-1.5 w-1.5 rounded-full bg-oz2-acc" />
+          <span className="text-[11px] font-semibold uppercase tracking-wide text-oz2-text-2">
             {c.label}
           </span>
           <span
             className="font-mono rounded border border-oz2-border-soft bg-oz2-bg-soft
-              px-1.5 py-px text-[9.5px] text-oz2-text-muted"
+              px-1.5 py-px text-[10px] text-oz2-text-muted"
           >
             {c.count}
           </span>
@@ -85,18 +85,38 @@ export default function ControlCenterGraphCanvas({
   onFocusNode?: (view: FocusType, id: string) => void;
   onRefresh?: () => void;
 }) {
-  const laid = useMemo(() => layoutGraph(graph), [graph]);
-  const headers = useMemo(() => columnHeaders(graph), [graph]);
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const [size, setSize] = useState({ w: 0, h: 0 });
   const [hovered, setHovered] = useState<string | null>(null);
 
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(([entry]) => {
+      const r = entry.contentRect;
+      setSize({ w: Math.round(r.width), h: Math.round(r.height) });
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const ready = size.w > 0 && size.h > 0;
+  const laid = useMemo(
+    () => (ready ? layoutGraph(graph, size.w, size.h) : null),
+    [graph, ready, size.w, size.h],
+  );
+  const headers = useMemo(
+    () => (ready ? columnHeaders(graph, size.w) : []),
+    [graph, ready, size.w],
+  );
   const lit = useMemo(
-    () => (hovered ? reachableFrom(hovered, laid.adjacency) : null),
-    [hovered, laid.adjacency],
+    () => (hovered && laid ? reachableFrom(hovered, laid.adjacency) : null),
+    [hovered, laid],
   );
 
   const nodes: Node[] = useMemo(
     () =>
-      laid.nodes.map((n) => ({
+      (laid?.nodes ?? []).map((n) => ({
         id: n.id,
         type: "cc",
         position: n.position,
@@ -111,114 +131,101 @@ export default function ControlCenterGraphCanvas({
           emphasis: !!lit && lit.has(n.id),
         },
       })),
-    [laid.nodes, lit],
+    [laid, lit],
   );
 
   const edges: Edge[] = useMemo(
     () =>
-      laid.edges.map((e) => {
+      (laid?.edges ?? []).map((e) => {
         const inLit = !!lit && lit.has(e.source) && lit.has(e.target);
         return {
           id: e.id,
           source: e.source,
           target: e.target,
           type: "cc",
-          data: {
-            ...e.data,
-            dimmed: !!lit && !inLit,
-            emphasis: inLit,
-          },
+          data: { ...e.data, dimmed: !!lit && !inLit, emphasis: inLit },
         };
       }),
-    [laid.edges, lit],
+    [laid, lit],
   );
 
   return (
     <div
-      className="oz-cc-scroll relative w-full overflow-auto rounded-oz2-card
-        border border-oz2-border-strong bg-oz2-bg"
-      style={{ height: "72vh" }}
+      ref={wrapRef}
+      className="oz-cc-scroll relative h-full w-full overflow-hidden
+        rounded-oz2-card border border-oz2-border-strong bg-oz2-bg"
     >
-      <div
-        className="relative"
-        style={{ width: STAGE_W, height: STAGE_H + HEADER_H + FOOTER_H }}
+      <div className="oz-cc-grid pointer-events-none absolute inset-0" />
+      <span
+        className="font-mono pointer-events-none absolute right-3 top-2.5 z-20
+          rounded-md bg-oz2-acc-soft px-2 py-0.5 text-[10px] uppercase text-oz2-acc-text"
       >
-        <div className="oz-cc-grid pointer-events-none absolute inset-0" />
-        <span
-          className="font-mono absolute right-4 top-3 z-10 rounded-md bg-oz2-acc-soft
-            px-2 py-0.5 text-[10px] uppercase text-oz2-acc-text"
-        >
-          Beta
-        </span>
-        <ColumnHeaders cols={headers} />
+        Beta
+      </span>
 
-        <div
-          className="absolute left-0"
-          style={{ top: HEADER_H, width: STAGE_W, height: STAGE_H }}
-        >
-          <ReactFlow
-            nodes={nodes}
-            edges={edges}
-            nodeTypes={CC_NODE_TYPES}
-            edgeTypes={CC_EDGE_TYPES}
-            fitView={false}
-            defaultViewport={{ x: 0, y: 0, zoom: 1 }}
-            nodesDraggable={false}
-            nodesConnectable={false}
-            elementsSelectable={!!onEdgeClick}
-            panOnDrag={false}
-            panOnScroll={false}
-            zoomOnScroll={false}
-            zoomOnPinch={false}
-            zoomOnDoubleClick={false}
-            preventScrolling={false}
-            proOptions={{ hideAttribution: true }}
-            onNodeMouseEnter={(_, n) => setHovered(n.id)}
-            onNodeMouseLeave={() => setHovered(null)}
-            onNodeClick={(_, node) => {
-              const d = node.data as {
-                kind?: string;
-                switchable?: boolean;
-              };
-              if (
-                onFocusNode &&
-                d.switchable &&
-                (d.kind === "peer" || d.kind === "group")
-              ) {
-                onFocusNode(d.kind as FocusType, node.id);
-              }
-            }}
-            onEdgeClick={(_, edge) => {
-              const pid = (edge.data as { policyId?: string } | undefined)
-                ?.policyId;
-              if (pid && onEdgeClick) onEdgeClick(pid);
-            }}
-          />
-        </div>
+      {ready && <ColumnHeaders cols={headers} />}
 
-        <div
-          className="sticky bottom-0 left-0 flex items-center justify-between
-            border-t border-oz2-border bg-oz2-surface/80 px-4 backdrop-blur-md"
-          style={{ height: FOOTER_H }}
-        >
-          <Legend />
-          <div className="flex items-center gap-3 text-[11px] text-oz2-text-muted">
-            <span>
-              {graph.edges.length} connection
-              {graph.edges.length === 1 ? "" : "s"}
-            </span>
-            {onRefresh && (
-              <button
-                type="button"
-                onClick={onRefresh}
-                className="flex items-center gap-1.5 rounded-md border border-oz2-border
-                  px-2 py-1 text-oz2-text-2 transition-colors hover:bg-oz2-hover"
-              >
-                <RefreshCw className="h-3 w-3" />
-                Refresh
-              </button>
-            )}
-          </div>
+      <div className="absolute inset-0">
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          nodeTypes={CC_NODE_TYPES}
+          edgeTypes={CC_EDGE_TYPES}
+          fitView={false}
+          defaultViewport={{ x: 0, y: 0, zoom: 1 }}
+          nodesDraggable={false}
+          nodesConnectable={false}
+          elementsSelectable={!!onEdgeClick}
+          panOnDrag={false}
+          panOnScroll={false}
+          zoomOnScroll={false}
+          zoomOnPinch={false}
+          zoomOnDoubleClick={false}
+          preventScrolling={false}
+          proOptions={{ hideAttribution: true }}
+          onNodeMouseEnter={(_, n) => setHovered(n.id)}
+          onNodeMouseLeave={() => setHovered(null)}
+          onNodeClick={(_, node) => {
+            const d = node.data as { kind?: string; switchable?: boolean };
+            if (
+              onFocusNode &&
+              d.switchable &&
+              (d.kind === "peer" || d.kind === "group")
+            ) {
+              onFocusNode(d.kind as FocusType, node.id);
+            }
+          }}
+          onEdgeClick={(_, edge) => {
+            const pid = (edge.data as { policyId?: string } | undefined)
+              ?.policyId;
+            if (pid && onEdgeClick) onEdgeClick(pid);
+          }}
+        />
+      </div>
+
+      <div
+        className="absolute inset-x-0 bottom-0 z-10 flex items-center
+          justify-between border-t border-oz2-border bg-oz2-surface/80 px-4
+          backdrop-blur-md"
+        style={{ height: FOOTER_BAND }}
+      >
+        <Legend />
+        <div className="flex items-center gap-3 text-[11px] text-oz2-text-muted">
+          <span>
+            {graph.edges.length} connection
+            {graph.edges.length === 1 ? "" : "s"}
+          </span>
+          {onRefresh && (
+            <button
+              type="button"
+              onClick={onRefresh}
+              className="flex items-center gap-1.5 rounded-md border border-oz2-border
+                px-2 py-1 text-oz2-text-2 transition-colors hover:bg-oz2-hover"
+            >
+              <RefreshCw className="h-3 w-3" />
+              Refresh
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/dashboard/src/modules/control-center/ControlCenterGraphCanvas.tsx
+++ b/dashboard/src/modules/control-center/ControlCenterGraphCanvas.tsx
@@ -79,11 +79,13 @@ export default function ControlCenterGraphCanvas({
   onEdgeClick,
   onFocusNode,
   onRefresh,
+  onOpenPicker,
 }: {
   graph: ControlCenterGraph;
   onEdgeClick?: (policyId: string) => void;
   onFocusNode?: (view: FocusType, id: string) => void;
   onRefresh?: () => void;
+  onOpenPicker?: () => void;
 }) {
   const wrapRef = useRef<HTMLDivElement>(null);
   const [size, setSize] = useState({ w: 0, h: 0 });
@@ -110,7 +112,10 @@ export default function ControlCenterGraphCanvas({
     [graph, ready, size.w],
   );
   const lit = useMemo(
-    () => (hovered && laid ? reachableFrom(hovered, laid.adjacency) : null),
+    () =>
+      hovered && laid
+        ? reachableFrom(hovered, laid.adjOut, laid.adjIn)
+        : null,
     [hovered, laid],
   );
 
@@ -186,7 +191,18 @@ export default function ControlCenterGraphCanvas({
           onNodeMouseEnter={(_, n) => setHovered(n.id)}
           onNodeMouseLeave={() => setHovered(null)}
           onNodeClick={(_, node) => {
-            const d = node.data as { kind?: string; switchable?: boolean };
+            const d = node.data as {
+              kind?: string;
+              switchable?: boolean;
+              column?: string;
+            };
+            // The focus card is the picker affordance: clicking it
+            // (or its chevron) opens the focus selector to swap the
+            // inspected entity — same as NetBird's focus dropdown.
+            if (d.kind === "focus" || d.column === "focus") {
+              onOpenPicker?.();
+              return;
+            }
             if (
               onFocusNode &&
               d.switchable &&

--- a/dashboard/src/modules/control-center/ControlCenterNodes.tsx
+++ b/dashboard/src/modules/control-center/ControlCenterNodes.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { Handle, type NodeProps,Position } from "@xyflow/react";
+import { ChevronDown, Server, Shield, Users } from "lucide-react";
+import React from "react";
+import { OSLogo } from "@/modules/peers/PeerOSCell";
+import type { CCFlowNodeData } from "./controlCenterLayout";
+
+// v2 topology kind-cards (ADR-0017 2026-05-18b / hifi handoff). One
+// info-dense card per node kind, themed via oz2-* tokens so light and
+// dark both work. xyflow injects width/height from the layout pass;
+// the card fills its node box.
+
+interface RenderData extends CCFlowNodeData {
+  dimmed?: boolean;
+  emphasis?: boolean;
+}
+
+function initials(label: string): string {
+  const parts = label.trim().split(/[\s@._-]+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[1][0]).toUpperCase();
+}
+
+const SHELL_BASE =
+  "group relative flex h-full w-full items-center rounded-[10px] " +
+  "border bg-oz2-surface shadow-oz2-sm transition-all duration-200";
+
+function shellClass(d: RenderData): string {
+  const tone = d.emphasis
+    ? "border-oz2-acc ring-[3px] ring-oz2-acc-soft -translate-y-px shadow-oz2-md"
+    : "border-oz2-border hover:border-oz2-acc hover:ring-[3px] " +
+      "hover:ring-oz2-acc-soft hover:-translate-y-px hover:shadow-oz2-md";
+  const dim = d.dimmed ? "opacity-25" : "opacity-100";
+  const click = d.switchable ? "cursor-pointer" : "";
+  return `${SHELL_BASE} ${tone} ${dim} ${click}`;
+}
+
+function Handles() {
+  return (
+    <>
+      <Handle
+        type="target"
+        position={Position.Left}
+        className="!h-1 !w-1 !border-0 !bg-transparent"
+        isConnectable={false}
+      />
+      <Handle
+        type="source"
+        position={Position.Right}
+        className="!h-1 !w-1 !border-0 !bg-transparent"
+        isConnectable={false}
+      />
+    </>
+  );
+}
+
+const AVATAR =
+  "flex shrink-0 items-center justify-center rounded-lg bg-gradient-to-br " +
+  "from-oz2-acc to-openzro-900 font-bold text-white";
+const TILE =
+  "flex shrink-0 items-center justify-center rounded-md " +
+  "border border-oz2-border-soft bg-oz2-bg-soft text-oz2-text-2";
+
+function FocusCard({ d }: { d: RenderData }) {
+  const sub = d.meta.email || d.meta.ip || d.meta.sub || "";
+  return (
+    <div className={`${shellClass(d)} px-3.5 py-3`}>
+      <Handles />
+      <div className={`${AVATAR} mr-3 h-[34px] w-[34px] text-sm`}>
+        {initials(d.label)}
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-[13.5px] font-semibold text-oz2-text">
+          {d.label}
+        </div>
+        {sub && (
+          <div className="font-mono mt-0.5 truncate text-[11px] text-oz2-text-muted">
+            {sub}
+          </div>
+        )}
+      </div>
+      <ChevronDown className="ml-2 h-4 w-4 shrink-0 text-oz2-text-faint" />
+    </div>
+  );
+}
+
+function PeerCard({ d }: { d: RenderData }) {
+  return (
+    <div className={`${shellClass(d)} gap-2.5 px-3 py-2`}>
+      <Handles />
+      <div className={`${TILE} relative h-[26px] w-[26px]`}>
+        <OSLogo os={d.meta.os || "linux"} />
+        <span
+          className="absolute -bottom-0.5 -right-0.5 h-[9px] w-[9px] rounded-full
+            border-2 border-oz2-surface bg-oz2-dot-on"
+        />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-[12.5px] font-medium text-oz2-text">
+          {d.label}
+        </div>
+        {d.meta.ip && (
+          <div className="font-mono mt-0.5 truncate text-[11px] text-oz2-text-muted">
+            {d.meta.ip}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function PolicyCard({ d }: { d: RenderData }) {
+  return (
+    <div className={`${shellClass(d)} gap-2 px-2.5 py-1.5`}>
+      <Handles />
+      <span className="relative flex h-[7px] w-[7px] shrink-0">
+        <span className="absolute inline-flex h-full w-full rounded-full bg-oz2-acc opacity-30" />
+        <span className="relative inline-flex h-[7px] w-[7px] rounded-full bg-oz2-acc" />
+      </span>
+      <span className="min-w-0 flex-1 truncate text-[11.5px] font-medium text-oz2-text">
+        {d.label}
+      </span>
+      {d.meta.port && (
+        <span
+          className="font-mono shrink-0 rounded-[5px] border border-oz2-border-soft
+            bg-oz2-bg-sunken px-1.5 py-0.5 text-[9.5px] uppercase text-oz2-text-muted"
+        >
+          {d.meta.port}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function ResourceCard({ d }: { d: RenderData }) {
+  const isPeerKind = d.meta.resourceKind === "peer" || d.kind === "group";
+  const Icon = isPeerKind ? (d.kind === "group" ? Users : Shield) : Server;
+  return (
+    <div className={`${shellClass(d)} gap-2.5 px-3 py-2`}>
+      <Handles />
+      <div className={`${TILE} h-[26px] w-[26px]`}>
+        <Icon className="h-3.5 w-3.5" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-[12.5px] font-medium text-oz2-text">
+          {d.label}
+        </div>
+        {d.meta.sub && (
+          <div className="font-mono mt-0.5 truncate text-[10.5px] text-oz2-text-muted">
+            {d.meta.sub}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function CCNode({ data }: NodeProps) {
+  // xyflow types node data as Record<string, unknown>; this is the
+  // third-party boundary (CLAUDE.md sanctioned `as` exception).
+  const d = data as unknown as RenderData;
+  if (d.kind === "focus") {
+    // network focus = the resource sitting on the right; render it as
+    // a resource card so the inverse fan-in reads correctly.
+    if (d.column === "focus" && (d.meta.resourceKind || d.meta.sub) && !d.meta.email)
+      return <ResourceCard d={d} />;
+    return <FocusCard d={d} />;
+  }
+  if (d.kind === "policy") return <PolicyCard d={d} />;
+  if (d.kind === "peer" || d.kind === "user") return <PeerCard d={d} />;
+  return <ResourceCard d={d} />;
+}
+
+export const CC_NODE_TYPES = { cc: CCNode };

--- a/dashboard/src/modules/control-center/ControlCenterNodes.tsx
+++ b/dashboard/src/modules/control-center/ControlCenterNodes.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Handle, type NodeProps,Position } from "@xyflow/react";
-import { ChevronDown, Server, Shield, Users } from "lucide-react";
+import { ChevronsUpDown, Server, Shield, Users } from "lucide-react";
 import React from "react";
 import { OSLogo } from "@/modules/peers/PeerOSCell";
 import type { CCFlowNodeData } from "./controlCenterLayout";
@@ -84,7 +84,7 @@ function FocusCard({ d }: { d: RenderData }) {
           </div>
         )}
       </div>
-      <ChevronDown className="ml-2 h-4 w-4 shrink-0 text-oz2-text-faint" />
+      <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 text-oz2-text-faint" />
     </div>
   );
 }

--- a/dashboard/src/modules/control-center/ControlCenterNodes.tsx
+++ b/dashboard/src/modules/control-center/ControlCenterNodes.tsx
@@ -66,14 +66,39 @@ const TILE =
   "flex shrink-0 items-center justify-center rounded-md " +
   "border border-oz2-border-soft bg-oz2-bg-soft text-oz2-text-2";
 
+// The focus card is the picker affordance for EVERY tab (peer, user,
+// group, network) — it always carries the ChevronsUpDown switcher.
+// Only the leading visual adapts to the entity: user → initials
+// avatar, peer → OS glyph, group → Users tile, network → Server tile.
+function FocusLead({ d }: { d: RenderData }) {
+  if (d.meta.email) {
+    return (
+      <div className={`${AVATAR} mr-3 h-[34px] w-[34px] text-sm`}>
+        {initials(d.label)}
+      </div>
+    );
+  }
+  if (d.meta.ip) {
+    return (
+      <div className={`${TILE} mr-3 h-[34px] w-[34px]`}>
+        <OSLogo os={d.meta.os || "linux"} />
+      </div>
+    );
+  }
+  const Icon = d.meta.resourceKind === "net" ? Server : Users;
+  return (
+    <div className={`${TILE} mr-3 h-[34px] w-[34px]`}>
+      <Icon className="h-4 w-4" />
+    </div>
+  );
+}
+
 function FocusCard({ d }: { d: RenderData }) {
   const sub = d.meta.email || d.meta.ip || d.meta.sub || "";
   return (
     <div className={`${shellClass(d)} px-3.5 py-3`}>
       <Handles />
-      <div className={`${AVATAR} mr-3 h-[34px] w-[34px] text-sm`}>
-        {initials(d.label)}
-      </div>
+      <FocusLead d={d} />
       <div className="min-w-0 flex-1">
         <div className="truncate text-[13.5px] font-semibold text-oz2-text">
           {d.label}
@@ -164,13 +189,10 @@ export function CCNode({ data }: NodeProps) {
   // xyflow types node data as Record<string, unknown>; this is the
   // third-party boundary (CLAUDE.md sanctioned `as` exception).
   const d = data as unknown as RenderData;
-  if (d.kind === "focus") {
-    // network focus = the resource sitting on the right; render it as
-    // a resource card so the inverse fan-in reads correctly.
-    if (d.column === "focus" && (d.meta.resourceKind || d.meta.sub) && !d.meta.email)
-      return <ResourceCard d={d} />;
-    return <FocusCard d={d} />;
-  }
+  // Every focus tab uses FocusCard so the picker chevron is always
+  // present (group/network previously fell through to ResourceCard
+  // and lost the selector — #39 v2 review).
+  if (d.kind === "focus") return <FocusCard d={d} />;
   if (d.kind === "policy") return <PolicyCard d={d} />;
   if (d.kind === "peer" || d.kind === "user") return <PeerCard d={d} />;
   return <ResourceCard d={d} />;

--- a/dashboard/src/modules/control-center/ControlCenterNodes.tsx
+++ b/dashboard/src/modules/control-center/ControlCenterNodes.tsx
@@ -33,7 +33,10 @@ function shellClass(d: RenderData): string {
     : "border-oz2-border hover:border-oz2-acc hover:ring-[3px] " +
       "hover:ring-oz2-acc-soft hover:-translate-y-px hover:shadow-oz2-md";
   const dim = d.dimmed ? "opacity-25" : "opacity-100";
-  const click = d.switchable ? "cursor-pointer" : "";
+  // focus card is the picker affordance, peer/group target nodes are
+  // re-focus affordances → both read as clickable.
+  const click =
+    d.switchable || d.column === "focus" ? "cursor-pointer" : "";
   return `${SHELL_BASE} ${tone} ${dim} ${click}`;
 }
 

--- a/dashboard/src/modules/control-center/ControlCenterView.tsx
+++ b/dashboard/src/modules/control-center/ControlCenterView.tsx
@@ -7,6 +7,12 @@ import {
   OzTabsTrigger,
 } from "@components/v2/OzTabs";
 import useFetchApi from "@utils/api";
+import {
+  Monitor,
+  Network,
+  User as UserIcon,
+  Users as UsersIcon,
+} from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import React, { useEffect, useMemo, useState } from "react";
 import {
@@ -27,12 +33,18 @@ import ControlCenterGraphCanvas from "@/modules/control-center/ControlCenterGrap
 // xyflow canvas is the primary view; the textual reachable list
 // stays as the accessible / no-graph fallback.
 
-const VIEWS: { value: FocusType; label: string }[] = [
-  { value: "peer", label: "Peer" },
-  { value: "user", label: "User" },
-  { value: "group", label: "Group" },
-  { value: "network", label: "Networks" },
+const VIEWS: {
+  value: FocusType;
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+}[] = [
+  { value: "peer", label: "Peer", icon: Monitor },
+  { value: "user", label: "User", icon: UserIcon },
+  { value: "group", label: "Group", icon: UsersIcon },
+  { value: "network", label: "Networks", icon: Network },
 ];
+
+const TABS_H = 48;
 
 function isFocusType(v: string | null): v is FocusType {
   return v === "peer" || v === "user" || v === "group" || v === "network";
@@ -145,49 +157,58 @@ export default function ControlCenterView() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [options, focusId, view]);
 
-  const viewLabel = VIEWS.find((v) => v.value === view)?.label ?? "focus";
   return (
-    <div className="flex h-full min-h-0 flex-col">
-      {/* Full-width toolbar strip over the canvas (hifi handoff): the
-          breadcrumb in the shell already names the page, so the
-          in-page title is dropped to give the graph 100% of the area.
-          The focus picker is a compact filter pill, not a wide
-          input. */}
+    <div className="flex h-full min-h-0 flex-col p-3">
+      {/* One self-contained card: tabs pinned at the TOP (like the
+          legend/footer at the bottom), graph filling everything in
+          between — no external chrome, maximum area. The tab bar
+          lives in the persistent card shell so it stays visible
+          through loading / empty / error states too. */}
       <div
-        className="flex flex-wrap items-center gap-3 border-b border-oz2-border
-          bg-oz2-bg-sunken px-5 py-2.5"
+        className="oz-cc-scroll relative min-h-0 flex-1 overflow-hidden
+          rounded-oz2-card border border-oz2-border-strong bg-oz2-bg"
       >
-        <OzTabs value={view} onValueChange={onViewChange}>
-          <OzTabsList>
-            {VIEWS.map((v) => (
-              <OzTabsTrigger key={v.value} value={v.value}>
-                {v.label}
-              </OzTabsTrigger>
-            ))}
-          </OzTabsList>
-        </OzTabs>
+        <div
+          className="absolute inset-x-0 top-0 z-30 flex items-center gap-3
+            border-b border-oz2-border bg-oz2-surface/80 px-3 backdrop-blur-md"
+          style={{ height: TABS_H }}
+        >
+          <OzTabs value={view} onValueChange={onViewChange}>
+            <OzTabsList>
+              {VIEWS.map((v) => (
+                <OzTabsTrigger key={v.value} value={v.value}>
+                  <v.icon className="h-3.5 w-3.5" />
+                  {v.label}
+                </OzTabsTrigger>
+              ))}
+            </OzTabsList>
+          </OzTabs>
+          <span
+            className="font-mono ml-auto rounded-md bg-oz2-acc-soft px-2
+              py-0.5 text-[10px] uppercase text-oz2-acc-text"
+          >
+            Beta
+          </span>
+        </div>
 
-        <p className="ml-auto hidden text-[11px] text-oz2-text-muted lg:block">
-          Read-only topology — who reaches what, through which policy,
-          on which ports. Click the focus card to switch{" "}
-          {viewLabel.toLowerCase()}.
-        </p>
-      </div>
-
-      <div className="relative min-h-0 flex-1 p-4">
-        <ControlCenterBody
-          view={view}
-          focusId={focusId}
-          isLoading={isLoading}
-          graph={graph}
-          onFocusNode={onFocusNode}
-          focusOptions={options}
-          onPickFocus={onFocusChange}
-          onRefresh={() => {
-            void mutate();
-          }}
-          onPolicyOpen={(policyId) => setEditPolicyId(policyId)}
-        />
+        <div
+          className="absolute inset-x-0 bottom-0"
+          style={{ top: TABS_H }}
+        >
+          <ControlCenterBody
+            view={view}
+            focusId={focusId}
+            isLoading={isLoading}
+            graph={graph}
+            onFocusNode={onFocusNode}
+            focusOptions={options}
+            onPickFocus={onFocusChange}
+            onRefresh={() => {
+              void mutate();
+            }}
+            onPolicyOpen={(policyId) => setEditPolicyId(policyId)}
+          />
+        </div>
       </div>
 
       <Modal

--- a/dashboard/src/modules/control-center/ControlCenterView.tsx
+++ b/dashboard/src/modules/control-center/ControlCenterView.tsx
@@ -20,14 +20,27 @@ import {
   FocusType,
 } from "@/interfaces/ControlCenter";
 import { Group } from "@/interfaces/Group";
+import { NetworkResource } from "@/interfaces/Network";
 import { Peer } from "@/interfaces/Peer";
+import { User } from "@/interfaces/User";
 import ControlCenterGraphCanvas from "@/modules/control-center/ControlCenterGraphCanvas";
 
-// Control Center data layer (ADR-0017 Phase 2, P3). Owns the focus
-// view (peer|group — v1 scope; Users/inverse-Networks are v2), the
-// focus-node selector, and the graph fetch. The xyflow canvas (P4)
-// replaces the textual reachable list below; that list stays as the
-// accessible / no-JS-graph fallback.
+// Control Center data layer (ADR-0017 2026-05-18b — v2 topology).
+// Owns the focus tab (peer|user|group|network), the focus-node
+// selector (sourced per tab), and the graph fetch. The columnar
+// xyflow canvas is the primary view; the textual reachable list
+// stays as the accessible / no-graph fallback.
+
+const VIEWS: { value: FocusType; label: string }[] = [
+  { value: "peer", label: "Peer" },
+  { value: "user", label: "User" },
+  { value: "group", label: "Group" },
+  { value: "network", label: "Networks" },
+];
+
+function isFocusType(v: string | null): v is FocusType {
+  return v === "peer" || v === "user" || v === "group" || v === "network";
+}
 
 export default function ControlCenterView() {
   const router = useRouter();
@@ -38,7 +51,7 @@ export default function ControlCenterView() {
   // remounts this view, which re-initialises from these params and
   // re-fetches the graph.
   const [view, setView] = useState<FocusType>(
-    sp.get("view") === "group" ? "group" : "peer",
+    isFocusType(sp.get("view")) ? (sp.get("view") as FocusType) : "peer",
   );
   const [focusId, setFocusId] = useState<string>(sp.get("focus") ?? "");
 
@@ -50,8 +63,17 @@ export default function ControlCenterView() {
 
   const { data: peers } = useFetchApi<Peer[]>("/peers", true);
   const { data: groups } = useFetchApi<Group[]>("/groups", true);
+  const { data: users } = useFetchApi<User[]>("/users", true);
+  const { data: resources } = useFetchApi<NetworkResource[]>(
+    "/networks/resources",
+    true,
+  );
 
-  const { data: graph, isLoading } = useFetchApi<ControlCenterGraph>(
+  const {
+    data: graph,
+    isLoading,
+    mutate,
+  } = useFetchApi<ControlCenterGraph>(
     `/control-center/${view}/${focusId}`,
     true,
     true,
@@ -64,16 +86,26 @@ export default function ControlCenterView() {
         .filter((p) => p.id)
         .map((p) => ({ id: p.id as string, label: p.name || (p.id as string) }));
     }
+    if (view === "user") {
+      return (users ?? [])
+        .filter((u) => u.id)
+        .map((u) => ({ id: u.id, label: u.name || u.email || u.id }));
+    }
+    if (view === "network") {
+      return (resources ?? [])
+        .filter((r) => r.id)
+        .map((r) => ({ id: r.id, label: r.name || r.address || r.id }));
+    }
     return (groups ?? [])
       .filter((g) => g.id)
       .map((g) => ({ id: g.id as string, label: g.name }));
-  }, [view, peers, groups]);
+  }, [view, peers, groups, users, resources]);
 
   const onViewChange = (v: string) => {
-    const fv = v as FocusType;
-    setView(fv);
-    setFocusId(""); // a peer id is not a valid group focus and vice-versa
-    syncUrl(fv, "");
+    if (!isFocusType(v)) return;
+    setView(v);
+    setFocusId(""); // an id is scoped to its focus type
+    syncUrl(v, "");
   };
 
   const onFocusChange = (f: string) => {
@@ -97,16 +129,20 @@ export default function ControlCenterView() {
           Control Center
         </h1>
         <p className="mt-1 text-sm text-oz2-text-muted">
-          Read-only access graph — what a {view} reaches, through which
-          policy, and what is policy-permitted but posture-blocked.
+          Read-only topology — who reaches what, through which policy,
+          on which ports, and what is policy-permitted but
+          posture-blocked.
         </p>
       </div>
 
       <div className="flex flex-wrap items-center gap-3">
         <OzTabs value={view} onValueChange={onViewChange}>
           <OzTabsList>
-            <OzTabsTrigger value="peer">Peers</OzTabsTrigger>
-            <OzTabsTrigger value="group">Groups</OzTabsTrigger>
+            {VIEWS.map((v) => (
+              <OzTabsTrigger key={v.value} value={v.value}>
+                {v.label}
+              </OzTabsTrigger>
+            ))}
           </OzTabsList>
         </OzTabs>
 
@@ -132,6 +168,9 @@ export default function ControlCenterView() {
         isLoading={isLoading}
         graph={graph}
         onFocusNode={onFocusNode}
+        onRefresh={() => {
+          void mutate();
+        }}
         onPolicyOpen={(policyId) => {
           // Round-trip (F1): tell the editor to return to THIS focus,
           // not the access-control list, so the audit loop closes.
@@ -156,6 +195,7 @@ function ControlCenterBody({
   graph,
   onFocusNode,
   onPolicyOpen,
+  onRefresh,
 }: {
   view: FocusType;
   focusId: string;
@@ -163,6 +203,7 @@ function ControlCenterBody({
   graph?: ControlCenterGraph;
   onFocusNode: (v: FocusType, id: string) => void;
   onPolicyOpen: (policyId: string) => void;
+  onRefresh: () => void;
 }) {
   if (focusId === "") {
     return (
@@ -215,6 +256,7 @@ function ControlCenterBody({
         graph={graph}
         onEdgeClick={onPolicyOpen}
         onFocusNode={onFocusNode}
+        onRefresh={onRefresh}
       />
       <details className="text-sm text-oz2-text-muted">
         <summary className="cursor-pointer select-none">

--- a/dashboard/src/modules/control-center/ControlCenterView.tsx
+++ b/dashboard/src/modules/control-center/ControlCenterView.tsx
@@ -69,21 +69,47 @@ export default function ControlCenterView() {
     router.replace(`/control-center?${q.toString()}`);
   };
 
-  const { data: peers } = useFetchApi<Peer[]>("/peers", true);
-  const { data: groups } = useFetchApi<Group[]>("/groups", true);
-  const { data: users } = useFetchApi<User[]>("/users", true);
+  // R5b: fetch ONLY the active tab's option source — the other three
+  // lists are dead weight on initial load. SWR keepPreviousData keeps
+  // a previously-visited tab instant on return. (4th arg = allowFetch.)
+  const { data: peers } = useFetchApi<Peer[]>(
+    "/peers",
+    true,
+    true,
+    view === "peer",
+  );
+  const { data: groups } = useFetchApi<Group[]>(
+    "/groups",
+    true,
+    true,
+    view === "group",
+  );
+  const { data: users } = useFetchApi<User[]>(
+    "/users",
+    true,
+    true,
+    view === "user",
+  );
   const { data: resources } = useFetchApi<NetworkResource[]>(
     "/networks/resources",
     true,
+    true,
+    view === "network",
   );
-  const { data: policies, mutate: mutatePolicies } = useFetchApi<
-    Policy[]
-  >("/policies", true);
 
   // Policy edit happens in a modal ON the Control Center, not by
   // navigating to /access-control — the operator must not lose the
-  // topology context (owner-decided 2026-05-18).
+  // topology context (owner-decided 2026-05-18). The policy list is
+  // only needed for that modal, so it is fetched lazily on the first
+  // policy-open, not on initial screen load (R5b).
   const [editPolicyId, setEditPolicyId] = useState<string | null>(null);
+  const [policiesNeeded, setPoliciesNeeded] = useState(false);
+  const { data: policies, mutate: mutatePolicies } = useFetchApi<Policy[]>(
+    "/policies",
+    true,
+    true,
+    policiesNeeded,
+  );
   const editPolicy = useMemo(
     () => (policies ?? []).find((p) => p.id === editPolicyId) ?? null,
     [policies, editPolicyId],
@@ -206,7 +232,10 @@ export default function ControlCenterView() {
             onRefresh={() => {
               void mutate();
             }}
-            onPolicyOpen={(policyId) => setEditPolicyId(policyId)}
+            onPolicyOpen={(policyId) => {
+              setPoliciesNeeded(true); // lazily pull /policies now
+              setEditPolicyId(policyId);
+            }}
           />
         </div>
       </div>

--- a/dashboard/src/modules/control-center/ControlCenterView.tsx
+++ b/dashboard/src/modules/control-center/ControlCenterView.tsx
@@ -284,47 +284,14 @@ function ControlCenterBody({
     );
   }
 
-  // The columnar canvas is the primary view; the textual list is the
-  // accessible / no-graph fallback, kept compact below it.
   return (
-    <div className="flex h-full min-h-0 flex-col gap-2">
-      <div className="min-h-0 flex-1">
-        <ControlCenterGraphCanvas
-          graph={graph}
-          onEdgeClick={onPolicyOpen}
-          onFocusNode={onFocusNode}
-          onRefresh={onRefresh}
-        />
-      </div>
-      <details className="shrink-0 text-sm text-oz2-text-muted">
-        <summary className="cursor-pointer select-none">
-          Reachable, as a list ({edges.length})
-        </summary>
-        <ul className="mt-2 flex max-h-40 flex-col gap-1 overflow-auto text-oz2-text">
-          {edges.map((e, i) => (
-            <li
-              key={`${e.from}-${e.to}-${e.policyId ?? e.permitSource}-${i}`}
-            >
-              → <span className="font-medium">{e.to}</span>{" "}
-              <span className="text-oz2-text-muted">
-                ({e.state},{" "}
-                {e.permitSource === "policy" && e.policyId ? (
-                  <button
-                    type="button"
-                    onClick={() => onPolicyOpen(e.policyId as string)}
-                    className="text-oz2-acc underline underline-offset-2"
-                  >
-                    {e.policyName || "policy"}
-                  </button>
-                ) : (
-                  e.permitSource
-                )}
-                {e.protocol ? `, ${e.protocol}` : ""})
-              </span>
-            </li>
-          ))}
-        </ul>
-      </details>
+    <div className="h-full min-h-0">
+      <ControlCenterGraphCanvas
+        graph={graph}
+        onEdgeClick={onPolicyOpen}
+        onFocusNode={onFocusNode}
+        onRefresh={onRefresh}
+      />
     </div>
   );
 }

--- a/dashboard/src/modules/control-center/ControlCenterView.tsx
+++ b/dashboard/src/modules/control-center/ControlCenterView.tsx
@@ -55,6 +55,8 @@ export default function ControlCenterView() {
     isFocusType(sp.get("view")) ? (sp.get("view") as FocusType) : "peer",
   );
   const [focusId, setFocusId] = useState<string>(sp.get("focus") ?? "");
+  // Controlled so the focus card in the canvas can open this picker.
+  const [pickerOpen, setPickerOpen] = useState(false);
 
   const syncUrl = (v: FocusType, f: string) => {
     const q = new URLSearchParams({ view: v });
@@ -145,7 +147,12 @@ export default function ControlCenterView() {
           </OzTabsList>
         </OzTabs>
 
-        <OzSelect value={focusId} onValueChange={onFocusChange}>
+        <OzSelect
+          value={focusId}
+          onValueChange={onFocusChange}
+          open={pickerOpen}
+          onOpenChange={setPickerOpen}
+        >
           <OzSelectTrigger
             className="!h-8 !w-auto min-w-[200px] gap-2 !rounded-full !px-3
               text-xs text-oz2-text-2"
@@ -177,6 +184,7 @@ export default function ControlCenterView() {
           isLoading={isLoading}
           graph={graph}
           onFocusNode={onFocusNode}
+          onOpenPicker={() => setPickerOpen(true)}
           onRefresh={() => {
             void mutate();
           }}
@@ -229,6 +237,7 @@ function ControlCenterBody({
   onFocusNode,
   onPolicyOpen,
   onRefresh,
+  onOpenPicker,
 }: {
   view: FocusType;
   focusId: string;
@@ -237,6 +246,7 @@ function ControlCenterBody({
   onFocusNode: (v: FocusType, id: string) => void;
   onPolicyOpen: (policyId: string) => void;
   onRefresh: () => void;
+  onOpenPicker: () => void;
 }) {
   if (focusId === "") {
     return (
@@ -291,6 +301,7 @@ function ControlCenterBody({
         onEdgeClick={onPolicyOpen}
         onFocusNode={onFocusNode}
         onRefresh={onRefresh}
+        onOpenPicker={onOpenPicker}
       />
     </div>
   );

--- a/dashboard/src/modules/control-center/ControlCenterView.tsx
+++ b/dashboard/src/modules/control-center/ControlCenterView.tsx
@@ -13,6 +13,7 @@ import {
   OzTabsTrigger,
 } from "@components/v2/OzTabs";
 import useFetchApi from "@utils/api";
+import { Filter } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import React, { useMemo, useState } from "react";
 import {
@@ -122,20 +123,18 @@ export default function ControlCenterView() {
     syncUrl(v, id);
   };
 
+  const viewLabel = VIEWS.find((v) => v.value === view)?.label ?? "focus";
   return (
-    <div className="flex h-full flex-col gap-4 p-6">
-      <div>
-        <h1 className="text-xl font-semibold text-oz2-text">
-          Control Center
-        </h1>
-        <p className="mt-1 text-sm text-oz2-text-muted">
-          Read-only topology — who reaches what, through which policy,
-          on which ports, and what is policy-permitted but
-          posture-blocked.
-        </p>
-      </div>
-
-      <div className="flex flex-wrap items-center gap-3">
+    <div className="flex h-full min-h-0 flex-col">
+      {/* Full-width toolbar strip over the canvas (hifi handoff): the
+          breadcrumb in the shell already names the page, so the
+          in-page title is dropped to give the graph 100% of the area.
+          The focus picker is a compact filter pill, not a wide
+          input. */}
+      <div
+        className="flex flex-wrap items-center gap-3 border-b border-oz2-border
+          bg-oz2-bg-sunken px-5 py-2.5"
+      >
         <OzTabs value={view} onValueChange={onViewChange}>
           <OzTabsList>
             {VIEWS.map((v) => (
@@ -147,9 +146,13 @@ export default function ControlCenterView() {
         </OzTabs>
 
         <OzSelect value={focusId} onValueChange={onFocusChange}>
-          <OzSelectTrigger className="w-[280px]">
+          <OzSelectTrigger
+            className="!h-8 !w-auto min-w-[200px] gap-2 !rounded-full !px-3
+              text-xs text-oz2-text-2"
+          >
+            <Filter className="h-3.5 w-3.5 shrink-0 text-oz2-text-muted" />
             <OzSelectValue
-              placeholder={`Select a ${view} to inspect…`}
+              placeholder={`Filter ${viewLabel.toLowerCase()}…`}
             />
           </OzSelectTrigger>
           <OzSelectContent>
@@ -160,30 +163,60 @@ export default function ControlCenterView() {
             ))}
           </OzSelectContent>
         </OzSelect>
+
+        <p className="ml-auto hidden text-[11px] text-oz2-text-muted lg:block">
+          Read-only topology — who reaches what, through which policy,
+          on which ports.
+        </p>
       </div>
 
-      <ControlCenterBody
-        view={view}
-        focusId={focusId}
-        isLoading={isLoading}
-        graph={graph}
-        onFocusNode={onFocusNode}
-        onRefresh={() => {
-          void mutate();
-        }}
-        onPolicyOpen={(policyId) => {
-          // Round-trip (F1): tell the editor to return to THIS focus,
-          // not the access-control list, so the audit loop closes.
-          const returnTo = `/control-center?view=${view}&focus=${encodeURIComponent(
-            focusId,
-          )}`;
-          router.push(
-            `/access-control/edit?id=${policyId}&returnTo=${encodeURIComponent(
-              returnTo,
-            )}`,
-          );
-        }}
-      />
+      <div className="relative min-h-0 flex-1 p-4">
+        <ControlCenterBody
+          view={view}
+          focusId={focusId}
+          isLoading={isLoading}
+          graph={graph}
+          onFocusNode={onFocusNode}
+          onRefresh={() => {
+            void mutate();
+          }}
+          onPolicyOpen={(policyId) => {
+            // Round-trip (F1): tell the editor to return to THIS
+            // focus, not the access-control list, so the audit loop
+            // closes.
+            const returnTo = `/control-center?view=${view}&focus=${encodeURIComponent(
+              focusId,
+            )}`;
+            router.push(
+              `/access-control/edit?id=${policyId}&returnTo=${encodeURIComponent(
+                returnTo,
+              )}`,
+            );
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function Centered({
+  children,
+  tone = "muted",
+}: {
+  children: React.ReactNode;
+  tone?: "muted" | "faint" | "err";
+}) {
+  const cls =
+    tone === "err"
+      ? "text-oz2-err"
+      : tone === "faint"
+        ? "text-oz2-text-faint"
+        : "text-oz2-text-muted";
+  return (
+    <div
+      className={`flex h-full items-center justify-center px-6 text-center text-sm ${cls}`}
+    >
+      <span className="max-w-md">{children}</span>
     </div>
   );
 }
@@ -207,15 +240,13 @@ function ControlCenterBody({
 }) {
   if (focusId === "") {
     return (
-      <div className="text-sm text-oz2-text-faint">
-        Pick a focus node above to render its access graph.
-      </div>
+      <Centered tone="faint">
+        Pick a {view} from the filter to render its topology.
+      </Centered>
     );
   }
   if (isLoading) {
-    return (
-      <div className="text-sm text-oz2-text-muted">Resolving access…</div>
-    );
+    return <Centered>Resolving access…</Centered>;
   }
   // Absence of evidence is NOT evidence of absence (audit tool). The
   // backend returns a graph OBJECT (edges possibly []) for a valid
@@ -233,37 +264,44 @@ function ControlCenterBody({
     graph.focus.type !== view
   ) {
     return (
-      <div className="text-sm text-oz2-err">
-        Could not resolve the access graph for the selected {view} —
-        it may no longer exist, or the request failed. Re-select a
-        focus or retry.
-      </div>
+      <Centered tone="err">
+        Could not resolve the topology for the selected {view} — it
+        may no longer exist, or the request failed. Re-select a focus
+        or retry.
+      </Centered>
     );
   }
-  if (graph.edges.length === 0) {
+  // Defensive at the API boundary: the backend now always emits
+  // arrays, but a nil slice would marshal as JSON null — guard so
+  // .length can never throw (#39 v2 review).
+  const edges = graph.edges ?? [];
+  if (edges.length === 0) {
     return (
-      <div className="text-sm text-oz2-text-muted">
-        This {graph.focus.type} reaches nothing right now.
-      </div>
+      <Centered>
+        This {graph.focus.type} reaches nothing through any policy
+        right now.
+      </Centered>
     );
   }
 
-  // P4: the xyflow canvas is the primary view; the textual list is
-  // kept as the accessible / no-graph fallback in a <details>.
+  // The columnar canvas is the primary view; the textual list is the
+  // accessible / no-graph fallback, kept compact below it.
   return (
-    <div className="flex min-h-0 flex-1 flex-col gap-3">
-      <ControlCenterGraphCanvas
-        graph={graph}
-        onEdgeClick={onPolicyOpen}
-        onFocusNode={onFocusNode}
-        onRefresh={onRefresh}
-      />
-      <details className="text-sm text-oz2-text-muted">
+    <div className="flex h-full min-h-0 flex-col gap-2">
+      <div className="min-h-0 flex-1">
+        <ControlCenterGraphCanvas
+          graph={graph}
+          onEdgeClick={onPolicyOpen}
+          onFocusNode={onFocusNode}
+          onRefresh={onRefresh}
+        />
+      </div>
+      <details className="shrink-0 text-sm text-oz2-text-muted">
         <summary className="cursor-pointer select-none">
-          Reachable, as a list ({graph.edges.length})
+          Reachable, as a list ({edges.length})
         </summary>
-        <ul className="mt-2 flex flex-col gap-1 text-oz2-text">
-          {graph.edges.map((e, i) => (
+        <ul className="mt-2 flex max-h-40 flex-col gap-1 overflow-auto text-oz2-text">
+          {edges.map((e, i) => (
             <li
               key={`${e.from}-${e.to}-${e.policyId ?? e.permitSource}-${i}`}
             >

--- a/dashboard/src/modules/control-center/ControlCenterView.tsx
+++ b/dashboard/src/modules/control-center/ControlCenterView.tsx
@@ -1,21 +1,14 @@
 "use client";
 
-import {
-  OzSelect,
-  OzSelectContent,
-  OzSelectItem,
-  OzSelectTrigger,
-  OzSelectValue,
-} from "@components/v2/OzSelect";
+import { Modal } from "@components/modal/Modal";
 import {
   OzTabs,
   OzTabsList,
   OzTabsTrigger,
 } from "@components/v2/OzTabs";
 import useFetchApi from "@utils/api";
-import { Filter } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
-import React, { useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import {
   ControlCenterGraph,
   FocusType,
@@ -23,7 +16,9 @@ import {
 import { Group } from "@/interfaces/Group";
 import { NetworkResource } from "@/interfaces/Network";
 import { Peer } from "@/interfaces/Peer";
+import { Policy } from "@/interfaces/Policy";
 import { User } from "@/interfaces/User";
+import { AccessControlModalContent } from "@/modules/access-control/AccessControlModal";
 import ControlCenterGraphCanvas from "@/modules/control-center/ControlCenterGraphCanvas";
 
 // Control Center data layer (ADR-0017 2026-05-18b — v2 topology).
@@ -55,8 +50,6 @@ export default function ControlCenterView() {
     isFocusType(sp.get("view")) ? (sp.get("view") as FocusType) : "peer",
   );
   const [focusId, setFocusId] = useState<string>(sp.get("focus") ?? "");
-  // Controlled so the focus card in the canvas can open this picker.
-  const [pickerOpen, setPickerOpen] = useState(false);
 
   const syncUrl = (v: FocusType, f: string) => {
     const q = new URLSearchParams({ view: v });
@@ -70,6 +63,18 @@ export default function ControlCenterView() {
   const { data: resources } = useFetchApi<NetworkResource[]>(
     "/networks/resources",
     true,
+  );
+  const { data: policies, mutate: mutatePolicies } = useFetchApi<
+    Policy[]
+  >("/policies", true);
+
+  // Policy edit happens in a modal ON the Control Center, not by
+  // navigating to /access-control — the operator must not lose the
+  // topology context (owner-decided 2026-05-18).
+  const [editPolicyId, setEditPolicyId] = useState<string | null>(null);
+  const editPolicy = useMemo(
+    () => (policies ?? []).find((p) => p.id === editPolicyId) ?? null,
+    [policies, editPolicyId],
   );
 
   const {
@@ -125,6 +130,21 @@ export default function ControlCenterView() {
     syncUrl(v, id);
   };
 
+  // NetBird-style: a tab always renders something. When no valid
+  // focus is selected (tab just opened, or a stale URL id that
+  // doesn't belong to this view), auto-pick the first entity; the
+  // user then switches via the picker on the focus card.
+  useEffect(() => {
+    if (options.length === 0) return;
+    if (focusId && options.some((o) => o.id === focusId)) return;
+    const first = options[0].id;
+    setFocusId(first);
+    syncUrl(view, first);
+    // syncUrl is a stable router.replace wrapper; re-running on its
+    // identity would loop. Intentionally keyed on the data only.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [options, focusId, view]);
+
   const viewLabel = VIEWS.find((v) => v.value === view)?.label ?? "focus";
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -147,33 +167,10 @@ export default function ControlCenterView() {
           </OzTabsList>
         </OzTabs>
 
-        <OzSelect
-          value={focusId}
-          onValueChange={onFocusChange}
-          open={pickerOpen}
-          onOpenChange={setPickerOpen}
-        >
-          <OzSelectTrigger
-            className="!h-8 !w-auto min-w-[200px] gap-2 !rounded-full !px-3
-              text-xs text-oz2-text-2"
-          >
-            <Filter className="h-3.5 w-3.5 shrink-0 text-oz2-text-muted" />
-            <OzSelectValue
-              placeholder={`Filter ${viewLabel.toLowerCase()}…`}
-            />
-          </OzSelectTrigger>
-          <OzSelectContent>
-            {options.map((o) => (
-              <OzSelectItem key={o.id} value={o.id}>
-                {o.label}
-              </OzSelectItem>
-            ))}
-          </OzSelectContent>
-        </OzSelect>
-
         <p className="ml-auto hidden text-[11px] text-oz2-text-muted lg:block">
           Read-only topology — who reaches what, through which policy,
-          on which ports.
+          on which ports. Click the focus card to switch{" "}
+          {viewLabel.toLowerCase()}.
         </p>
       </div>
 
@@ -184,25 +181,32 @@ export default function ControlCenterView() {
           isLoading={isLoading}
           graph={graph}
           onFocusNode={onFocusNode}
-          onOpenPicker={() => setPickerOpen(true)}
+          focusOptions={options}
+          onPickFocus={onFocusChange}
           onRefresh={() => {
             void mutate();
           }}
-          onPolicyOpen={(policyId) => {
-            // Round-trip (F1): tell the editor to return to THIS
-            // focus, not the access-control list, so the audit loop
-            // closes.
-            const returnTo = `/control-center?view=${view}&focus=${encodeURIComponent(
-              focusId,
-            )}`;
-            router.push(
-              `/access-control/edit?id=${policyId}&returnTo=${encodeURIComponent(
-                returnTo,
-              )}`,
-            );
-          }}
+          onPolicyOpen={(policyId) => setEditPolicyId(policyId)}
         />
       </div>
+
+      <Modal
+        open={!!editPolicy}
+        onOpenChange={(s) => {
+          if (!s) setEditPolicyId(null);
+        }}
+      >
+        {editPolicy && (
+          <AccessControlModalContent
+            key={editPolicy.id}
+            policy={editPolicy}
+            onSuccess={async () => {
+              setEditPolicyId(null);
+              await Promise.all([mutate(), mutatePolicies()]);
+            }}
+          />
+        )}
+      </Modal>
     </div>
   );
 }
@@ -237,7 +241,8 @@ function ControlCenterBody({
   onFocusNode,
   onPolicyOpen,
   onRefresh,
-  onOpenPicker,
+  focusOptions,
+  onPickFocus,
 }: {
   view: FocusType;
   focusId: string;
@@ -246,12 +251,13 @@ function ControlCenterBody({
   onFocusNode: (v: FocusType, id: string) => void;
   onPolicyOpen: (policyId: string) => void;
   onRefresh: () => void;
-  onOpenPicker: () => void;
+  focusOptions: { id: string; label: string }[];
+  onPickFocus: (id: string) => void;
 }) {
   if (focusId === "") {
     return (
       <Centered tone="faint">
-        Pick a {view} from the filter to render its topology.
+        No {view} available to inspect.
       </Centered>
     );
   }
@@ -281,19 +287,11 @@ function ControlCenterBody({
       </Centered>
     );
   }
-  // Defensive at the API boundary: the backend now always emits
-  // arrays, but a nil slice would marshal as JSON null — guard so
-  // .length can never throw (#39 v2 review).
-  const edges = graph.edges ?? [];
-  if (edges.length === 0) {
-    return (
-      <Centered>
-        This {graph.focus.type} reaches nothing through any policy
-        right now.
-      </Centered>
-    );
-  }
-
+  // Even with zero edges we still render the canvas: the focus card
+  // (and its picker) must stay on screen so the operator can switch
+  // to another entity instead of being dropped onto a dead-end text
+  // message (#39 v2 review). The empty state is conveyed by the
+  // footer ("0 connections") and the empty columns.
   return (
     <div className="h-full min-h-0">
       <ControlCenterGraphCanvas
@@ -301,7 +299,9 @@ function ControlCenterBody({
         onEdgeClick={onPolicyOpen}
         onFocusNode={onFocusNode}
         onRefresh={onRefresh}
-        onOpenPicker={onOpenPicker}
+        focusOptions={focusOptions}
+        focusId={focusId}
+        onPickFocus={onPickFocus}
       />
     </div>
   );

--- a/dashboard/src/modules/control-center/controlCenterLayout.ts
+++ b/dashboard/src/modules/control-center/controlCenterLayout.ts
@@ -9,11 +9,15 @@ import type {
   NodeKind,
 } from "@/interfaces/ControlCenter";
 
-export const STAGE_W = 1500;
-export const STAGE_H = 760;
-const PAD_Y = 48;
-const COL_X0 = 48;
-const COL_GAP = 352;
+// Columns span the MEASURED canvas (the view is full-bleed now), not
+// a fixed stage: x is derived from the live container width so the
+// graph uses 100% of the available area. HEADER_BAND/FOOTER_BAND are
+// the chrome the canvas overlays at top (column labels) and bottom
+// (legend + status).
+export const HEADER_BAND = 40;
+export const FOOTER_BAND = 44;
+const PAD_X = 28;
+const PAD_Y = 18;
 
 export type ColumnId =
   | "focus"
@@ -103,13 +107,17 @@ function columnOf(
 }
 
 // distributeY returns the vertical CENTRE of each of `count` items,
-// evenly spread and block-centred in the stage.
-function distributeY(count: number): number[] {
+// fully contained in the band between the header and footer chrome so
+// cards never clip. Compresses to fit when a column is dense.
+function distributeY(count: number, height: number, cardH: number): number[] {
   if (count <= 0) return [];
-  if (count === 1) return [STAGE_H / 2];
-  const usable = STAGE_H - PAD_Y * 2;
-  const step = usable / (count - 1);
-  return Array.from({ length: count }, (_, i) => PAD_Y + step * i);
+  const top = HEADER_BAND + PAD_Y + cardH / 2;
+  const bottom = height - FOOTER_BAND - PAD_Y - cardH / 2;
+  const mid = (top + bottom) / 2;
+  if (count === 1) return [mid];
+  if (bottom <= top) return Array.from({ length: count }, () => mid);
+  const step = (bottom - top) / (count - 1);
+  return Array.from({ length: count }, (_, i) => top + step * i);
 }
 
 const cmp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0);
@@ -120,9 +128,34 @@ function structural(permitSource: string, policyId?: string): boolean {
   return !policyId && permitSource === "";
 }
 
-export function layoutGraph(graph: ControlCenterGraph): LaidOutGraph {
+// columnSlots spreads the focus's columns evenly across the live
+// width: each column gets an equal slot, card centred in it.
+function columnSlots(
+  order: ColumnId[],
+  width: number,
+): Record<ColumnId, { x: number; centerX: number; width: number }> {
+  const usable = Math.max(width - PAD_X * 2, order.length * 200);
+  const slotW = usable / order.length;
+  const out = {} as Record<
+    ColumnId,
+    { x: number; centerX: number; width: number }
+  >;
+  order.forEach((col, slot) => {
+    const centerX = PAD_X + slotW * (slot + 0.5);
+    const cardW = Math.min(CARD_W[col], slotW - 32);
+    out[col] = { x: centerX - cardW / 2, centerX, width: cardW };
+  });
+  return out;
+}
+
+export function layoutGraph(
+  graph: ControlCenterGraph,
+  width: number,
+  height: number,
+): LaidOutGraph {
   const focus = graph.focus.type;
   const order = COLUMN_ORDER[focus] ?? COLUMN_ORDER.peer;
+  const slots = columnSlots(order, width);
 
   const byColumn = new Map<ColumnId, typeof graph.nodes>();
   for (const n of graph.nodes) {
@@ -133,18 +166,22 @@ export function layoutGraph(graph: ControlCenterGraph): LaidOutGraph {
   }
 
   const nodes: LaidOutNode[] = [];
-  order.forEach((col, slot) => {
+  order.forEach((col) => {
     const bucket = (byColumn.get(col) ?? [])
       .slice()
       .sort((a, b) => cmp(a.label || a.id, b.label || b.id));
-    const xLeft = COL_X0 + slot * COL_GAP;
-    const ys = distributeY(bucket.length);
+    const slotInfo = slots[col];
+    const tallest = bucket.reduce(
+      (m, n) => Math.max(m, CARD_H[n.kind] ?? 50),
+      40,
+    );
+    const ys = distributeY(bucket.length, height, tallest);
     bucket.forEach((n, i) => {
       const h = CARD_H[n.kind] ?? 50;
       nodes.push({
         id: n.id,
-        position: { x: xLeft, y: ys[i] - h / 2 },
-        width: CARD_W[col],
+        position: { x: slotInfo.x, y: ys[i] - h / 2 },
+        width: slotInfo.width,
         height: h,
         data: {
           kind: n.kind,
@@ -189,13 +226,7 @@ export function layoutGraph(graph: ControlCenterGraph): LaidOutGraph {
     };
   });
 
-  return {
-    nodes,
-    edges,
-    adjacency,
-    width: STAGE_W,
-    height: STAGE_H,
-  };
+  return { nodes, edges, adjacency, width, height };
 }
 
 const COLUMN_LABEL: Record<ColumnId, string> = {
@@ -214,20 +245,24 @@ export interface ColumnHeader {
   width: number;
 }
 
-export function columnHeaders(graph: ControlCenterGraph): ColumnHeader[] {
+export function columnHeaders(
+  graph: ControlCenterGraph,
+  width: number,
+): ColumnHeader[] {
   const focus = graph.focus.type;
   const order = COLUMN_ORDER[focus] ?? COLUMN_ORDER.peer;
+  const slots = columnSlots(order, width);
   const counts = new Map<ColumnId, number>();
   for (const n of graph.nodes) {
     const col = columnOf(n, order);
     counts.set(col, (counts.get(col) ?? 0) + 1);
   }
-  return order.map((col, slot) => ({
+  return order.map((col) => ({
     id: col,
     label: COLUMN_LABEL[col],
     count: counts.get(col) ?? 0,
-    x: COL_X0 + slot * COL_GAP,
-    width: CARD_W[col],
+    x: slots[col].x,
+    width: slots[col].width,
   }));
 }
 

--- a/dashboard/src/modules/control-center/controlCenterLayout.ts
+++ b/dashboard/src/modules/control-center/controlCenterLayout.ts
@@ -67,6 +67,10 @@ export interface CCFlowEdgeData {
   blocked: boolean;
   structural: boolean;
   label: string;
+  // group/network source→policy aggregate: "k of n members". Shown
+  // always (not only on hover) so partial reach is never mistaken
+  // for full (#39 v2 review, finding 2).
+  reachedBy: string;
 }
 
 export interface LaidOutNode {
@@ -240,6 +244,7 @@ export function layoutGraph(
         blocked,
         structural: isStructural,
         label: protoPorts,
+        reachedBy: e.meta?.reachedBy ?? "",
       },
     };
   });

--- a/dashboard/src/modules/control-center/controlCenterLayout.ts
+++ b/dashboard/src/modules/control-center/controlCenterLayout.ts
@@ -87,9 +87,14 @@ export interface LaidOutEdge {
 export interface LaidOutGraph {
   nodes: LaidOutNode[];
   edges: LaidOutEdge[];
-  // undirected adjacency for hover-isolation (two-hop transitive
-  // reachability is derived from this in the canvas).
-  adjacency: Record<string, string[]>;
+  // DIRECTED adjacency for hover-isolation. Hovering a node lights
+  // only the nodes on a path THROUGH it: its ancestors (followed via
+  // adjIn, left-ward) and its descendants (via adjOut, right-ward).
+  // A plain undirected closure would, on a dense graph, light the
+  // whole component — hovering a resource must reveal only the peers
+  // / policies / flows that reach THAT resource.
+  adjOut: Record<string, string[]>;
+  adjIn: Record<string, string[]>;
   width: number;
   height: number;
 }
@@ -106,9 +111,13 @@ function columnOf(
   return "resources";
 }
 
-// distributeY returns the vertical CENTRE of each of `count` items,
-// fully contained in the band between the header and footer chrome so
-// cards never clip. Compresses to fit when a column is dense.
+const ROW_GAP = 16;
+
+// distributeY returns the vertical CENTRE of each of `count` items.
+// Items sit at a fixed pitch (card height + gap) so a sparse column
+// reads as a tight, vertically-centred stack — not two cards pinned
+// to the top and bottom edges. Only when the natural stack is taller
+// than the band does it compress to fit (dense columns still fill).
 function distributeY(count: number, height: number, cardH: number): number[] {
   if (count <= 0) return [];
   const top = HEADER_BAND + PAD_Y + cardH / 2;
@@ -116,7 +125,15 @@ function distributeY(count: number, height: number, cardH: number): number[] {
   const mid = (top + bottom) / 2;
   if (count === 1) return [mid];
   if (bottom <= top) return Array.from({ length: count }, () => mid);
-  const step = (bottom - top) / (count - 1);
+
+  const pitch = cardH + ROW_GAP;
+  const naturalSpan = (count - 1) * pitch;
+  const available = bottom - top;
+  if (naturalSpan <= available) {
+    const start = mid - naturalSpan / 2;
+    return Array.from({ length: count }, (_, i) => start + i * pitch);
+  }
+  const step = available / (count - 1);
   return Array.from({ length: count }, (_, i) => top + step * i);
 }
 
@@ -197,10 +214,11 @@ export function layoutGraph(
     });
   });
 
-  const adjacency: Record<string, string[]> = {};
-  const link = (a: string, b: string) => {
-    (adjacency[a] ??= []).push(b);
-    (adjacency[b] ??= []).push(a);
+  const adjOut: Record<string, string[]> = {};
+  const adjIn: Record<string, string[]> = {};
+  const link = (from: string, to: string) => {
+    (adjOut[from] ??= []).push(to);
+    (adjIn[to] ??= []).push(from);
   };
 
   const edges: LaidOutEdge[] = graph.edges.map((e, i) => {
@@ -226,7 +244,7 @@ export function layoutGraph(
     };
   });
 
-  return { nodes, edges, adjacency, width, height };
+  return { nodes, edges, adjOut, adjIn, width, height };
 }
 
 const COLUMN_LABEL: Record<ColumnId, string> = {
@@ -266,19 +284,12 @@ export function columnHeaders(
   }));
 }
 
-// reachableFrom does the two-hop-and-beyond transitive walk the hifi
-// spec asks for: hovering a node reveals its full reachability tree
-// (both directions, since the column graph is a DAG and an auditor
-// wants "what touches this" as well as "what this touches").
-export function reachableFrom(
-  start: string,
-  adjacency: Record<string, string[]>,
-): Set<string> {
+function cone(start: string, adj: Record<string, string[]>): Set<string> {
   const seen = new Set<string>([start]);
   const queue = [start];
   while (queue.length) {
     const cur = queue.shift() as string;
-    for (const next of adjacency[cur] ?? []) {
+    for (const next of adj[cur] ?? []) {
       if (!seen.has(next)) {
         seen.add(next);
         queue.push(next);
@@ -286,4 +297,20 @@ export function reachableFrom(
     }
   }
   return seen;
+}
+
+// reachableFrom lights only the nodes on a path THROUGH `start`: its
+// ancestor cone (walked left-ward via adjIn) ∪ its descendant cone
+// (right-ward via adjOut). On the resource end this is exactly "the
+// peers, policies and flows that permit access to THIS resource" —
+// it does NOT bleed into sibling branches the way an undirected
+// closure would on a dense mesh (#39 v2 review — hover isolation).
+export function reachableFrom(
+  start: string,
+  adjOut: Record<string, string[]>,
+  adjIn: Record<string, string[]>,
+): Set<string> {
+  const lit = cone(start, adjIn);
+  for (const id of cone(start, adjOut)) lit.add(id);
+  return lit;
 }

--- a/dashboard/src/modules/control-center/controlCenterLayout.ts
+++ b/dashboard/src/modules/control-center/controlCenterLayout.ts
@@ -1,0 +1,254 @@
+// v2 columnar layout (ADR-0017 2026-05-18b). Replaces the v1 dagre
+// pass: positions are derived directly from the backend's
+// meta.column tag — Policy is always the middle pivot column. Pure
+// (no React / no DOM) so it is unit-testable and memoisable.
+
+import type {
+  ControlCenterGraph,
+  FocusType,
+  NodeKind,
+} from "@/interfaces/ControlCenter";
+
+export const STAGE_W = 1500;
+export const STAGE_H = 760;
+const PAD_Y = 48;
+const COL_X0 = 48;
+const COL_GAP = 352;
+
+export type ColumnId =
+  | "focus"
+  | "peers"
+  | "policies"
+  | "resources"
+  | "groups";
+
+// Display order of columns per focus tab. Policy is always the pivot;
+// only User adds a Peers column; Network is the inverse fan-in.
+const COLUMN_ORDER: Record<FocusType, ColumnId[]> = {
+  peer: ["focus", "policies", "resources"],
+  user: ["focus", "peers", "policies", "resources"],
+  group: ["focus", "policies", "resources"],
+  network: ["groups", "policies", "focus"],
+};
+
+const CARD_W: Record<ColumnId, number> = {
+  focus: 280,
+  peers: 240,
+  policies: 260,
+  resources: 260,
+  groups: 240,
+};
+
+export const CARD_H: Record<NodeKind, number> = {
+  focus: 58,
+  user: 58,
+  peer: 50,
+  policy: 38,
+  group: 50,
+  route: 50,
+  network_resource: 50,
+  network: 58,
+};
+
+export interface CCFlowNodeData {
+  kind: NodeKind;
+  label: string;
+  column: ColumnId;
+  meta: Record<string, string>;
+  switchable: boolean;
+}
+
+export interface CCFlowEdgeData {
+  policyId: string;
+  blocked: boolean;
+  structural: boolean;
+  label: string;
+}
+
+export interface LaidOutNode {
+  id: string;
+  position: { x: number; y: number };
+  width: number;
+  height: number;
+  data: CCFlowNodeData;
+}
+
+export interface LaidOutEdge {
+  id: string;
+  source: string;
+  target: string;
+  data: CCFlowEdgeData;
+}
+
+export interface LaidOutGraph {
+  nodes: LaidOutNode[];
+  edges: LaidOutEdge[];
+  // undirected adjacency for hover-isolation (two-hop transitive
+  // reachability is derived from this in the canvas).
+  adjacency: Record<string, string[]>;
+  width: number;
+  height: number;
+}
+
+function columnOf(
+  node: { kind: NodeKind; meta?: Record<string, string> },
+  order: ColumnId[],
+): ColumnId {
+  const tagged = node.meta?.column as ColumnId | undefined;
+  if (tagged && order.includes(tagged)) return tagged;
+  if (node.kind === "focus") return "focus";
+  if (node.kind === "policy") return "policies";
+  if (node.kind === "peer") return order.includes("peers") ? "peers" : "resources";
+  return "resources";
+}
+
+// distributeY returns the vertical CENTRE of each of `count` items,
+// evenly spread and block-centred in the stage.
+function distributeY(count: number): number[] {
+  if (count <= 0) return [];
+  if (count === 1) return [STAGE_H / 2];
+  const usable = STAGE_H - PAD_Y * 2;
+  const step = usable / (count - 1);
+  return Array.from({ length: count }, (_, i) => PAD_Y + step * i);
+}
+
+const cmp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0);
+
+// edgeKind: a User→Peer (or any policy-less) edge is identity
+// ownership — drawn solid, not as an animated policy flow.
+function structural(permitSource: string, policyId?: string): boolean {
+  return !policyId && permitSource === "";
+}
+
+export function layoutGraph(graph: ControlCenterGraph): LaidOutGraph {
+  const focus = graph.focus.type;
+  const order = COLUMN_ORDER[focus] ?? COLUMN_ORDER.peer;
+
+  const byColumn = new Map<ColumnId, typeof graph.nodes>();
+  for (const n of graph.nodes) {
+    const col = columnOf(n, order);
+    const bucket = byColumn.get(col) ?? [];
+    bucket.push(n);
+    byColumn.set(col, bucket);
+  }
+
+  const nodes: LaidOutNode[] = [];
+  order.forEach((col, slot) => {
+    const bucket = (byColumn.get(col) ?? [])
+      .slice()
+      .sort((a, b) => cmp(a.label || a.id, b.label || b.id));
+    const xLeft = COL_X0 + slot * COL_GAP;
+    const ys = distributeY(bucket.length);
+    bucket.forEach((n, i) => {
+      const h = CARD_H[n.kind] ?? 50;
+      nodes.push({
+        id: n.id,
+        position: { x: xLeft, y: ys[i] - h / 2 },
+        width: CARD_W[col],
+        height: h,
+        data: {
+          kind: n.kind,
+          label: n.label || n.id,
+          column: col,
+          meta: n.meta ?? {},
+          // peer/group nodes that are not the current focus are valid
+          // foci → clicking re-centres the graph on them.
+          switchable:
+            n.kind !== "focus" && (n.kind === "peer" || n.kind === "group"),
+        },
+      });
+    });
+  });
+
+  const adjacency: Record<string, string[]> = {};
+  const link = (a: string, b: string) => {
+    (adjacency[a] ??= []).push(b);
+    (adjacency[b] ??= []).push(a);
+  };
+
+  const edges: LaidOutEdge[] = graph.edges.map((e, i) => {
+    link(e.from, e.to);
+    const blocked = e.state === "posture_blocked";
+    const isStructural = structural(e.permitSource, e.policyId);
+    const protoPorts = [
+      e.protocol && e.protocol !== "all" ? e.protocol : "",
+      e.ports && e.ports.length ? e.ports.join(",") : "",
+    ]
+      .filter(Boolean)
+      .join("/");
+    return {
+      id: `e${i}-${e.from}-${e.to}-${e.state}`,
+      source: e.from,
+      target: e.to,
+      data: {
+        policyId: e.policyId ?? "",
+        blocked,
+        structural: isStructural,
+        label: protoPorts,
+      },
+    };
+  });
+
+  return {
+    nodes,
+    edges,
+    adjacency,
+    width: STAGE_W,
+    height: STAGE_H,
+  };
+}
+
+const COLUMN_LABEL: Record<ColumnId, string> = {
+  focus: "Focus",
+  peers: "Peers",
+  policies: "Policies",
+  resources: "Resources",
+  groups: "Groups",
+};
+
+export interface ColumnHeader {
+  id: ColumnId;
+  label: string;
+  count: number;
+  x: number;
+  width: number;
+}
+
+export function columnHeaders(graph: ControlCenterGraph): ColumnHeader[] {
+  const focus = graph.focus.type;
+  const order = COLUMN_ORDER[focus] ?? COLUMN_ORDER.peer;
+  const counts = new Map<ColumnId, number>();
+  for (const n of graph.nodes) {
+    const col = columnOf(n, order);
+    counts.set(col, (counts.get(col) ?? 0) + 1);
+  }
+  return order.map((col, slot) => ({
+    id: col,
+    label: COLUMN_LABEL[col],
+    count: counts.get(col) ?? 0,
+    x: COL_X0 + slot * COL_GAP,
+    width: CARD_W[col],
+  }));
+}
+
+// reachableFrom does the two-hop-and-beyond transitive walk the hifi
+// spec asks for: hovering a node reveals its full reachability tree
+// (both directions, since the column graph is a DAG and an auditor
+// wants "what touches this" as well as "what this touches").
+export function reachableFrom(
+  start: string,
+  adjacency: Record<string, string[]>,
+): Set<string> {
+  const seen = new Set<string>([start]);
+  const queue = [start];
+  while (queue.length) {
+    const cur = queue.shift() as string;
+    for (const next of adjacency[cur] ?? []) {
+      if (!seen.has(next)) {
+        seen.add(next);
+        queue.push(next);
+      }
+    }
+  }
+  return seen;
+}

--- a/dashboard/src/modules/control-center/controlCenterLayout.ts
+++ b/dashboard/src/modules/control-center/controlCenterLayout.ts
@@ -143,10 +143,12 @@ function distributeY(count: number, height: number, cardH: number): number[] {
 
 const cmp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0);
 
-// edgeKind: a User→Peer (or any policy-less) edge is identity
-// ownership — drawn solid, not as an animated policy flow.
+// A User→Peer edge is identity ownership — drawn solid, not as an
+// animated policy flow. Keyed on the explicit "identity"
+// permitSource (ADR-0017 2026-05-18c); the legacy empty-string
+// sentinel is still tolerated for forward/backward safety.
 function structural(permitSource: string, policyId?: string): boolean {
-  return !policyId && permitSource === "";
+  return !policyId && (permitSource === "identity" || permitSource === "");
 }
 
 // columnSlots spreads the focus's columns evenly across the live


### PR DESCRIPTION
## Summary

Phase **T2** of the Control Center **v2 topology** rebuild (#39) — the frontend. Replaces the v1 dagre reach canvas with the columnar topology view from the hifi handoff.

> Stacked on #58 (`feat/cc-v2-t1-columnar`, the backend projection). Base is that branch so this diff is frontend-only. Merge order: #57 → #58 → this. GitHub will retarget as the parents merge.

## What changed

A single view with **four focus tabs** (Peer / User / Group / Networks); **Policy is always the middle pivot column**; a fixed 1500×760 stage that scrolls horizontally on narrow viewports (pan/zoom locked), matching the handoff.

- **TS contract** (`interfaces/ControlCenter.ts`): `FocusType` + `NodeKind` extended with `user`/`network`; `meta.column` documented. Stays in lockstep with the Go `contract_test.go`.
- **`controlCenterLayout.ts`** — pure, memoisable, unit-testable: columnar placement derived from `meta.column` (no dagre), deterministic column slots + vertical distribution, undirected adjacency for hover-isolation, column-header descriptors.
- **`ControlCenterNodes.tsx`** — four info-dense kind cards (focus/user with avatar + email, peer with OS glyph + online dot, policy with violet bullet + port tag, resource/group with icon tile + sub), all `oz2-*` tokens → light **and** dark.
- **`ControlCenterFlowEdge.tsx`** — cubic Bézier (handoff's `bezierPath`, curve 0.55), **coloured by enforcement state: green = enforced, red = posture\_blocked**. Policy edges get the animated "live traffic" dash; a structural User→Peer edge is solid.
- **`ControlCenterGraphCanvas.tsx`** — orchestrates the stage: dot-grid + centre-glow background, column headers w/ count pills, Beta tag, hover-isolation (transitive both-direction reachability), sticky footer (legend + connection count + Refresh).
- **`ControlCenterView.tsx`** — 4-tab switch, focus selector sourced per tab (`/peers`, `/users`, `/groups`, `/networks/resources`); preserves the v1 policy-editor round-trip, the focus-identity guard, and the accessible textual fallback.
- **`globals.css`** — scoped `.oz-cc-*`: dot-grid, `oz-cc-dash-flow` keyframe, reduced-motion pause, slim scrollbar.
- **`@dagrejs/dagre` dropped** (package.json + lockfile) — unused after the columnar layout (ADR-0017 2026-05-18b "tira dagre").

## Owner-sanctioned brand exception

Edges are coloured by enforcement **state** (green/red), not the handoff's violet gradient. This is the explicit owner override recorded in ADR-0017 2026-05-18b: the audit signal (allowed vs posture-blocked) is the entire point of this view.

## Notable adaptation

The handoff's column labels are an absolute overlay; under xyflow that would desync with any transform, so the stage is **pan/zoom-locked** (zoom 1, viewport 0,0) and wrapped in an `overflow:auto` scroller — the headers then align 1:1 with the columns, exactly as specced, without fragility. The dev-only "Tweaks" panel is intentionally **not** shipped, per the handoff.

## Test plan

- [x] `npx tsc --noEmit` — full dashboard, exit 0 (no type errors)
- [x] `npx eslint` on all touched files — exit 0 (import order autofixed)
- [x] No remaining dagre imports; dependency removed from package.json + lockfile
- [ ] **Not browser-verified** — no browser/Cypress harness in this env (documented limitation; CI/owner review is authoritative). `next build` is environmentally flaky here so `tsc` is the deterministic gate.
- [ ] Cypress E2E remains deferred to #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- \#62 <!-- branch-stack -->
  - \#59 :point\_left:
