### PR TITLE
docs(adr): renumber duplicate ADR-0017 — schedule-posture-check → 0019

### DIFF
--- a/docs/adr/0019-schedule-posture-check.md
+++ b/docs/adr/0019-schedule-posture-check.md
@@ -1,4 +1,4 @@
-# ADR-0017 — Time-based posture check (`ScheduleCheck`)
+# ADR-0019 — Time-based posture check (`ScheduleCheck`)
 
 **Status:** Accepted (2026-05-13). Phase 1 — predicate + plumbing —
 shipped in `2bae7363`. Phase 2 (cluster-coordinated scheduler) and


### PR DESCRIPTION
## Summary

Doc-only, isolated. The repo had **two ADRs numbered 0017**:

| File | Title | Added | Inbound refs |
|---|---|---|---|
| `0017-schedule-posture-check.md` | Time-based posture check (`ScheduleCheck`) | 2026-05-12 | **0** |
| `0017-control-center-access-graph.md` | Control Center access-graph | 2026-05-17 | **21** (`controlcenter` pkg, handler, comments, memory, v2 PR stack #57–#60) |

The posture-check ADR had the number first by date, but it has **zero** inbound references anywhere in code/docs, while the Control Center ADR is cited as "ADR-0017 Dx" in 21 places and across the in-flight v2 stack. So the collision is resolved by moving the **unreferenced** one to the next free number (0018 is the highest; **0019** free):

- `git mv 0017-schedule-posture-check.md 0019-schedule-posture-check.md`
- its own title line `# ADR-0017 —` → `# ADR-0019 —` (the only internal "0017")

No external reference churn — verified zero inbound refs (`grep` of `0017-schedule-posture` / `schedule-posture-check` / `ADR-0017` in `management/server/posture/` all empty). Control Center keeps **0017**.

Independent of the v2 Control Center work (different ADR file); not part of the #60 amendment, which explicitly scoped this out.

## Test plan

- [ ] Doc-only rename — confirm `docs/adr/0019-schedule-posture-check.md` exists with the corrected title and no other 0017 collision remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)