### PR TITLE
fix(client): Windows daemon port 41731→41831 (coexist with NetBird)

### DIFF
--- a/client/cmd/root.go
+++ b/client/cmd/root.go
@@ -113,7 +113,12 @@ func init() {
 
 	defaultDaemonAddr := "unix:///var/run/openzro.sock"
 	if runtime.GOOS == "windows" {
-		defaultDaemonAddr = "tcp://127.0.0.1:41731"
+		// 41831, NOT NetBird's 41731: on Windows the daemon↔CLI gRPC
+		// binds a fixed loopback TCP port (no unix socket), so reusing
+		// NetBird's port means the openZro service can't start while a
+		// NetBird service is also installed. A distinct port lets both
+		// coexist. Keep in sync with client/ui/client_ui.go.
+		defaultDaemonAddr = "tcp://127.0.0.1:41831"
 	}
 
 	rootCmd.PersistentFlags().StringVar(&daemonAddr, "daemon-addr", defaultDaemonAddr, "Daemon service address to serve CLI requests [unix|tcp]://[path|host:port]")

--- a/client/ui/client_ui.go
+++ b/client/ui/client_ui.go
@@ -137,7 +137,10 @@ func parseFlags() *cliFlags {
 
 	defaultDaemonAddr := "unix:///var/run/openzro.sock"
 	if runtime.GOOS == "windows" {
-		defaultDaemonAddr = "tcp://127.0.0.1:41731"
+		// 41831, NOT NetBird's 41731 — must match the daemon default
+		// in client/cmd/root.go so the UI dials the openZro daemon
+		// (and both can coexist with a NetBird install on Windows).
+		defaultDaemonAddr = "tcp://127.0.0.1:41831"
 	}
 	flag.StringVar(&flags.daemonAddr, "daemon-addr", defaultDaemonAddr, "Daemon service address to serve CLI requests [unix|tcp]://[path|host:port]")
 	flag.BoolVar(&flags.showSettings, "settings", false, "run settings window")


### PR DESCRIPTION
## Problem

On Windows the openZro client **service fails to start when a NetBird service is present** — port conflict.

## Root cause

On Windows the daemon↔CLI/UI gRPC has no unix socket; it binds a fixed loopback TCP port. openZro inherited NetBird's default **`tcp://127.0.0.1:41731`** verbatim in two places:

- `client/cmd/root.go:116` — daemon + CLI default
- `client/ui/client_ui.go:140` — desktop UI default

So whenever NetBird's service is installed/running and holding `127.0.0.1:41731`, the openZro service can't bind it and won't start. The Windows **service name** (`openzro`) and the unix socket (`/var/run/openzro.sock`) were already rebranded — only this Windows TCP port was still NetBird's.

## Fix

Both sites → `tcp://127.0.0.1:41831` (deliberately ≠ 41731), kept in sync, with a comment explaining the constraint. openZro and NetBird can now run side by side on Windows.

## Test plan
- [x] `gofmt` clean; `go build ./client/...` OK
- [x] No functional `41731` reference left (only explanatory comments)
- [ ] Windows: with NetBird service running, install+start openZro service → binds 41831, starts cleanly; CLI (`openzro status`) and the UI both reach the daemon
- [ ] Existing single-product install still works (no NetBird) — default just changed port

🤖 Generated with [Claude Code](https://claude.com/claude-code)