### PR TITLE
fix(server): seed parent account in ScheduleLoader tests (residual Postgres/MySQL FK red)

### DIFF
--- a/management/server/posture_schedule_loader_test.go
+++ b/management/server/posture_schedule_loader_test.go
@@ -11,6 +11,19 @@ import (
 	"github.com/openzro/openzro/management/server/store"
 )
 
+// seedAccount persists a bare parent account so SavePostureChecks
+// satisfies the posture_checks → accounts FK
+// (fk_accounts_posture_checks). These loader tests start from an
+// empty store and used raw account-id strings that were never
+// created — that only "worked" on SQLite (FKs off by default); on
+// Postgres/MySQL it violated the constraint (SQLSTATE 23503) and
+// failed CI. Same root-cause class as the store-layer fix in #66.
+func seedAccount(t testing.TB, st store.Store, id string) {
+	t.Helper()
+	require.NoError(t, st.SaveAccount(context.Background(),
+		newAccountWithId(context.Background(), id, id+"-user", "", false)))
+}
+
 // TestScheduleLoader_AccountsWithActiveSchedules covers the N+1 fix:
 // AccountsWithActiveSchedules must return exactly the set of accounts
 // owning at least one posture check with a ScheduleCheck, deduped,
@@ -24,6 +37,9 @@ func TestScheduleLoader_AccountsWithActiveSchedules(t *testing.T) {
 	accountSched1 := "acct-sched-1"
 	accountSched2 := "acct-sched-2"
 	accountNoSched := "acct-no-sched"
+	seedAccount(t, st, accountSched1)
+	seedAccount(t, st, accountSched2)
+	seedAccount(t, st, accountNoSched)
 
 	seed := []*posture.Checks{
 		{
@@ -98,6 +114,7 @@ func TestScheduleLoader_LoadActiveSchedules(t *testing.T) {
 	ctx := context.Background()
 
 	const accountID = "acct-x"
+	seedAccount(t, st, accountID)
 	require.NoError(t, st.SavePostureChecks(ctx, store.LockingStrengthUpdate, &posture.Checks{
 		ID:        "pc-sched",
 		AccountID: accountID,


### PR DESCRIPTION
## Problem

After #66 (Docker Hub auth via #67 now working — no more "Failed to get image auth"), `Management / Unit (postgres|mysql)` and `Management / Integration (postgres)` were **still red**, now on different tests:

- `TestScheduleLoader_AccountsWithActiveSchedules`
- `TestScheduleLoader_LoadActiveSchedules`

Same root-cause **class** as #66: `posture_schedule_loader_test.go` starts from an empty store and calls `SavePostureChecks` with raw account ids (`acct-sched-1/2`, `acct-no-sched`, `acct-x`) that were never persisted. The `posture_checks → accounts` FK (`fk_accounts_posture_checks`) is only enforced on Postgres/MySQL, so the orphan inserts passed on SQLite and failed there (`SQLSTATE 23503`).

## Fix

Add a `seedAccount` helper that `SaveAccount`s a bare parent account (`newAccountWithId`) before the posture seed, called for every account id the tests use. Assertions are unchanged (bare accounts carry zero posture checks). `*_EmptyStore` tests untouched (no SavePostureChecks). Clean-room — openZro's own ScheduleCheck tests.

`TestAccountManager_NetworkUpdates_DeleteGroup` appeared adjacent in the failing log but uses `createManager` (real account) — its FAIL was collateral log-noise from the parallel ScheduleLoader failure; the next run confirms.

## Test plan
- [x] `gofmt` clean; `go test -run '^TestScheduleLoader_' ./management/server/` green on SQLite
- [ ] CI: `Management / Unit (postgres|mysql)` + `Integration (postgres)` go green (authoritative — FK only enforced there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)