### PR TITLE
fix(dashboard): CC re-focus prefixed-id bug + /policies prefetch

### DIFF
--- a/dashboard/src/components/modal/Modal.tsx
+++ b/dashboard/src/components/modal/Modal.tsx
@@ -53,6 +53,14 @@ type ModalContentProps = {
   // `accessibilityTitle` prop is the fallback we emit visually
   // hidden when the caller hasn't supplied one. Defaults to "Dialog".
   accessibilityTitle?: string;
+  // a11y description — Radix 1.1+ also warns when Dialog.Content has
+  // neither a Dialog.Description nor an explicit aria-describedby.
+  // Same fallback strategy as accessibilityTitle: emit a visually
+  // hidden Dialog.Description so the contract is satisfied without
+  // forcing every caller to thread one through. Empty by default —
+  // the element/id alone silences the warning; pass a string when a
+  // modal has a meaningful screen-reader description.
+  accessibilityDescription?: string;
 };
 
 const ModalContent = React.forwardRef<
@@ -67,6 +75,7 @@ const ModalContent = React.forwardRef<
       showClose = true,
       maxWidthClass = "max-w-3xl",
       accessibilityTitle = "Dialog",
+      accessibilityDescription = "",
       ...props
     },
     ref,
@@ -91,6 +100,9 @@ const ModalContent = React.forwardRef<
           <>
             <VisuallyHidden.Root>
               <DialogPrimitive.Title>{accessibilityTitle}</DialogPrimitive.Title>
