### PR TITLE
fix(store): create accountB before seeding its posture check (fixes Management Unit Postgres/MySQL red)

### DIFF
--- a/management/server/store/sql_store_test.go
+++ b/management/server/store/sql_store_test.go
@@ -1762,6 +1762,17 @@ func TestSqlStore_GetAllPostureChecks(t *testing.T) {
 			},
 		},
 	}
+	// accountB is NOT in extended-store.sql (only accountA's row is —
+	// edafee4e… merely appears there as a column value, not as an
+	// accounts.id). posture_checks has a real FK to accounts
+	// (fk_accounts_posture_checks), so seeding accountB's check only
+	// "worked" on SQLite, which does not enforce FKs by default; on
+	// Postgres/MySQL it violated the constraint (SQLSTATE 23503) and
+	// failed CI. Create the parent account so the cross-account
+	// assertion this test exists for is exercised on every engine.
+	require.NoError(t, store.SaveAccount(ctx,
+		newAccountWithId(ctx, accountB, "posture-test-userB", "")))
+
 	for _, c := range seed {
 		require.NoError(t, store.SavePostureChecks(ctx, LockingStrengthUpdate, c))
 	}


### PR DESCRIPTION
## Problem

`Management / Unit (amd64, postgres)` and `(amd64, mysql)` have failed on **every PR** (and on `main` itself) — a pre-existing red, not introduced by recent work.

## Root cause

`TestSqlStore_GetAllPostureChecks` seeds a posture check with `AccountID = edafee4e-63fb-11ec-90d6-0242ac120003` ("accountB"). That UUID is **not an `accounts.id`** in `testdata/extended-store.sql` — the fixture has a single account row (`bf1c8084-…` = accountA); `edafee4e-…` only appears there as a *column value* of accountA's row. `posture_checks` has a real FK `fk_accounts_posture_checks → accounts`. The orphan insert only succeeded on **SQLite** (FK enforcement off by default); on **Postgres/MySQL** it violated the constraint (`SQLSTATE 23503`) and failed the job.

## Fix

Create accountB (via `store.SaveAccount` + the test-local `newAccountWithId`) before the seed loop, so the FK is satisfied and the test's cross-account intent (`GetAllPostureChecks` returns rows from two accounts) is actually exercised on every engine. One test file; no production code touched. Clean-room — openZro's own test for the openZro ScheduleCheck feature.

## Test plan
- [x] `gofmt` clean; `go test -run '^TestSqlStore_GetAllPostureChecks$' ./management/server/store/` green on SQLite
- [ ] CI: `Management / Unit (amd64, postgres)` and `(amd64, mysql)` go green (authoritative — the FK is only enforced there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)