### PR TITLE
ci: authenticate Docker Hub for testcontainers (fix anon rate-limit red)

### DIFF
--- a/.github/workflows/golang-test-linux.yml
+++ b/.github/workflows/golang-test-linux.yml
@@ -354,6 +354,31 @@ jobs:
       - name: check git status
         run: git --no-pager diff --exit-code
 
+      # Authenticated Docker Hub pulls so testcontainers (postgres/
+      # mysql) don't hit the anonymous rate limit — "Failed to get
+      # image auth … mysql:8.0" was the pre-existing Management red.
+      # Adapted from netbirdio/netbird's BSD-licensed
+      # golang-test-linux.yml (test_management job). The Test step
+      # runs `go test -exec sudo …`, so root's docker config needs
+      # the login too. Gated on the secret being present, so fork
+      # PRs / forks without it skip cleanly (fall back to anon pulls)
+      # instead of failing.
+      - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker login for root user
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: echo "$DOCKERHUB_TOKEN" | sudo docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+
       - name: Test
         run: |
           CGO_ENABLED=1 GOARCH=${{ matrix.arch }} \
@@ -403,6 +428,31 @@ jobs:
 
       - name: check git status
         run: git --no-pager diff --exit-code
+
+      # Authenticated Docker Hub pulls so testcontainers (postgres/
+      # mysql) don't hit the anonymous rate limit — "Failed to get
+      # image auth … mysql:8.0" was the pre-existing Management red.
+      # Adapted from netbirdio/netbird's BSD-licensed
+      # golang-test-linux.yml (test_management job). The Test step
+      # runs `go test -exec sudo …`, so root's docker config needs
+      # the login too. Gated on the secret being present, so fork
+      # PRs / forks without it skip cleanly (fall back to anon pulls)
+      # instead of failing.
+      - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker login for root user
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: echo "$DOCKERHUB_TOKEN" | sudo docker login --username "$DOCKERHUB_USERNAME" --password-stdin
 
       - name: Test
         run: |
@@ -481,6 +531,31 @@ jobs:
       - name: check git status
         run: git --no-pager diff --exit-code
 
+      # Authenticated Docker Hub pulls so testcontainers (postgres/
+      # mysql) don't hit the anonymous rate limit — "Failed to get
+      # image auth … mysql:8.0" was the pre-existing Management red.
+      # Adapted from netbirdio/netbird's BSD-licensed
+      # golang-test-linux.yml (test_management job). The Test step
+      # runs `go test -exec sudo …`, so root's docker config needs
+      # the login too. Gated on the secret being present, so fork
+      # PRs / forks without it skip cleanly (fall back to anon pulls)
+      # instead of failing.
+      - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker login for root user
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: echo "$DOCKERHUB_TOKEN" | sudo docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+
       - name: Test
         run: |
           CGO_ENABLED=1 GOARCH=${{ matrix.arch }} \
@@ -533,6 +608,31 @@ jobs:
 
       - name: check git status
         run: git --no-pager diff --exit-code
+
+      # Authenticated Docker Hub pulls so testcontainers (postgres/
+      # mysql) don't hit the anonymous rate limit — "Failed to get
+      # image auth … mysql:8.0" was the pre-existing Management red.
+      # Adapted from netbirdio/netbird's BSD-licensed
+      # golang-test-linux.yml (test_management job). The Test step
+      # runs `go test -exec sudo …`, so root's docker config needs
+      # the login too. Gated on the secret being present, so fork
+      # PRs / forks without it skip cleanly (fall back to anon pulls)
+      # instead of failing.
+      - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker login for root user
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: echo "$DOCKERHUB_TOKEN" | sudo docker login --username "$DOCKERHUB_USERNAME" --password-stdin
 
       - name: Test
         run: |


### PR DESCRIPTION
## Problem

`Management / Unit (postgres|mysql)`, `Management / Integration (postgres)`, and the Management Benchmark jobs intermittently/consistently failed with `Failed to get image auth for https://index.docker.io/v1/ … mysql:8.0` — testcontainers pulling DB images **anonymously** from Docker Hub and hitting the anonymous pull rate limit. Pre-existing red on every PR and on `main`.

## Fix

Add, before the `Test` step in the **4 management testcontainer jobs** (`test_management`, `benchmark`, `api_benchmark`, `api_integration_test`):

1. `docker/login-action@v3` (runner user)
2. a root-user `docker login` — the Test step runs `go test -exec "sudo …"`, so testcontainers' docker calls run as root, which has its own `~/.docker/config.json`.

Both gated on `env.DOCKERHUB_USERNAME != ''` so forks / PRs without the secret **skip cleanly** (fall back to anonymous pulls) instead of erroring.

Adapted from **netbirdio/netbird**'s BSD-licensed `.github/workflows/golang-test-linux.yml` (`test_management` job), per the project's BSD-adaptation posture; deviation from upstream noted in the commit (secret-presence gate vs upstream's fork-status gate).

## ⚠️ Required repository secrets

This needs **both** `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`. `DOCKERHUB_TOKEN` was created; **`DOCKERHUB_USERNAME` (the Docker Hub account login) must also be added** — until it is, the gate keeps the steps skipped and the rate-limit fix is inert (no failure, just no effect).

## Test plan
- [x] `yaml.safe_load` parses; login present in exactly the 4 management jobs, nowhere else
- [ ] With both secrets set: `Management / Unit (postgres|mysql)` + `Integration` pull authenticated, no rate-limit error
- [ ] Combined with #66 (FK fix), the Management Unit reds clear on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)