+              <DialogPrimitive.Description>
+                {accessibilityDescription}
+              </DialogPrimitive.Description>
             </VisuallyHidden.Root>
             {children}
             {showClose && (
@@ -122,6 +134,7 @@ const SidebarModalContent = React.forwardRef<
       showClose = true,
       maxWidthClass = "max-w-3xl",
       accessibilityTitle = "Dialog",
+      accessibilityDescription = "",
       ...props
     },
     ref,
@@ -162,6 +175,9 @@ const SidebarModalContent = React.forwardRef<
               <DialogPrimitive.Title>
                 {accessibilityTitle}
               </DialogPrimitive.Title>
+              <DialogPrimitive.Description>
+                {accessibilityDescription}
+              </DialogPrimitive.Description>
             </VisuallyHidden.Root>
             {children}
             {showClose && (

--- a/dashboard/src/modules/control-center/ControlCenterGraphCanvas.tsx
+++ b/dashboard/src/modules/control-center/ControlCenterGraphCanvas.tsx
@@ -310,6 +310,21 @@ export default function ControlCenterGraphCanvas({
               onEdgeClick(node.id.replace(/^policy:/, ""));
               return;
             }
+            // A network-resource leaf re-focuses the Networks tab on
+            // that resource ("who else can reach this?") — symmetric
+            // with the peer/group re-focus. d.entityId is the raw
+            // resource id (the "nr:" node-id prefix is already
+            // stripped in the layout); /control-center/network/<id>
+            // and the picker both key on that raw id.
+            if (
+              onFocusNode &&
+              d.kind === "network_resource" &&
+              d.column !== "focus" &&
+              d.entityId
+            ) {
+              onFocusNode("network", d.entityId);
+              return;
+            }
             if (
               onFocusNode &&
               d.switchable &&

--- a/dashboard/src/modules/control-center/ControlCenterGraphCanvas.tsx
+++ b/dashboard/src/modules/control-center/ControlCenterGraphCanvas.tsx
@@ -295,6 +295,7 @@ export default function ControlCenterGraphCanvas({
               kind?: string;
               switchable?: boolean;
               column?: string;
+              entityId?: string;
             };
             // The focus card is the picker affordance: clicking it
             // (or its chevron) opens an inline selector anchored to
@@ -312,9 +313,15 @@ export default function ControlCenterGraphCanvas({
             if (
               onFocusNode &&
               d.switchable &&
+              d.entityId &&
               (d.kind === "peer" || d.kind === "group")
             ) {
-              onFocusNode(d.kind as FocusType, node.id);
+              // d.entityId is the raw account-entity id; node.id is
+              // prefixed for groups ("group:<gid>") / resources, which
+              // the focus endpoint + picker do NOT understand —
+              // passing node.id 404'd or fell back to the default
+              // focus (#39 v2 review).
+              onFocusNode(d.kind as FocusType, d.entityId);
             }
           }}
           onEdgeClick={(_, edge) => {

--- a/dashboard/src/modules/control-center/ControlCenterNodes.tsx
+++ b/dashboard/src/modules/control-center/ControlCenterNodes.tsx
@@ -33,10 +33,17 @@ function shellClass(d: RenderData): string {
     : "border-oz2-border hover:border-oz2-acc hover:ring-[3px] " +
       "hover:ring-oz2-acc-soft hover:-translate-y-px hover:shadow-oz2-md";
   const dim = d.dimmed ? "opacity-25" : "opacity-100";
-  // focus card is the picker affordance, peer/group target nodes are
-  // re-focus affordances → both read as clickable.
-  const click =
-    d.switchable || d.column === "focus" ? "cursor-pointer" : "";
+  // Every node the canvas wires a click to must read as clickable:
+  // focus card (picker), switchable peer/group (re-focus), policy
+  // (opens the editor), and network-resource leaves (re-focus the
+  // Networks tab on that resource). Keep this predicate in lockstep
+  // with ControlCenterGraphCanvas onNodeClick.
+  const clickable =
+    d.switchable ||
+    d.column === "focus" ||
+    d.kind === "policy" ||
+    d.kind === "network_resource";
+  const click = clickable ? "cursor-pointer" : "";
   return `${SHELL_BASE} ${tone} ${dim} ${click}`;
 }
 

--- a/dashboard/src/modules/control-center/ControlCenterView.tsx
+++ b/dashboard/src/modules/control-center/ControlCenterView.tsx
@@ -23,6 +23,7 @@ import { Group } from "@/interfaces/Group";
 import { NetworkResource } from "@/interfaces/Network";
 import { Peer } from "@/interfaces/Peer";
 import { Policy } from "@/interfaces/Policy";
+import { PostureCheck } from "@/interfaces/PostureCheck";
 import { User } from "@/interfaces/User";
 import { AccessControlModalContent } from "@/modules/access-control/AccessControlModal";
 import ControlCenterGraphCanvas from "@/modules/control-center/ControlCenterGraphCanvas";
@@ -72,30 +73,31 @@ export default function ControlCenterView() {
   // R5b: fetch ONLY the active tab's option source — the other three
   // lists are dead weight on initial load. SWR keepPreviousData keeps
   // a previously-visited tab instant on return. (4th arg = allowFetch.)
-  const { data: peers } = useFetchApi<Peer[]>(
+  const { data: peers, isLoading: peersLoading } = useFetchApi<Peer[]>(
     "/peers",
     true,
     true,
     view === "peer",
   );
-  const { data: groups } = useFetchApi<Group[]>(
+  const { data: groups, isLoading: groupsLoading } = useFetchApi<Group[]>(
     "/groups",
     true,
     true,
     view === "group",
   );
-  const { data: users } = useFetchApi<User[]>(
+  const { data: users, isLoading: usersLoading } = useFetchApi<User[]>(
     "/users",
     true,
     true,
     view === "user",
   );
-  const { data: resources } = useFetchApi<NetworkResource[]>(
-    "/networks/resources",
-    true,
-    true,
-    view === "network",
-  );
+  const { data: resources, isLoading: resourcesLoading } =
+    useFetchApi<NetworkResource[]>(
+      "/networks/resources",
+      true,
+      true,
+      view === "network",
+    );
 
   // Policy edit happens in a modal ON the Control Center, not by
   // navigating to /access-control — the operator must not lose the
@@ -113,6 +115,22 @@ export default function ControlCenterView() {
   const editPolicy = useMemo(
     () => (policies ?? []).find((p) => p.id === editPolicyId) ?? null,
     [policies, editPolicyId],
+  );
+
+  // #70 prefetched /policies so the editPolicy LOOKUP is instant, but
+  // the modal BODY (useAccessControl + the two PeerGroupSelectors)
+  // still cold-fetched /posture-checks and /networks/resources on
+  // first mount — that residual fetch was the lingering open lag.
+  // Warm both as soon as the editor is reachable (graph has a policy
+  // node, same trigger as policiesNeeded). SWR dedupes the
+  // /networks/resources key with the Networks-tab fetch above, so
+  // this only actually fetches on the peer/user/group tabs.
+  useFetchApi<PostureCheck[]>("/posture-checks", true, true, policiesNeeded);
+  useFetchApi<NetworkResource[]>(
+    "/networks/resources",
+    true,
+    true,
+    policiesNeeded,
   );
 
   const {
@@ -158,6 +176,17 @@ export default function ControlCenterView() {
       .filter((g) => g.id)
       .map((g) => ({ id: g.id as string, label: g.name }));
   }, [view, peers, groups, users, resources]);
+
+  // "This tab genuinely has no entities" vs "the tab's list is still
+  // loading" are different states. Switching tabs resets focusId to ""
+  // and the auto-select-first effect can't pick until the active
+  // list resolves — without this flag the empty-state ("No <view>
+  // available to inspect.") flashes for the whole fetch window.
+  const optionsLoading =
+    (view === "peer" && peersLoading) ||
+    (view === "user" && usersLoading) ||
+    (view === "group" && groupsLoading) ||
+    (view === "network" && resourcesLoading);
 
   const onViewChange = (v: string) => {
     if (!isFocusType(v)) return;
@@ -237,6 +266,7 @@ export default function ControlCenterView() {
             view={view}
             focusId={focusId}
             isLoading={isLoading}
+            optionsLoading={optionsLoading}
             graph={graph}
             onFocusNode={onFocusNode}
             focusOptions={options}
@@ -299,6 +329,7 @@ function ControlCenterBody({
   view,
   focusId,
   isLoading,
+  optionsLoading,
   graph,
   onFocusNode,
   onPolicyOpen,
@@ -309,6 +340,7 @@ function ControlCenterBody({
   view: FocusType;
   focusId: string;
   isLoading: boolean;
+  optionsLoading: boolean;
   graph?: ControlCenterGraph;
   onFocusNode: (v: FocusType, id: string) => void;
   onPolicyOpen: (policyId: string) => void;
@@ -317,6 +349,14 @@ function ControlCenterBody({
   onPickFocus: (id: string) => void;
 }) {
   if (focusId === "") {
+    // Don't claim "nothing here" while the tab's entity list is still
+    // in flight — that false-empty flash on every tab switch is the
+    // reported bug. Show the load state until the list resolves; the
+    // auto-select-first effect then picks an entity (or, if the list
+    // really is empty, the message below is finally correct).
+    if (optionsLoading) {
+      return <Centered>Loading {view}s…</Centered>;
+    }
     return (
       <Centered tone="faint">
         No {view} available to inspect.

--- a/dashboard/src/modules/control-center/ControlCenterView.tsx
+++ b/dashboard/src/modules/control-center/ControlCenterView.tsx
@@ -126,6 +126,18 @@ export default function ControlCenterView() {
     focusId !== "",
   );
 
+  // Prefetch /policies as soon as a topology with policy nodes is
+  // shown, so the edit modal is ready *before* the first click
+  // instead of blocking on the request then (R5b deferred it to
+  // the click, which made the first edit feel broken). The four
+  // entity lists stay active-tab-only — the R5b win is kept.
+  useEffect(() => {
+    if (policiesNeeded) return;
+    if (graph?.nodes?.some((n) => n.kind === "policy")) {
+      setPoliciesNeeded(true);
+    }
+  }, [graph, policiesNeeded]);
+
   const options = useMemo(() => {
     if (view === "peer") {
       return (peers ?? [])

--- a/dashboard/src/modules/control-center/controlCenterLayout.ts
+++ b/dashboard/src/modules/control-center/controlCenterLayout.ts
@@ -60,6 +60,10 @@ export interface CCFlowNodeData {
   column: ColumnId;
   meta: Record<string, string>;
   switchable: boolean;
+  // Raw account-entity id. Node ids are prefixed ("group:<id>",
+  // "nr:<id>", "policy:<id>"); peer/user are raw. Re-focusing and the
+  // focus endpoint need the RAW id, never the prefixed node id.
+  entityId: string;
 }
 
 export interface CCFlowEdgeData {
@@ -211,6 +215,9 @@ export function layoutGraph(
           label: n.label || n.id,
           column: col,
           meta: n.meta ?? {},
+          // strip the node-id prefix to recover the raw entity id
+          // (peer/user ids are already raw).
+          entityId: n.id.replace(/^(group|nr|policy):/, ""),
           // peer/group nodes that are not the current focus are valid
           // foci → clicking re-centres the graph on them.
           switchable:


### PR DESCRIPTION
## Bugs (reported from local testing)

1. **User tab → click a group →** Group tab shows *"Could not resolve the topology for the selected group…"*
2. **Peers tab → click a group →** Group tab, no error, but **default group** (clicked one lost)
3. **Group tab → click a (destination) group →** view **resets to the default group**
4. **Network tab → click a group →** Group tab on **default group**, reference lost
5. **Policy edit modal** slow to appear the first time after a tab switch

## Root cause

1–4 are one bug: `onNodeClick` passed the **raw graph node id** to `onFocusNode`. Group nodes are `group:<gid>` (network resources `nr:<id>`), so the focus became `group:<gid>` → `/control-center/group/group:<gid>` → `ErrFocusNotFound` (404 → the identity-guard error in User tab) or, via the auto-select effect (the prefixed id isn't in the option list), a silent fallback to the **first/default group** (Peer/Group/Network tabs). Peer nodes worked only because their ids are already raw.

5 is the R5b lazy `/policies`: it was fetched **on the first policy click**, so the modal blocked on that round-trip before `editPolicy` could resolve.

## Fix

- Layout adds `entityId` to node data = node id minus the `group|nr|policy` prefix (peer/user already raw). The canvas re-focuses on `d.entityId`, never the prefixed `node.id`.
- Prefetch `/policies` as soon as a topology containing policy nodes renders (background, non-blocking) so the edit modal is ready before the click. The four entity lists (peers/users/groups/resources) stay active-tab-only — the R5b initial-load win is preserved.

Note: Group focus has no peer nodes by design (group → policy → resource); "clicking a peer in Group tab" was actually a destination-group node — now it correctly re-focuses that group instead of resetting.

## Test plan
- [x] `tsc --noEmit` exit 0; `eslint` exit 0
- [ ] User/Peer/Network tab → click a group node → Group tab focuses **that** group (no error, no default fallback)
- [ ] Network tab → click a source group → focuses that group
- [ ] First policy click after load opens the modal without the network wait
- [ ] Peer re-focus from User tab still works (raw ids unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)