### PR TITLE
chore(lint): #20 B2 — non-misspell findings

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -144,6 +144,10 @@ issues:
     - path: scripts/dev-seed-flow-events/main\.go
       linters:
         - forbidigo
+    # Same: dev seeding CLI — fmt.Print* is its user-facing output.
+    - path: scripts/dev-seed-peers/main\.go
+      linters:
+        - forbidigo
     - path: sharedsock/filter\.go
       linters:
       - unused
@@ -171,6 +175,17 @@ issues:
       - mirror
       - gosec
     - path: mock\.go
+      linters:
+      - nilnil
+    # Factories: `(nil, nil)` is the intentional "nothing configured /
+    # no-op backend selected" return — the caller treats a nil product
+    # with nil error as "feature disabled", not an error condition.
+    # Converting to sentinel errors would be a behavioral contract
+    # change across every call site (owner-decided: exclude, same as
+    # the mock\.go nilnil precedent above). Non-factory nilnil sites
+    # (dex_proxy, user_scim, handlers) are handled case-by-case, not
+    # here.
+    - path: (cluster/factory|flow/sinks|flow/store/archive|flow/store/factory|management/server/activity/exporter)/factory\.go
       linters:
       - nilnil
     # Exclude specific deprecation warnings for grpc methods

--- a/client/firewall/uspfilter/conntrack/tcp.go
+++ b/client/firewall/uspfilter/conntrack/tcp.go
@@ -242,10 +242,7 @@ func (t *TCPTracker) IsValidInbound(srcIP, dstIP netip.Addr, srcPort, dstPort ui
 	if !t.isValidStateForFlags(currentState, flags) {
 		t.logger.Warn("TCP state %s is not valid with flags %x for connection %s", currentState, flags, key)
 		// allow all flags for established for now
-		if currentState == TCPStateEstablished {
-			return true
-		}
-		return false
+		return currentState == TCPStateEstablished
 	}
 
 	t.updateState(key, conn, flags, nftypes.Ingress, size)

--- a/flow/sinks/gcs.go
+++ b/flow/sinks/gcs.go
@@ -130,9 +130,15 @@ func NewGCS(ctx context.Context, cfg GCSConfig) (*GCS, error) {
 	opts := []option.ClientOption{}
 	switch {
 	case len(cfg.CredentialsJSON) > 0:
-		opts = append(opts, option.WithCredentialsJSON(cfg.CredentialsJSON))
+		// SA1019: option.WithCredentialsJSON is being phased out in favor
+		// of the new cloud.google.com/go/auth.Credentials surface. Keeping
+		// the legacy path here because the alternative changes how the
+		// storage client minds token refresh, and that needs explicit
+		// testing against the prod GCS sink before flipping. Tracked in
+		// #82.
+		opts = append(opts, option.WithCredentialsJSON(cfg.CredentialsJSON)) //nolint:staticcheck // SA1019 — migration to cloud.google.com/go/auth tracked in #82.
 	case cfg.CredentialsFile != "":
-		opts = append(opts, option.WithCredentialsFile(cfg.CredentialsFile))
+		opts = append(opts, option.WithCredentialsFile(cfg.CredentialsFile)) //nolint:staticcheck // SA1019 — same as above, migration tracked.
 	}
 	if cfg.Endpoint != "" {
 		httpClient := cfg.HTTPClient

--- a/flow/sinks/s3.go
+++ b/flow/sinks/s3.go
@@ -79,7 +79,7 @@ type S3Config struct {
 // Object keys partition by date and account so common queries can
 // prune at the path level:
 //
-//   <prefix>/year=2026/month=04/day=26/account=<id>/<unix-nano>-<rand>.ndjson.gz
+//	<prefix>/year=2026/month=04/day=26/account=<id>/<unix-nano>-<rand>.ndjson.gz
 type S3 struct {
 	cfg    S3Config
 	format archiveFormat
@@ -354,11 +354,4 @@ func dirString(d store.Direction) string {
 		return "egress"
 	}
 	return "unknown"
-}
-
-func min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
 }

--- a/management/server/client_update_targeting_test.go
+++ b/management/server/client_update_targeting_test.go
@@ -41,8 +41,8 @@ func TestUpdateBucket(t *testing.T) {
 			t.Fatalf("bucket out of 0..99: %d", b)
 		}
 	}
-	if updateBucket("stable") != updateBucket("stable") {
-		t.Fatal("updateBucket must be deterministic for the same key")
+	if first, second := updateBucket("stable"), updateBucket("stable"); first != second {
+		t.Fatalf("updateBucket must be deterministic for the same key: %d != %d", first, second)
 	}
 }
 

--- a/management/server/controlcenter/columnar_helpers.go
+++ b/management/server/controlcenter/columnar_helpers.go
@@ -48,13 +48,13 @@ func (b *colBuilder) peerState(ctx context.Context, acc *types.Account, peerID s
 //     is visible, never silently shown as full.
 func (b *colBuilder) groupState(ctx context.Context, acc *types.Account, members []string) stateFn {
 	return func(pol *types.Policy) (EdgeState, map[string]string, bool) {
-		real := make([]string, 0, len(members))
+		realMembers := make([]string, 0, len(members))
 		for _, mID := range members {
 			if acc.GetPeer(mID) != nil {
-				real = append(real, mID)
+				realMembers = append(realMembers, mID)
 			}
 		}
-		n := len(real)
+		n := len(realMembers)
 		if n == 0 {
 			return EdgeEnforced, nil, false
 		}
@@ -63,10 +63,10 @@ func (b *colBuilder) groupState(ctx context.Context, acc *types.Account, members
 				map[string]string{"reachedBy": fmt.Sprintf("%d of %d members", n, n)},
 				true
 		}
-		sort.Strings(real)
+		sort.Strings(realMembers)
 		pass := 0
 		var firstDenial *types.AdmissionDenial
-		for _, mID := range real {
+		for _, mID := range realMembers {
 			if d := admissionDenial(ctx, acc, mID, pol.SourcePostureChecks, b.posture); d == nil {
 				pass++
 			} else if firstDenial == nil {

--- a/management/server/dex_proxy/client.go
+++ b/management/server/dex_proxy/client.go
@@ -47,7 +47,7 @@ type Config struct {
 // nil + nil when no Addr is set: the operator hasn't wired Dex
 // yet, so the gRPC client should not start. Callers treat the
 // nil Config as "feature off, fall back gracefully".
-func FromEnv() (*Config, error) {
+func FromEnv() (*Config, error) { //nolint:nilnil // optional dependency: nil config + nil error means "Dex not configured" (see doc above); callers handle cfg == nil as "feature off".
 	addr := strings.TrimSpace(os.Getenv("OPENZRO_DEX_GRPC_ADDR"))
 	if addr == "" {
 		return nil, nil

--- a/management/server/dex_proxy/client.go
+++ b/management/server/dex_proxy/client.go
@@ -47,10 +47,13 @@ type Config struct {
 // nil + nil when no Addr is set: the operator hasn't wired Dex
 // yet, so the gRPC client should not start. Callers treat the
 // nil Config as "feature off, fall back gracefully".
-func FromEnv() (*Config, error) { //nolint:nilnil // optional dependency: nil config + nil error means "Dex not configured" (see doc above); callers handle cfg == nil as "feature off".
+func FromEnv() (*Config, error) {
 	addr := strings.TrimSpace(os.Getenv("OPENZRO_DEX_GRPC_ADDR"))
 	if addr == "" {
-		return nil, nil
+		// Optional dependency: nil config + nil error means "Dex not
+		// configured" (see doc above); callers handle cfg == nil as
+		// "feature off".
+		return nil, nil //nolint:nilnil // see comment above.
 	}
 	cfg := &Config{
 		Addr:           addr,

--- a/management/server/http/handlers/control_center/handler_test.go
+++ b/management/server/http/handlers/control_center/handler_test.go
@@ -67,7 +67,7 @@ func TestControlCenter_HappyPath(t *testing.T) {
 }
 
 func TestControlCenter_ForbiddenWhenNotAdmin(t *testing.T) {
-	r := newFixture(t, false, func(context.Context, string, string, string) (*controlcenter.GraphDTO, error) {
+	r := newFixture(t, false, func(context.Context, string, string, string) (*controlcenter.GraphDTO, error) { //nolint:nilnil // test stub: t.Fatal above ensures this path is never reached; the return only exists to satisfy the function signature.
 		t.Fatal("manager must not be reached when RBAC denies")
 		return nil, nil
 	})
@@ -77,7 +77,7 @@ func TestControlCenter_ForbiddenWhenNotAdmin(t *testing.T) {
 }
 
 func TestControlCenter_BadView(t *testing.T) {
-	r := newFixture(t, true, func(context.Context, string, string, string) (*controlcenter.GraphDTO, error) {
+	r := newFixture(t, true, func(context.Context, string, string, string) (*controlcenter.GraphDTO, error) { //nolint:nilnil // test stub: t.Fatal above ensures this path is never reached; the return only exists to satisfy the function signature.
 		t.Fatal("manager must not be reached for an invalid view")
 		return nil, nil
 	})
@@ -108,7 +108,7 @@ func TestControlCenter_GenericErrorIsNot404(t *testing.T) {
 }
 
 func TestControlCenter_Unauthenticated(t *testing.T) {
-	r := newFixture(t, true, func(context.Context, string, string, string) (*controlcenter.GraphDTO, error) {
+	r := newFixture(t, true, func(context.Context, string, string, string) (*controlcenter.GraphDTO, error) { //nolint:nilnil // test stub: handler must short-circuit on missing UserAuth before reaching the manager; the return is unreachable in practice.
 		return nil, nil
 	})
 	rr := httptest.NewRecorder()

--- a/management/server/http/handlers/control_center/handler_test.go
+++ b/management/server/http/handlers/control_center/handler_test.go
@@ -67,9 +67,9 @@ func TestControlCenter_HappyPath(t *testing.T) {
 }
 
 func TestControlCenter_ForbiddenWhenNotAdmin(t *testing.T) {
-	r := newFixture(t, false, func(context.Context, string, string, string) (*controlcenter.GraphDTO, error) { //nolint:nilnil // test stub: t.Fatal above ensures this path is never reached; the return only exists to satisfy the function signature.
+	r := newFixture(t, false, func(context.Context, string, string, string) (*controlcenter.GraphDTO, error) {
 		t.Fatal("manager must not be reached when RBAC denies")
-		return nil, nil
+		return nil, nil //nolint:nilnil // unreachable: t.Fatal above stops the goroutine; the return only satisfies the signature.
 	})
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, withAuth(httptest.NewRequest(http.MethodGet, "/control-center/peer/p1", nil)))
@@ -77,9 +77,9 @@ func TestControlCenter_ForbiddenWhenNotAdmin(t *testing.T) {
 }
 
 func TestControlCenter_BadView(t *testing.T) {
-	r := newFixture(t, true, func(context.Context, string, string, string) (*controlcenter.GraphDTO, error) { //nolint:nilnil // test stub: t.Fatal above ensures this path is never reached; the return only exists to satisfy the function signature.
+	r := newFixture(t, true, func(context.Context, string, string, string) (*controlcenter.GraphDTO, error) {
 		t.Fatal("manager must not be reached for an invalid view")
-		return nil, nil
+		return nil, nil //nolint:nilnil // unreachable: t.Fatal above stops the goroutine; the return only satisfies the signature.
 	})
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, withAuth(httptest.NewRequest(http.MethodGet, "/control-center/bogus/x", nil)))
@@ -108,8 +108,11 @@ func TestControlCenter_GenericErrorIsNot404(t *testing.T) {
 }
 
 func TestControlCenter_Unauthenticated(t *testing.T) {
-	r := newFixture(t, true, func(context.Context, string, string, string) (*controlcenter.GraphDTO, error) { //nolint:nilnil // test stub: handler must short-circuit on missing UserAuth before reaching the manager; the return is unreachable in practice.
-		return nil, nil
+	r := newFixture(t, true, func(context.Context, string, string, string) (*controlcenter.GraphDTO, error) {
+		// Handler must short-circuit on missing UserAuth before reaching
+		// the manager; this stub return is here only to satisfy the
+		// signature.
+		return nil, nil //nolint:nilnil // see comment above.
 	})
 	rr := httptest.NewRecorder()
 	// no withAuth → no UserAuth in context.

--- a/management/server/http/handlers/scim/groups.go
+++ b/management/server/http/handlers/scim/groups.go
@@ -165,9 +165,9 @@ type memberPatchValue struct {
 
 // handlePatchGroup: PATCH /Groups/{id}. Supports:
 //
-//   replace path=displayName value="..."
-//   add path=members value=[{value:userId}, ...]
-//   remove path=members[value eq "userId"]
+//	replace path=displayName value="..."
+//	add path=members value=[{value:userId}, ...]
+//	remove path=members[value eq "userId"]
 //
 // Other operations are ignored — the format above is what Okta and
 // Entra send for the common create-and-add-members flow.
@@ -273,11 +273,11 @@ func parseDisplayNameFilter(raw string) string {
 func extractRemoveUserID(path string) string {
 	// Looking for: members[value eq "..."]
 	open := strings.Index(path, "[")
-	close := strings.LastIndex(path, "]")
-	if open < 0 || close < 0 || close < open {
+	closeIdx := strings.LastIndex(path, "]")
+	if open < 0 || closeIdx < 0 || closeIdx < open {
 		return ""
 	}
-	inner := path[open+1 : close]
+	inner := path[open+1 : closeIdx]
 	parts := strings.Fields(inner)
 	if len(parts) < 3 || !strings.EqualFold(parts[0], "value") || !strings.EqualFold(parts[1], "eq") {
 		return ""

--- a/management/server/http/handlers/scim/users.go
+++ b/management/server/http/handlers/scim/users.go
@@ -78,44 +78,12 @@ func fromUser(u *types.User) User {
 	return out
 }
 
-// fromUserInfo is used by the list path when the data already comes
-// from the IdP-cache-backed AccountManager.GetUsersFromAccount —
-// kept for the legacy non-SCIM read flow and the GET /Users
-// endpoint's combined view.
-func fromUserInfo(u *types.UserInfo) User {
-	un := u.Email
-	if un == "" {
-		un = u.ID
-	}
-	out := User{
-		Schemas:  []string{SchemaUserURN},
-		ID:       u.ID,
-		UserName: un,
-		Active:   !u.IsBlocked,
-		Meta: ResourceMeta{
-			ResourceType: "User",
-			Location:     "/scim/v2/Users/" + u.ID,
-		},
-	}
-	if u.Name != "" {
-		out.DisplayName = u.Name
-		out.Name = &userName{Formatted: u.Name}
-	}
-	if u.Email != "" {
-		out.Emails = []userEmail{{Value: u.Email, Primary: true, Type: "work"}}
-	}
-	for _, gid := range u.AutoGroups {
-		out.Groups = append(out.Groups, userGroup{Value: gid})
-	}
-	return out
-}
-
 // handleListUsers implements GET /Users with optional filter and
 // pagination. RFC 7644 §3.4.2.
 //
 // Supported filter expressions (subset):
 //
-//   userName eq "alice@example.com"
+//	userName eq "alice@example.com"
 //
 // Anything else is ignored and a full unfiltered list is returned —
 // well-behaved IdPs send only equality filters on userName.
@@ -215,7 +183,7 @@ func (h *Handler) handleReplaceUser(w http.ResponseWriter, r *http.Request) {
 
 // patchOpRequest is the wire shape for PATCH per RFC 7644 §3.5.2.
 type patchOpRequest struct {
-	Schemas    []string `json:"schemas"`
+	Schemas    []string  `json:"schemas"`
 	Operations []patchOp `json:"Operations"`
 }
 

--- a/management/server/idp/google_workspace.go
+++ b/management/server/idp/google_workspace.go
@@ -229,7 +229,12 @@ func getGoogleCredentials(ctx context.Context, serviceAccountKey string) (*googl
 		return nil, fmt.Errorf("failed to decode service account key: %w", err)
 	}
 
-	creds, err := google.CredentialsFromJSON(
+	// SA1019: google.CredentialsFromJSON is gradually being superseded by
+	// the new cloud.google.com/go/auth surface. Holding the legacy call
+	// here because this is the Google Workspace IdP path — any change to
+	// how the service-account JWT is minted needs an end-to-end test
+	// against the directory API, which is gated behind #82.
+	creds, err := google.CredentialsFromJSON( //nolint:staticcheck // SA1019 — Google IdP credential minting; migration tracked in #82.
 		context.Background(),
 		decodeKey,
 		admin.AdminDirectoryUserReadonlyScope,

--- a/management/server/mdm/crowdstrike.go
+++ b/management/server/mdm/crowdstrike.go
@@ -160,7 +160,7 @@ func (c *CrowdStrike) fetchAIDs(ctx context.Context, target string) ([]string, e
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	resp, err := c.client.Do(req)
+	resp, err := c.client.Do(req) //nolint:bodyclose // closed via drainAndClose(resp.Body) below; the linter does not see the helper.
 	if err != nil {
 		return nil, fmt.Errorf("crowdstrike: query api: %w", err)
 	}
@@ -182,7 +182,7 @@ func (c *CrowdStrike) fetchDevice(ctx context.Context, target string) (csDevice,
 		return csDevice{}, err
 	}
 	req.Header.Set("Accept", "application/json")
-	resp, err := c.client.Do(req)
+	resp, err := c.client.Do(req) //nolint:bodyclose // closed via drainAndClose(resp.Body) below; the linter does not see the helper.
 	if err != nil {
 		return csDevice{}, fmt.Errorf("crowdstrike: entities api: %w", err)
 	}

--- a/management/server/posture/evaluation.go
+++ b/management/server/posture/evaluation.go
@@ -7,7 +7,7 @@ import (
 	"gorm.io/gorm"
 )
 
-// PostureEvaluation is one row of "what happened when posture check X
+// Evaluation is one row of "what happened when posture check X
 // ran on peer Y at time T". The dashboard's per-peer Posture Status
 // panel reads the last N records for a peer to render the timeline
 // that closed the cluster-debugging loop: instead of grepping
@@ -23,7 +23,7 @@ import (
 // AccountID is denormalised onto every row so the retention worker
 // and the per-account API queries don't have to JOIN through
 // peers/posture_checks for the (very) common access pattern.
-type PostureEvaluation struct {
+type Evaluation struct {
 	// ID is an auto-incrementing surrogate. The natural key
 	// (account_id, peer_id, posture_check_id, evaluated_at) is unique
 	// enough in practice — same peer + same check at the same UTC ms
@@ -83,7 +83,7 @@ type PostureEvaluation struct {
 
 // TableName pins the GORM table name so the auto-migration emits the
 // expected SQL identifier regardless of struct renames.
-func (PostureEvaluation) TableName() string { return "posture_evaluations" }
+func (Evaluation) TableName() string { return "posture_evaluations" }
 
 // EvalRecorder is the write-side hook that validatePostureChecksOnPeer
 // calls after each check.Check() invocation. The implementation is
@@ -94,7 +94,7 @@ func (PostureEvaluation) TableName() string { return "posture_evaluations" }
 // Nil-safe by convention: callers should accept that no recorder
 // means "don't record" and skip the hook.
 type EvalRecorder interface {
-	Record(ctx context.Context, e PostureEvaluation)
+	Record(ctx context.Context, e Evaluation)
 }
 
 // evalRecorderContextKey is the context key used to carry an
@@ -137,7 +137,7 @@ func SetDefaultEvalRecorder(r EvalRecorder) {
 	defaultEvalRecorder = r
 }
 
-// EvalStore persists PostureEvaluation rows and answers the
+// EvalStore persists Evaluation rows and answers the
 // per-peer-timeline query the dashboard makes. Implemented by the
 // GORM-backed store in evaluation_store.go; tests can inject an
 // in-memory fake.
@@ -146,11 +146,11 @@ type EvalStore interface {
 	// expected to swallow individual row errors at the persistence
 	// layer (best-effort) — failing the eval pipeline on a logging
 	// hiccup is the wrong trade-off.
-	Insert(ctx context.Context, batch []PostureEvaluation) error
+	Insert(ctx context.Context, batch []Evaluation) error
 
 	// ListForPeer returns the most recent `limit` evaluations for
 	// the given peer in the given account, newest first.
-	ListForPeer(ctx context.Context, accountID, peerID string, limit int) ([]PostureEvaluation, error)
+	ListForPeer(ctx context.Context, accountID, peerID string, limit int) ([]Evaluation, error)
 
 	// PurgeOlderThan deletes rows whose EvaluatedAt is older than
 	// the cutoff. Returns the number of rows removed for telemetry.
@@ -161,5 +161,5 @@ type EvalStore interface {
 // its compound index if they don't exist yet. Called from the same
 // init path as the other GORM auto-migrations.
 func MigrateEvaluationTable(db *gorm.DB) error {
-	return db.AutoMigrate(&PostureEvaluation{})
+	return db.AutoMigrate(&Evaluation{})
 }

--- a/management/server/posture/evaluation_pubsub_test.go
+++ b/management/server/posture/evaluation_pubsub_test.go
@@ -94,7 +94,7 @@ func TestBufferedRecorder_PublishesOnCacheCommit(t *testing.T) {
 	defer r.Close()
 
 	now := time.Now().UTC()
-	e := PostureEvaluation{
+	e := Evaluation{
 		AccountID:      "a",
 		PeerID:         "p",
 		PostureCheckID: "c",
@@ -149,7 +149,7 @@ func TestBufferedRecorder_AppliesInboundBroadcastToCache(t *testing.T) {
 
 	// Now a Record() on this replica with the same state should be
 	// suppressed by the freshly-populated cache.
-	r.Record(context.Background(), PostureEvaluation{
+	r.Record(context.Background(), Evaluation{
 		AccountID:      "a",
 		PeerID:         "p",
 		PostureCheckID: "c",
@@ -252,7 +252,7 @@ func TestBufferedRecorder_SelfEchoIsNoOp(t *testing.T) {
 	defer r.Close()
 
 	now := time.Now().UTC()
-	r.Record(context.Background(), PostureEvaluation{
+	r.Record(context.Background(), Evaluation{
 		AccountID:      "a",
 		PeerID:         "p",
 		PostureCheckID: "c",
@@ -302,7 +302,7 @@ func TestBufferedRecorder_SubscribeFailureDegradesGracefully(t *testing.T) {
 
 	// Record() must still work end-to-end even though subscription
 	// failed. The write goes to the store via the channel/drainer.
-	r.Record(context.Background(), PostureEvaluation{
+	r.Record(context.Background(), Evaluation{
 		AccountID:      "a",
 		PeerID:         "p",
 		PostureCheckID: "c",
@@ -350,7 +350,7 @@ func TestBufferedRecorder_NilCoordIsSafe(t *testing.T) {
 	}, nil)
 	defer r.Close()
 
-	r.Record(context.Background(), PostureEvaluation{
+	r.Record(context.Background(), Evaluation{
 		AccountID:      "a",
 		PeerID:         "p",
 		PostureCheckID: "c",
@@ -385,7 +385,7 @@ func TestBufferedRecorder_CrossReplicaDedupReducesDuplicateWrites(t *testing.T) 
 	defer rB.Close()
 
 	now := time.Now().UTC()
-	e := PostureEvaluation{
+	e := Evaluation{
 		AccountID:      "a",
 		PeerID:         "p",
 		PostureCheckID: "c",

--- a/management/server/posture/evaluation_recorder.go
+++ b/management/server/posture/evaluation_recorder.go
@@ -47,7 +47,7 @@ type BufferedRecorder struct {
 	flushInterval time.Duration
 	refreshTTL    time.Duration
 
-	in           chan PostureEvaluation
+	in           chan Evaluation
 	closeOnce    sync.Once
 	stop         chan struct{}
 	done         chan struct{}
@@ -147,7 +147,7 @@ func NewBufferedRecorder(store EvalStore, opts BufferedRecorderOpts, coord clust
 		batchSize:     opts.BatchSize,
 		flushInterval: opts.FlushInterval,
 		refreshTTL:    opts.RefreshTTL,
-		in:            make(chan PostureEvaluation, opts.QueueSize),
+		in:            make(chan Evaluation, opts.QueueSize),
 		stop:          make(chan struct{}),
 		done:          make(chan struct{}),
 		subCtx:        subCtx,
@@ -176,7 +176,7 @@ func NewBufferedRecorder(store EvalStore, opts BufferedRecorderOpts, coord clust
 // drainer never sees the row. State CHANGES (a previously compliant
 // peer flips to non-compliant, or a denial reason changes) propagate
 // through.
-func (r *BufferedRecorder) Record(ctx context.Context, e PostureEvaluation) {
+func (r *BufferedRecorder) Record(ctx context.Context, e Evaluation) {
 	if r == nil {
 		return
 	}
@@ -280,7 +280,7 @@ func (r *BufferedRecorder) Close() {
 func (r *BufferedRecorder) run() {
 	defer close(r.done)
 
-	buf := make([]PostureEvaluation, 0, r.batchSize)
+	buf := make([]Evaluation, 0, r.batchSize)
 	flushTimer := time.NewTimer(r.flushInterval)
 	defer flushTimer.Stop()
 

--- a/management/server/posture/evaluation_store.go
+++ b/management/server/posture/evaluation_store.go
@@ -29,7 +29,7 @@ func NewGormEvalStore(db *gorm.DB) *GormEvalStore {
 // posture eval pipeline keeps working through transient persistence
 // issues (table locks, brief outage). The recorder treats this as
 // best-effort by design.
-func (s *GormEvalStore) Insert(ctx context.Context, batch []PostureEvaluation) error {
+func (s *GormEvalStore) Insert(ctx context.Context, batch []Evaluation) error {
 	if len(batch) == 0 {
 		return nil
 	}
@@ -43,7 +43,7 @@ func (s *GormEvalStore) Insert(ctx context.Context, batch []PostureEvaluation) e
 // for one peer in one account, capped at limit. The compound index
 // (account_id, peer_id, evaluated_at DESC) makes this a straight
 // index range scan with no sort.
-func (s *GormEvalStore) ListForPeer(ctx context.Context, accountID, peerID string, limit int) ([]PostureEvaluation, error) {
+func (s *GormEvalStore) ListForPeer(ctx context.Context, accountID, peerID string, limit int) ([]Evaluation, error) {
 	if accountID == "" || peerID == "" {
 		return nil, errors.New("posture: ListForPeer requires accountID and peerID")
 	}
@@ -53,7 +53,7 @@ func (s *GormEvalStore) ListForPeer(ctx context.Context, accountID, peerID strin
 		// the UI ever renders (we paginate at 50 rows there).
 		limit = 100
 	}
-	var rows []PostureEvaluation
+	var rows []Evaluation
 	err := s.db.WithContext(ctx).
 		Where("account_id = ? AND peer_id = ?", accountID, peerID).
 		Order("evaluated_at DESC").
@@ -70,7 +70,7 @@ func (s *GormEvalStore) ListForPeer(ctx context.Context, accountID, peerID strin
 func (s *GormEvalStore) PurgeOlderThan(ctx context.Context, cutoff time.Time) (int64, error) {
 	res := s.db.WithContext(ctx).
 		Where("evaluated_at < ?", cutoff).
-		Delete(&PostureEvaluation{})
+		Delete(&Evaluation{})
 	if res.Error != nil {
 		return 0, fmt.Errorf("posture: purge evaluations: %w", res.Error)
 	}

--- a/management/server/posture/evaluation_test.go
+++ b/management/server/posture/evaluation_test.go
@@ -23,11 +23,11 @@ func openSqliteForTest(_ *testing.T) (*gorm.DB, error) {
 // drained out.
 type fakeEvalStore struct {
 	mu    sync.Mutex
-	rows  []PostureEvaluation
+	rows  []Evaluation
 	calls int
 }
 
-func (f *fakeEvalStore) Insert(_ context.Context, batch []PostureEvaluation) error {
+func (f *fakeEvalStore) Insert(_ context.Context, batch []Evaluation) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.rows = append(f.rows, batch...)
@@ -35,10 +35,10 @@ func (f *fakeEvalStore) Insert(_ context.Context, batch []PostureEvaluation) err
 	return nil
 }
 
-func (f *fakeEvalStore) ListForPeer(_ context.Context, accountID, peerID string, limit int) ([]PostureEvaluation, error) {
+func (f *fakeEvalStore) ListForPeer(_ context.Context, accountID, peerID string, limit int) ([]Evaluation, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	out := []PostureEvaluation{}
+	out := []Evaluation{}
 	for i := len(f.rows) - 1; i >= 0; i-- {
 		if f.rows[i].AccountID == accountID && f.rows[i].PeerID == peerID {
 			out = append(out, f.rows[i])
@@ -66,10 +66,10 @@ func (f *fakeEvalStore) PurgeOlderThan(_ context.Context, cutoff time.Time) (int
 	return purged, nil
 }
 
-func (f *fakeEvalStore) snapshot() []PostureEvaluation {
+func (f *fakeEvalStore) snapshot() []Evaluation {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	out := make([]PostureEvaluation, len(f.rows))
+	out := make([]Evaluation, len(f.rows))
 	copy(out, f.rows)
 	return out
 }
@@ -87,7 +87,7 @@ func TestBufferedRecorder_FlushesOnBatchSize(t *testing.T) {
 	// Distinct PeerIDs so dedup does not suppress identical-state repeats —
 	// this test asserts the batch-size flush path, not dedup behavior.
 	for i := 0; i < 3; i++ {
-		r.Record(context.Background(), PostureEvaluation{
+		r.Record(context.Background(), Evaluation{
 			AccountID:      "acct",
 			PeerID:         fmt.Sprintf("peer-%d", i),
 			PostureCheckID: "check",
@@ -122,7 +122,7 @@ func TestBufferedRecorder_FlushesOnInterval(t *testing.T) {
 	}, nil)
 	defer r.Close()
 
-	r.Record(context.Background(), PostureEvaluation{
+	r.Record(context.Background(), Evaluation{
 		AccountID:      "acct",
 		PeerID:         "peer",
 		PostureCheckID: "check",
@@ -153,7 +153,7 @@ func TestBufferedRecorder_FlushesOnClose(t *testing.T) {
 		FlushInterval: 1 * time.Hour,
 	}, nil)
 
-	r.Record(context.Background(), PostureEvaluation{
+	r.Record(context.Background(), Evaluation{
 		AccountID:      "acct",
 		PeerID:         "peer",
 		PostureCheckID: "check",
@@ -191,7 +191,7 @@ func TestBufferedRecorder_DropsOnOverflow(t *testing.T) {
 	// without this every Record() after the first would short-circuit
 	// before ever reaching the channel-send path we're trying to exercise.
 	for i := 0; i < 10; i++ {
-		r.Record(context.Background(), PostureEvaluation{
+		r.Record(context.Background(), Evaluation{
 			PeerID:      fmt.Sprintf("peer-a-%d", i),
 			EvaluatedAt: now,
 		})
@@ -201,7 +201,7 @@ func TestBufferedRecorder_DropsOnOverflow(t *testing.T) {
 	// block in Insert. After that, additional Records must overflow.
 	time.Sleep(50 * time.Millisecond)
 	for i := 0; i < 20; i++ {
-		r.Record(context.Background(), PostureEvaluation{
+		r.Record(context.Background(), Evaluation{
 			PeerID:      fmt.Sprintf("peer-b-%d", i),
 			EvaluatedAt: now,
 		})
@@ -217,11 +217,11 @@ func TestBufferedRecorder_DropsOnOverflow(t *testing.T) {
 
 type blockingStore struct{ released chan struct{} }
 
-func (b *blockingStore) Insert(_ context.Context, _ []PostureEvaluation) error {
+func (b *blockingStore) Insert(_ context.Context, _ []Evaluation) error {
 	<-b.released
 	return nil
 }
-func (b *blockingStore) ListForPeer(_ context.Context, _, _ string, _ int) ([]PostureEvaluation, error) {
+func (b *blockingStore) ListForPeer(_ context.Context, _, _ string, _ int) ([]Evaluation, error) {
 	return nil, nil
 }
 func (b *blockingStore) PurgeOlderThan(_ context.Context, _ time.Time) (int64, error) {
@@ -232,7 +232,7 @@ func TestFakeStore_ListReturnsNewestFirst(t *testing.T) {
 	store := &fakeEvalStore{}
 	now := time.Now().UTC()
 	for i := 0; i < 5; i++ {
-		_ = store.Insert(context.Background(), []PostureEvaluation{{
+		_ = store.Insert(context.Background(), []Evaluation{{
 			AccountID:   "a",
 			PeerID:      "p",
 			EvaluatedAt: now.Add(time.Duration(i) * time.Second),
@@ -255,7 +255,7 @@ func TestEvalRetention_PurgesOldRows(t *testing.T) {
 	store := &fakeEvalStore{}
 	old := time.Now().UTC().Add(-48 * time.Hour)
 	fresh := time.Now().UTC().Add(-1 * time.Hour)
-	_ = store.Insert(context.Background(), []PostureEvaluation{
+	_ = store.Insert(context.Background(), []Evaluation{
 		{AccountID: "a", PeerID: "p", EvaluatedAt: old, CheckType: "old"},
 		{AccountID: "a", PeerID: "p", EvaluatedAt: fresh, CheckType: "fresh"},
 	})
@@ -305,7 +305,7 @@ func TestMigrateEvaluationTable_CreatesIndexes(t *testing.T) {
 		"idx_posture_eval_account_peer_time",
 		"idx_posture_eval_evaluated_at",
 	} {
-		if !mig.HasIndex(&PostureEvaluation{}, idx) {
+		if !mig.HasIndex(&Evaluation{}, idx) {
 			t.Errorf("expected index %q after AutoMigrate", idx)
 		}
 	}
@@ -324,7 +324,7 @@ func BenchmarkRecord_HotPath(b *testing.B) {
 	}, nil)
 	defer r.Close()
 
-	ev := PostureEvaluation{
+	ev := Evaluation{
 		AccountID:      "bench-account",
 		PeerID:         "bench-peer",
 		PostureCheckID: "bench-check",
@@ -351,7 +351,7 @@ func TestBufferedRecorder_DedupesIdenticalConsecutiveStates(t *testing.T) {
 	defer r.Close()
 
 	now := time.Now().UTC()
-	base := PostureEvaluation{
+	base := Evaluation{
 		AccountID:      "a",
 		PeerID:         "p",
 		PostureCheckID: "c",
@@ -408,7 +408,7 @@ func TestBufferedRecorder_StateChangeBreaksDedup(t *testing.T) {
 	defer r.Close()
 
 	now := time.Now().UTC()
-	base := PostureEvaluation{
+	base := Evaluation{
 		AccountID:      "a",
 		PeerID:         "p",
 		PostureCheckID: "c",
@@ -459,7 +459,7 @@ func TestBufferedRecorder_RefreshTTLBypassesDedup(t *testing.T) {
 	defer r.Close()
 
 	now := time.Now().UTC()
-	base := PostureEvaluation{
+	base := Evaluation{
 		AccountID:      "a",
 		PeerID:         "p",
 		PostureCheckID: "c",
@@ -510,7 +510,7 @@ func TestBufferedRecorder_DedupIsPerCheckType(t *testing.T) {
 
 	now := time.Now().UTC()
 	for _, check := range []string{"EndpointSecurityCheck", "OSVersionCheck"} {
-		r.Record(context.Background(), PostureEvaluation{
+		r.Record(context.Background(), Evaluation{
 			AccountID:      "a",
 			PeerID:         "p",
 			PostureCheckID: "c",

--- a/management/server/types/account.go
+++ b/management/server/types/account.go
@@ -1172,7 +1172,7 @@ func (a *Account) validatePostureChecksOnPeer(ctx context.Context, sourcePosture
 				if err != nil {
 					reason = err.Error()
 				}
-				recorder.Record(ctx, posture.PostureEvaluation{
+				recorder.Record(ctx, posture.Evaluation{
 					AccountID:      a.Id,
 					PeerID:         peer.ID,
 					PostureCheckID: postureChecksID,

--- a/management/server/user_scim.go
+++ b/management/server/user_scim.go
@@ -252,7 +252,7 @@ func (am *DefaultAccountManager) SCIMGetUser(ctx context.Context, accountID, cal
 // findSCIMUserByUserName scans the account's user set for a match.
 // Returns nil, nil when no user has this userName (a non-error case
 // in the create flow).
-func (am *DefaultAccountManager) findSCIMUserByUserName(ctx context.Context, accountID, userName string) (*types.User, error) { //nolint:nilnil // documented contract: "not found" is a non-error case in the SCIM create flow; caller at :38 checks err==nil && existing!=nil.
+func (am *DefaultAccountManager) findSCIMUserByUserName(ctx context.Context, accountID, userName string) (*types.User, error) {
 	users, err := am.Store.GetAccountUsers(ctx, store.LockingStrengthShare, accountID)
 	if err != nil {
 		return nil, err
@@ -262,7 +262,10 @@ func (am *DefaultAccountManager) findSCIMUserByUserName(ctx context.Context, acc
 			return u, nil
 		}
 	}
-	return nil, nil
+	// Documented contract: "not found" is a non-error case in the SCIM
+	// create flow; the caller (SCIMCreateUser) checks err == nil &&
+	// existing != nil to decide whether the userName collides.
+	return nil, nil //nolint:nilnil // see comment above.
 }
 
 func (am *DefaultAccountManager) requireSCIMPermission(ctx context.Context, accountID, callerID string, op operations.Operation) error {

--- a/management/server/user_scim.go
+++ b/management/server/user_scim.go
@@ -252,7 +252,7 @@ func (am *DefaultAccountManager) SCIMGetUser(ctx context.Context, accountID, cal
 // findSCIMUserByUserName scans the account's user set for a match.
 // Returns nil, nil when no user has this userName (a non-error case
 // in the create flow).
-func (am *DefaultAccountManager) findSCIMUserByUserName(ctx context.Context, accountID, userName string) (*types.User, error) {
+func (am *DefaultAccountManager) findSCIMUserByUserName(ctx context.Context, accountID, userName string) (*types.User, error) { //nolint:nilnil // documented contract: "not found" is a non-error case in the SCIM create flow; caller at :38 checks err==nil && existing!=nil.
 	users, err := am.Store.GetAccountUsers(ctx, store.LockingStrengthShare, accountID)
 	if err != nil {
 		return nil, err

--- a/safedial/safedial_test.go
+++ b/safedial/safedial_test.go
@@ -100,8 +100,9 @@ func TestGuardedTransport_BlocksLoopback(t *testing.T) {
 	defer srv.Close()
 
 	guarded := &http.Client{Timeout: 2 * time.Second, Transport: Transport()}
-	_, err := guarded.Get(srv.URL)
+	resp, err := guarded.Get(srv.URL)
 	if err == nil {
+		resp.Body.Close()
 		t.Fatal("guarded transport reached a loopback server — SSRF guard not wired into the dialer")
 	}
 }

--- a/version/selfupdate/gate_test.go
+++ b/version/selfupdate/gate_test.go
@@ -129,7 +129,7 @@ func TestEvaluate_StagedRollout(t *testing.T) {
 	if Evaluate(mOut).Eligible {
 		t.Fatalf("client %q (bucket %d) should be outside a 50%% rollout", outID, bucketOf(outID))
 	}
-	if Evaluate(mIn).Eligible != Evaluate(mIn).Eligible {
+	if first, second := Evaluate(mIn).Eligible, Evaluate(mIn).Eligible; first != second {
 		t.Fatal("bucketing must be deterministic")
 	}
 	crit := mOut

--- a/version/selfupdate/verify.go
+++ b/version/selfupdate/verify.go
@@ -87,10 +87,10 @@ func (v macVerifier) Verify(ctx context.Context, pkgPath string) error {
 }
 
 func trim(b []byte) string {
-	const max = 200
+	const maxLen = 200
 	s := string(b)
-	if len(s) > max {
-		return s[:max] + "…"
+	if len(s) > maxLen {
+		return s[:maxLen] + "…"
 	}
 	return s
 }


### PR DESCRIPTION
Part of #20. Clears the **non-misspell** golangci-lint backlog, using a **cap-free** `golangci-lint v1.62.2` run as the authoritative oracle (the CI log under-counts: `max-issues-per-linter: 50` + `max-same-issues: 5` hid most nilnil/misspell).

#80 (B1, misspell) is merged. This stack is now linear on main.

Inventory at start (cap-free, post-B1): **41** non-misspell.
**Inventory now: 0.**

### Done

| Group | Approach | Count | Notes |
|---|---|---|---|
| forbidigo + nilnil (factories) | `.golangci.yaml` exclude-rules | 7+14 | dev-seed CLI + factory files; `(nil,nil)` is intentional "feature disabled" shape, same precedent as `mock\.go` |
| gosimple S1008 | trivial: `return x == y` | 1 | uspfilter/conntrack/tcp.go |
| unused | delete dead `fromUserInfo` | 1 | scim/users.go — zero callers repo-wide |
| predeclared | rename builtins-shadowers | 4 | `min` (deleted; Go 1.21+ builtin covers), `real`→`realMembers`, `close`→`closeIdx`, `max`→`maxLen` |
| staticcheck SA4000 | capture two evaluations into distinct vars | 2 | client_update_targeting_test, gate_test — vacuous `f()!=f()` checks now actually test determinism |
| bodyclose | `//nolint` (FP via drainAndClose helper) + 1 real fix | 2+1 | crowdstrike ×2 (linter blind to wrapper); safedial_test real hygiene fix (Close on fail path before t.Fatal) |
| nilnil (non-factory) | per-site `//nolint:nilnil` with local rationale | 5 | dex_proxy, user_scim, control_center handler_test ×3 — all documented contracts |
| SA1019 | `//nolint:staticcheck` + follow-up issue #82 | 3 | Google credentials APIs; migration auth-sensitive, deserves its own focused PR |
| revive (stutter) | rename `posture.PostureEvaluation` → `posture.Evaluation` | 1 | DB table name pinned via `TableName()`, no schema/query impact |

### Verification

\`\`\`
\$ golangci-lint run --max-issues-per-linter=0 --max-same-issues=0 --timeout=10m
\$ echo \$?
0
\`\`\`

Build green (`go build ./...`), posture package tests green (the only package whose identifiers changed).

### Closing condition (separate)

Lote C: remove `continue-on-error: true` from `golangci-lint.yml` once cap-free remains 0 on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)