### PR TITLE
release: fix dead CHANGELOG.md pointer in goreleaser header

### DIFF
--- a/.goreleaser.binaries.yaml
+++ b/.goreleaser.binaries.yaml
@@ -605,8 +605,8 @@ release:
   header: |
     ## openZro {{ .Tag }}
 
-    See `CHANGELOG.md` (or commit log) for the full list of changes
-    in this release.
+    Full list of changes in this release:
+    https://github.com/openzro/openzro/commits/{{ .Tag }}
 
     ### Verifying downloads
 


### PR DESCRIPTION
## Summary

The goreleaser release-body `header` told readers to *"See `CHANGELOG.md`"* — a file that has **never existed** (changelog is intentionally `disable: true`; ~7k inherited NetBird commits would exceed GitHub's 125k release-body limit). Every release shipped a dead pointer.

Replace it with the GitHub commit-log URL for the tag (`{{ .Tag }}` is valid in the header template; the URL always resolves). 2-line, config-only, no pipeline change.

The `gh --generate-notes` (since-last-tag PR notes) automation is a **separate follow-up**, deliberately sequenced to validate on the *next* release rather than debut on the one being cut now.

## Test plan

- [x] `.goreleaser.binaries.yaml` parses (YAML valid); header renders the intended text.
- [ ] Next published release body shows a working commit-log link instead of the dead `CHANGELOG.md` reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)