### PR TITLE
chore(lint): #20 real findings — exitAfterDefer, MDM stutter, PT comment

### DIFF
--- a/cluster/nats/nats.go
+++ b/cluster/nats/nats.go
@@ -91,11 +91,12 @@ func New(ctx context.Context, cfg Config) (*Coordinator, error) {
 
 	parentCtx, cancel := context.WithCancel(ctx)
 
-	// JetStream cluster precisa de meta-leader eleito antes do bucket KV
-	// poder ser criado. Em deploys HA fresh (3 pods boot juntos), a eleição
-	// leva alguns segundos — o boot do management nesse momento perde a
-	// janela e o pod sai com erro, criando um loop de restart que nunca
-	// converge. Retry com backoff até 60s cobre o caso comum.
+	// The JetStream cluster needs an elected meta-leader before the KV
+	// bucket can be created. On fresh HA deploys (3 pods booting
+	// together) the election takes a few seconds; a management boot in
+	// that window misses it and the pod exits with an error, creating
+	// a restart loop that never converges. Retry with backoff up to
+	// 60s covers the common case.
 	var kv jetstream.KeyValue
 	const (
 		bucketRetryTimeout = 60 * time.Second

--- a/docs/adr/0005-centralized-login.md
+++ b/docs/adr/0005-centralized-login.md
@@ -170,7 +170,7 @@ flow. Scope:
 
 1. **Schema + storage** (`management/server/auth/providers/`):
    - `AuthenticationProvider` GORM row with the same encrypted
-     blob layout as `mdm.MDMProvider`.
+     blob layout as `mdm.ProviderRow`.
    - `Store` with `Save` / `List` / `Get` / `Delete`,
      `Decrypt` for the live OIDC manager.
 2. **Provider manager** (`management/server/auth/manager.go`):

--- a/management/server/http/handlers/mdm_providers/handler.go
+++ b/management/server/http/handlers/mdm_providers/handler.go
@@ -71,7 +71,7 @@ type responseBody struct {
 	UpdatedAt              time.Time        `json:"updated_at"`
 }
 
-func toResponse(row *mdm.MDMProvider) responseBody {
+func toResponse(row *mdm.ProviderRow) responseBody {
 	return responseBody{
 		ID:                     row.ID,
 		Name:                   row.Name,

--- a/management/server/mdm/manager.go
+++ b/management/server/mdm/manager.go
@@ -17,7 +17,7 @@ import (
 //   - constructs concrete drivers (Intune / SentinelOne / Huntress /
 //     CrowdStrike)
 //   - wraps them in a CachedProvider with the per-provider configured
-//     TTL (MDMProvider.RefreshIntervalMinutes)
+//     TTL (ProviderRow.RefreshIntervalMinutes)
 //   - serves status lookups to posture checks via Lookup()
 //   - keeps a per-provider RefreshWorker warming the cache so big
 //     tenants don't thunder-herd the vendor API on rollout
@@ -155,7 +155,7 @@ func (m *Manager) Refresh(ctx context.Context) error {
 	return nil
 }
 
-func (m *Manager) buildProvider(row *MDMProvider) (Provider, error) {
+func (m *Manager) buildProvider(row *ProviderRow) (Provider, error) {
 	plain, err := m.store.Decrypt(row)
 	if err != nil {
 		return nil, fmt.Errorf("decrypt: %w", err)

--- a/management/server/mdm/model.go
+++ b/management/server/mdm/model.go
@@ -11,11 +11,11 @@ import (
 // existing tenants see no behavior change on first boot.
 const defaultRefreshIntervalMinutes = 5
 
-// MDMProvider is the GORM-managed row holding one vendor's
+// ProviderRow is the GORM-managed row holding one vendor's
 // credentials, encrypted at rest. PublicConfig carries the
 // non-sensitive subset (tenant ID, base URL) so the dashboard can
 // render the configuration without holding the secret.
-type MDMProvider struct {
+type ProviderRow struct {
 	ID      uint64       `gorm:"primaryKey;autoIncrement"`
 	Name    string       `gorm:"size:128;not null"`
 	Type    ProviderType `gorm:"size:32;not null;index"`
@@ -44,7 +44,7 @@ type MDMProvider struct {
 // time.Duration, falling back to the default for legacy rows that
 // stored 0 (pre-knob) or values that bypassed the API layer's
 // validation. Always non-zero.
-func (p MDMProvider) ResolvedRefreshInterval() time.Duration {
+func (p ProviderRow) ResolvedRefreshInterval() time.Duration {
 	m := p.RefreshIntervalMinutes
 	if m == 0 {
 		m = defaultRefreshIntervalMinutes
@@ -52,7 +52,7 @@ func (p MDMProvider) ResolvedRefreshInterval() time.Duration {
 	return time.Duration(m) * time.Minute
 }
 
-func (MDMProvider) TableName() string { return "mdm_providers" }
+func (ProviderRow) TableName() string { return "mdm_providers" }
 
 // IntuneConfig is the full Intune configuration as stored
 // (encrypted). Public projection omits ClientSecret.

--- a/management/server/mdm/store.go
+++ b/management/server/mdm/store.go
@@ -35,7 +35,7 @@ func validateSentinelOneCompliance(c SentinelOneCompliance) error {
 // translate it to HTTP 404 at the API layer.
 var ErrNotFound = errors.New("mdm: provider not found")
 
-// Store provides CRUD for MDMProvider rows with credentials encrypted
+// Store provides CRUD for ProviderRow rows with credentials encrypted
 // at rest. The encryption helper is reused from flow_exports — same
 // envelope, same key, same threat model.
 type Store struct {
@@ -52,7 +52,7 @@ func NewStore(db *gorm.DB, key string) (*Store, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := db.AutoMigrate(&MDMProvider{}); err != nil {
+	if err := db.AutoMigrate(&ProviderRow{}); err != nil {
 		return nil, err
 	}
 	return &Store{db: db, encrypt: enc}, nil
@@ -217,7 +217,7 @@ func (in *SaveInput) MergeIncomingSecret(prev any) {
 
 // Save creates or updates a row. Sensitive fields are encrypted
 // before INSERT/UPDATE.
-func (s *Store) Save(ctx context.Context, in SaveInput) (*MDMProvider, error) {
+func (s *Store) Save(ctx context.Context, in SaveInput) (*ProviderRow, error) {
 	if in.ID != 0 {
 		// Preserve write-only credentials when the caller posts
 		// placeholders. See MergeIncomingSecret for the rationale.
@@ -252,11 +252,11 @@ func (s *Store) Save(ctx context.Context, in SaveInput) (*MDMProvider, error) {
 		// Collapse 0 (operator didn't fill the form, or upgrader hasn't
 		// re-saved a pre-knob row) to the default so the column is
 		// never persisted as zero. The resolver in
-		// MDMProvider.ResolvedRefreshInterval also tolerates zero, but
+		// ProviderRow.ResolvedRefreshInterval also tolerates zero, but
 		// keeping the DB clean makes the form roundtrip readable.
 		refreshMinutes = defaultRefreshIntervalMinutes
 	}
-	row := MDMProvider{
+	row := ProviderRow{
 		ID:                     in.ID,
 		Name:                   in.Name,
 		Type:                   in.Type,
@@ -272,7 +272,7 @@ func (s *Store) Save(ctx context.Context, in SaveInput) (*MDMProvider, error) {
 			return nil, err
 		}
 	} else {
-		var existing MDMProvider
+		var existing ProviderRow
 		if err := s.db.WithContext(ctx).First(&existing, in.ID).Error; err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
 				return nil, ErrNotFound
@@ -287,16 +287,16 @@ func (s *Store) Save(ctx context.Context, in SaveInput) (*MDMProvider, error) {
 	return &row, nil
 }
 
-func (s *Store) List(ctx context.Context) ([]MDMProvider, error) {
-	var rows []MDMProvider
+func (s *Store) List(ctx context.Context) ([]ProviderRow, error) {
+	var rows []ProviderRow
 	if err := s.db.WithContext(ctx).Order("id ASC").Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	return rows, nil
 }
 
-func (s *Store) Get(ctx context.Context, id uint64) (*MDMProvider, error) {
-	var row MDMProvider
+func (s *Store) Get(ctx context.Context, id uint64) (*ProviderRow, error) {
+	var row ProviderRow
 	if err := s.db.WithContext(ctx).First(&row, id).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
@@ -307,7 +307,7 @@ func (s *Store) Get(ctx context.Context, id uint64) (*MDMProvider, error) {
 }
 
 func (s *Store) Delete(ctx context.Context, id uint64) error {
-	res := s.db.WithContext(ctx).Delete(&MDMProvider{}, id)
+	res := s.db.WithContext(ctx).Delete(&ProviderRow{}, id)
 	if res.Error != nil {
 		return res.Error
 	}
@@ -319,7 +319,7 @@ func (s *Store) Delete(ctx context.Context, id uint64) error {
 
 // Decrypt reads ConfigCipher into the type-appropriate Go struct.
 // Used by the manager to instantiate live Provider drivers.
-func (s *Store) Decrypt(row *MDMProvider) (any, error) {
+func (s *Store) Decrypt(row *ProviderRow) (any, error) {
 	plain, err := s.encrypt.Decrypt(row.ConfigCipher)
 	if err != nil {
 		return nil, err

--- a/management/server/mdm/store_test.go
+++ b/management/server/mdm/store_test.go
@@ -150,10 +150,10 @@ func TestStore_RefreshIntervalDefaultsToFiveWhenZero(t *testing.T) {
 func TestMDMProvider_ResolvedRefreshIntervalFallback(t *testing.T) {
 	// Row loaded from a pre-knob database carries 0 in the column.
 	// Resolver must paper over it without forcing a migration.
-	p := MDMProvider{RefreshIntervalMinutes: 0}
+	p := ProviderRow{RefreshIntervalMinutes: 0}
 	assert.Equal(t, 5*time.Minute, p.ResolvedRefreshInterval())
 
-	p = MDMProvider{RefreshIntervalMinutes: 15}
+	p = ProviderRow{RefreshIntervalMinutes: 15}
 	assert.Equal(t, 15*time.Minute, p.ResolvedRefreshInterval())
 }
 

--- a/management/server/mdm/store_test.go
+++ b/management/server/mdm/store_test.go
@@ -147,7 +147,7 @@ func TestStore_RefreshIntervalDefaultsToFiveWhenZero(t *testing.T) {
 		"zero must be normalised to the documented default")
 }
 
-func TestMDMProvider_ResolvedRefreshIntervalFallback(t *testing.T) {
+func TestProviderRow_ResolvedRefreshIntervalFallback(t *testing.T) {
 	// Row loaded from a pre-knob database carries 0 in the column.
 	// Resolver must paper over it without forcing a migration.
 	p := ProviderRow{RefreshIntervalMinutes: 0}

--- a/management/server/posture/endpoint_security.go
+++ b/management/server/posture/endpoint_security.go
@@ -16,16 +16,16 @@ import (
 //
 // Conceptually:
 //
-//   posture.EndpointSecurityCheck (this struct, persisted) stores
-//   "which provider should answer + what counts as compliant".
-//   The Manager wired into the validator resolves the provider and
-//   returns a boolean.
+//	posture.EndpointSecurityCheck (this struct, persisted) stores
+//	"which provider should answer + what counts as compliant".
+//	The Manager wired into the validator resolves the provider and
+//	returns a boolean.
 //
 // The Resolver is a function rather than a concrete dependency so
 // the posture package stays free of import cycles with mdm and so
 // tests can inject deterministic outcomes.
 type EndpointSecurityCheck struct {
-	// ProviderID is the row ID of an mdm.MDMProvider stored in the
+	// ProviderID is the row ID of an mdm.ProviderRow stored in the
 	// management's primary DB. Operators pick from the configured
 	// list when defining the check.
 	ProviderID uint64 `json:"provider_id"`

--- a/scripts/dev-seed-flow-events/main.go
+++ b/scripts/dev-seed-flow-events/main.go
@@ -35,7 +35,7 @@ import (
 	"time"
 
 	_ "github.com/glebarez/go-sqlite" // pure-go sqlite driver for reading the management data store
-	_ "github.com/lib/pq"              // database/sql driver for the postgres admin connection used by ensureDatabase
+	_ "github.com/lib/pq"             // database/sql driver for the postgres admin connection used by ensureDatabase
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 
@@ -152,12 +152,15 @@ func main() {
 	if err != nil {
 		log.Fatalf("flow store init: %v", err)
 	}
-	defer s.Close()
-
+	// No `defer s.Close()`: log.Fatalf calls os.Exit, which skips
+	// deferred closes (gocritic exitAfterDefer). Close explicitly on
+	// both the error and success paths so the store is always flushed.
 	events := generate(accountID)
 	if err := s.Save(context.Background(), events); err != nil {
+		_ = s.Close()
 		log.Fatalf("save: %v", err)
 	}
+	_ = s.Close()
 	fmt.Printf("✓ seeded %d flow events under account %s\n", len(events), accountID)
 	fmt.Println("  open http://localhost:3000/events/network-traffic to preview")
 }


### PR DESCRIPTION
Part of #20 (golangci-lint backlog).

## Re-scope (verified against current code)

The issue's **"Easy" exclude-rules are already in `.golangci.yaml`** (forbidigo `scripts/dev-seed-flow-events`, unused `duckdb_stub.go`, gosec `flow/*/factory.go`) — so the bulk was already handled. What actually remained was the **3 "real findings"**, all confirmed still present. This PR fixes those:

1. **`fix(scripts)`** — `dev-seed-flow-events/main.go`: `defer s.Close()` + later `log.Fatalf` (os.Exit skips defers) → store never flushed on the save-error path. Close explicitly on both paths (gocritic `exitAfterDefer`). Dev tool only.
2. **`refactor(mdm)`** — `revive` stutter `mdm.MDMProvider`. The issue suggested `mdm.Provider` but that **collides with the existing `Provider` interface** (`provider.go`); renamed the GORM row struct to **`ProviderRow`** instead (22 refs / 6 files). Table name `"mdm_providers"` unchanged → **no migration / no behavior change**; `go build ./...` verifies all callers. `management/` is AGPL — internal rename of our own code, no upstream consulted.
3. **`style(cluster/nats)`** — `misspell` on "momento": Portuguese comment rewritten in English (meaning preserved; also aligns with the English-code-comments rule). `cluster/` is BSD.

## Not in this PR (follow-up = closing condition)

Flipping the Lint job back to **default-strict** (remove `continue-on-error: true` in `golangci-lint.yml`) is the issue's closing condition — done as a **separate small PR after this lands and the Lint job is verified green**, so it doesn't block PRs mid-cleanup.

## Verification

- `go build ./...` exit 0 (strong verifier for the 22-ref cross-package rename).
- `go vet` on affected packages: clean. `gofmt -l`: clean (normalized 2 pre-existing nits in touched files).
- Lint job is `continue-on-error: true`; its output on this PR should show the 3 findings gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)