### PR TITLE
docs(adr): ADR-0017 amendment 2026-05-18c — network-focus scope + policy modal (#39)

### DIFF
--- a/docs/adr/0017-control-center-access-graph.md
+++ b/docs/adr/0017-control-center-access-graph.md
@@ -490,3 +490,55 @@ value and de-risks the resolver contract for the v2 widening.
   Same cadence: this corrective amendment is the re-gate (doc-only,
   owner-authorised) before the backend reshape lands. #39 stays the
   umbrella; Cypress still #52.
+
+- **2026-05-18c — Network-focus scope + policy-edit modal (owner-decided,
+  during the v2 build review).** Two model/behaviour decisions surfaced
+  while iterating on the v2 PRs (#58 backend, #59 frontend); recorded
+  here so the rationale and the known divergence survive:
+
+  1. **Network focus = a single `NetworkResource`, NOT a whole
+     `Network`.** NetBird's Networks tab focuses a *Network* (which
+     groups several resources) and fans in across all of them. openZro
+     v2 instead keys `Focus{type:network}` on **one network-resource
+     id** (`focus.id` = resource id; the picker lists individual
+     resources from `/networks/resources`). The inverse fan-in is
+     `Groups → Policies → that resource`. This is a **deliberate
+     scoping choice**, not an oversight: it keeps the wire contract
+     (`focus.id` is a single node id) and the projection uniform with
+     the other three tabs. Consequence/known gap: we do not reproduce
+     NetBird's "focus an entire Network with N resources" view.
+     Promoting the focus to a `Network` entity (an extra
+     `Network → Resources` column) is a **conscious future ADR
+     decision**, not a silent change — do not "fix" the single-resource
+     model without a new amendment. *Correctness note (not a decision):*
+     the resolver MUST use openZro's own
+     `Account.GetPoliciesForNetworkResource` and resolve the resource's
+     groups via `Group.Resources` — never `NetworkResource.GroupIDs`,
+     which is `gorm:"-"` and empty on the graph-loaded account (that
+     bug made the network focus look empty; fixed in #58).
+
+  2. **Policy edit is an in-context MODAL — supersedes the Phase-3 / F1
+     editor round-trip.** ADR-0017 Phase 3 (F1) specified that clicking
+     a policy-backed edge navigates to `/access-control/edit?id=…` with
+     a `returnTo` back to the same focus. That round-trip is **retired**:
+     clicking a policy edge OR a policy card now opens
+     `AccessControlModalContent` in a modal **on the Control Center**,
+     and on save the graph + policy list are revalidated in place. The
+     operator must never lose the topology context for an edit. The
+     `returnTo` navigation contract is dropped.
+
+  Supporting UX decisions (owner-confirmed against NetBird's product,
+  recorded for coherence, none of them contract-affecting): the focus
+  selector is an **inline picker anchored to the focus card** (search +
+  list), not a header control; **no header filter** — a tab always
+  auto-selects the first entity and the card picker switches it; a
+  focus with **zero edges still renders the focus card + picker** (never
+  a dead-end message); the 4 focus tabs and the legend/status footer
+  both live **inside the canvas card** (tabs pinned top, footer pinned
+  bottom) for maximum graph area. **This card/tab/footer layout is
+  explicitly UI-only and NOT an ADR decision** — it is noted here solely
+  to record that it was considered and deliberately left out of the
+  decision record (pixel layout is not architecture).
+
+  Same cadence: doc-only, owner-authorised, stacked on the
+  2026-05-18b re-gate branch. #39 umbrella; Cypress still #52.

--- a/docs/adr/0017-control-center-access-graph.md
+++ b/docs/adr/0017-control-center-access-graph.md
@@ -540,5 +540,20 @@ value and de-risks the resolver contract for the v2 widening.
   to record that it was considered and deliberately left out of the
   decision record (pixel layout is not architecture).
 
+  **Strict-green group semantics + structural edge (owner-decided in
+  the v2 build review, recorded so the decision is not lost).** "Green"
+  must be a trustworthy audit signal, so the group aggregate is strict:
+  only REAL members (`acc.GetPeer != nil`) are counted — a stale member
+  id is never a posture pass; an empty / all-stale source group emits
+  NO edge (a configured-but-actor-less group is not "permitted"), and a
+  network focus drops the policy node + `policy→resource` edge entirely
+  when every source group of the targeting policy is empty/stale (no
+  orphan green flow); partial posture stays UNION (k>0 ⇒ enforced) but
+  `meta.reachedBy="k of n members"` is ALWAYS surfaced (never shown as
+  full). Separately, the structural User→Peer edge is the explicit
+  `permitSource: "identity"` (ownership, no `policyId`) — not the
+  empty-string sentinel it used to be; the wire `PermitSource` set is
+  now `policy | route_default_permit | router_local | identity`.
+
   Same cadence: doc-only, owner-authorised, stacked on the
   2026-05-18b re-gate branch. #39 umbrella; Cypress still #52.


### PR DESCRIPTION
## Summary

Doc-only. Appends amendment **2026-05-18c** to ADR-0017 (Control Center access-graph), recording two owner decisions that surfaced while iterating on the v2 PRs (#58 backend, #59 frontend).

> Stacked on `docs/adr-0017-topology-v2-correction` (#57, the 2026-05-18b re-gate), same doc cadence — owner-authorised, owner-merges. GitHub retargets to `main` once #57 merges.

## What it records

1. **Network focus = a single `NetworkResource`, not a whole `Network`.** Deliberate scoping divergence from NetBird (which focuses an entire Network grouping several resources). Keeps `focus.id` a single node id and the projection uniform across the four tabs. Promoting to a `Network` entity is flagged as a **conscious future ADR decision**, not a silent change. Correctness note (not a decision): the resolver must use `Account.GetPoliciesForNetworkResource` + group resolution via `Group.Resources`, never the `gorm:"-"` empty `NetworkResource.GroupIDs` (that bug made the network focus look empty — fixed in #58).
2. **Policy edit = in-context modal, superseding the Phase-3 / F1 `/access-control` round-trip.** The `returnTo` navigation contract is dropped; clicking a policy edge/card opens `AccessControlModalContent` on the Control Center and revalidates in place.

Plus the supporting UX choices (inline focus picker on the card, no header filter + auto-select first, zero-edges still renders the focus, tabs/footer inside the canvas card) — recorded for coherence, none contract-affecting. The card/tab/footer **layout is explicitly noted as UI-only and deliberately NOT an ADR decision**.

## Why an amendment, not a new ADR

Per the repo convention (old ADRs append-only; new ADRs for standalone non-trivial decisions), this is a refinement of the same Control Center decision area — it belongs in 0017's dated Amendments log alongside 2026-05-17 / -18 / -18b, keeping the feature's decision trail in one place.

> Note (pre-existing, out of scope): the repo has two `0017-*` ADR files (`0017-control-center-access-graph.md` and `0017-schedule-posture-check.md`). Renumbering would break the many `ADR-0017` references in code/comments — left as a separate cleanup decision, not touched here.

## Test plan

- [ ] Doc-only — no code, no tests. Review the amendment prose for accuracy against the shipped behaviour in #58/#59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- `main` <!-- branch-stack -->
  - \#57
    - \#60 :point\_left:
