### PR TITLE
fix(dashboard): policies list opens A→Z, not reversed

### DIFF
--- a/dashboard/src/modules/access-control/v2/AccessControlTableV2.tsx
+++ b/dashboard/src/modules/access-control/v2/AccessControlTableV2.tsx
@@ -103,8 +103,10 @@ export default function AccessControlTableV2({ policies, isLoading }: Props) {
   const [search, setSearch] = useState("");
   const [enabledFilter, setEnabledFilter] = useState<EnabledFilter>("all");
   const [refreshing, setRefreshing] = useState(false);
+  // Default to A→Z by name (ascending). desc:true opened the list
+  // reversed, which reads as "wrong order" to the operator.
   const [sorting, setSorting] = useState<SortingState>([
-    { id: "name", desc: true },
+    { id: "name", desc: false },
   ]);
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,


### PR DESCRIPTION
## Summary

The Access Control / Policies list opened in **reversed alphabetical order**. `AccessControlTableV2`'s default `sorting` state was `{ id: "name", desc: true }`; with `getSortedRowModel()` + the name column's built-in `"text"` sort that renders Z→A. Changed the default to ascending (`desc: false`) → A→Z.

One-line behavioural fix; no contract/API change. The pre-existing `react-hooks/exhaustive-deps` warning on the columns `useMemo` (line ~227, unrelated to this change) is intentionally left untouched.

## Test plan
- [x] `tsc --noEmit` clean (no new errors)
- [x] `eslint` exit 0 (only the pre-existing unrelated warning)
- [ ] Open /access-control → list is A→Z by name; clicking the Name header still toggles asc/desc

🤖 Generated with [Claude Code](https://claude.com/claude-code)