### PR TITLE
fix(dashboard): post-login eternal spinner + OIDC auth security hardening

### DIFF
--- a/dashboard/docker/default.conf
+++ b/dashboard/docker/default.conf
@@ -4,16 +4,43 @@ server {
 
     root /usr/share/nginx/html;
 
+    # Baseline security + cache headers for the dashboard static export.
+    # nginx `add_header` does NOT merge across levels — if a `location`
+    # block declares its own add_header, *all* parent-level add_headers
+    # are dropped for that location. So everything we want everywhere
+    # lives here at server scope, and the location blocks do not set
+    # their own add_header.
+    #
+    # `always` so the headers also apply to error responses (404 etc.),
+    # not just 200/30x — without it, nginx skips add_header on errors.
+    #
+    # Not included here (deliberately):
+    #   * Content-Security-Policy — requires templating connect-src
+    #     with AUTH_AUTHORITY + OPENZRO_MGMT_API_ENDPOINT at startup
+    #     (the operator decides those origins). Tracked as a follow-up.
+    #   * X-XSS-Protection — deprecated, modern browsers ignore it
+    #     and a misconfigured value can BE the vulnerability.
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    # Conservative Permissions-Policy: revoke every powerful API the
+    # dashboard does not use. If we later need any of these, drop the
+    # specific entry from this list rather than removing the header.
+    add_header Permissions-Policy "accelerometer=(), autoplay=(), camera=(), display-capture=(), encrypted-media=(), fullscreen=(self), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), picture-in-picture=(), publickey-credentials-get=(), screen-wake-lock=(), sync-xhr=(), usb=(), xr-spatial-tracking=()" always;
+    # Block client/proxy caching of the SPA shell so a new release
+    # invalidates immediately. The hashed Next chunks under /_next/
+    # are content-addressed and safe to long-cache; revisit if/when we
+    # add an exception for that path.
+    add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0" always;
+    expires off;
+
     location / {
       try_files $uri $uri.html $uri/ =404;
-      add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
-      expires off;
-   }
+    }
 
-   error_page 404 /404.html;
-   location = /404.html {
+    error_page 404 /404.html;
+    location = /404.html {
       internal;
-      add_header Cache-Control "no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0";
-      expires off;
-   }
+    }
 }

--- a/dashboard/public/local/OidcTrustedDomains.js
+++ b/dashboard/public/local/OidcTrustedDomains.js
@@ -1,6 +1,13 @@
-﻿
-// Add here trusted domains, access tokens will be send to 
+// Origins to which the @axa-fr/oidc-client lib is allowed to forward
+// access tokens. Must stay in sync with `apiOrigin` from
+// `.local-config.json` — the dev management API lives at :33071, not
+// :3001 (the dashboard's own port). Earlier versions listed :3001/3000
+// which is stale: the lib's interceptor never matched the real API
+// origin, so it silently never forwarded tokens. `useOpenzroFetch`
+// attaches the Bearer manually so the dev flow worked anyway, but
+// that fallback is fragile and the trusted-domains list is the
+// authoritative source.
 const trustedDomains = {
-    default:["http://localhost:3001","http://127.0.0.1:3001", "http://0.0.0.0:33071"],
-    auth0:[]
-};  
+  default: ["http://localhost:33071", "http://127.0.0.1:33071"],
+  auth0: [],
+};

--- a/dashboard/src/auth/OIDCProvider.tsx
+++ b/dashboard/src/auth/OIDCProvider.tsx
@@ -71,9 +71,25 @@ export default function OIDCProvider({ children }: Props) {
 
   const withCustomHistory = () => {
     return {
-      replaceState: (url: any) => {
-        router.replace(url);
-        window.dispatchEvent(new Event("popstate"));
+      // The OIDC lib calls this after exchanging `/auth?code=...`
+      // for the originally requested page. A hard replace guarantees
+      // Next mounts the destination route instead of keeping the
+      // callback segment alive behind a spinner.
+      //
+      // Open-redirect guard: the native history.replaceState() treats
+      // any non-same-origin URL as a relative path and stays on-origin.
+      // window.location.replace() does NOT — it cross-navigates. So
+      // accept only same-origin absolute paths ("/foo"), and reject
+      // protocol-relative ("//evil.com/x") and any absolute URL.
+      // Without this guard, a sessionStorage poisoning (XSS or
+      // malicious browser extension) into the lib's loginParams could
+      // steer the post-callback redirect to an attacker origin.
+      replaceState: (url?: string | null) => {
+        const safe =
+          typeof url === "string" &&
+          url.startsWith("/") &&
+          !url.startsWith("//");
+        window.location.replace(safe ? url : "/");
       },
     };
   };
@@ -107,7 +123,7 @@ export default function OIDCProvider({ children }: Props) {
   return mounted && providerConfig ? (
     <OidcProvider
       configuration={providerConfig}
-      //withCustomHistory={withCustomHistory}
+      withCustomHistory={withCustomHistory}
       authenticatingComponent={FullScreenLoading}
       authenticatingErrorComponent={OIDCError}
       loadingComponent={FullScreenLoading}

--- a/dashboard/src/auth/OIDCProvider.tsx
+++ b/dashboard/src/auth/OIDCProvider.tsx
@@ -109,9 +109,14 @@ export default function OIDCProvider({ children }: Props) {
         ? auth0AuthorityConfig
         : undefined,
       extras: buildExtras(),
-      ...(config.clientSecret
-        ? { token_request_extras: { client_secret: config.clientSecret } }
-        : null),
+      // No client_secret branch on purpose: this is a public OIDC
+      // client (SPA). PKCE (S256, configured in @axa-fr/oidc-client
+      // requests.ts) authenticates the token exchange without a
+      // shared secret. Putting a client_secret in `token_request_extras`
+      // here would ship it inside the JS bundle to every browser —
+      // any inspection of DevTools would leak it. Operators upgrading
+      // from a confidential-client setup must rotate the credential
+      // and register a public-client app at the IdP.
     });
     setMounted(true);
   }, []);

--- a/dashboard/src/hooks/useRedirect.tsx
+++ b/dashboard/src/hooks/useRedirect.tsx
@@ -23,7 +23,12 @@ export const useRedirect = (
     const performRedirect = () => {
       if (!isRedirecting.current) {
         isRedirecting.current = true;
-        router.refresh();
+        // No router.refresh() before push: in App Router, refresh()
+        // triggers a server re-fetch of the CURRENT route, and its
+        // in-flight RSC payload can race with the subsequent push()
+        // and effectively "resurrect" the old route. The retry
+        // setInterval below handles the rare case where push() is
+        // dropped on its own.
         if (replace) {
           router.replace(url);
         } else {

--- a/dashboard/src/utils/api.tsx
+++ b/dashboard/src/utils/api.tsx
@@ -72,6 +72,7 @@ async function apiRequest<T>(
 
 export function useOpenzroFetch(ignoreError: boolean = false): {
   fetch: (input: RequestInfo, init?: RequestInit) => Promise<Response>;
+  token: string | undefined;
 } {
   const tokenSource = config.tokenSource || "accessToken";
   const { idToken } = useOidcIdToken();
@@ -114,6 +115,7 @@ export function useOpenzroFetch(ignoreError: boolean = false): {
       input: RequestInfo,
       init?: RequestInit,
     ) => Promise<Response>,
+    token,
   };
 }
 
@@ -124,11 +126,24 @@ export default function useFetchApi<T>(
   allowFetch = true,
   options?: RequestOptions,
 ) {
-  const { fetch } = useOpenzroFetch(ignoreError);
+  const { fetch, token } = useOpenzroFetch(ignoreError);
   const handleErrors = useApiErrorHandling(ignoreError);
   const { globalApiParams } = useApplicationContext();
 
-  const cacheKey = options?.key ? [url, options?.key] : url;
+  // Gate the SWR key on `token` so the first render right after the
+  // OIDC callback — when the OIDC provider is still hydrating and
+  // `token` is undefined — does not fire a fetch with `Bearer
+  // undefined`. SWR treats a null key as "do not fetch"; when the
+  // token arrives in a later render, the key flips to the URL and
+  // SWR fires the request automatically. Defense-in-depth alongside
+  // the post-login navigation fix in OIDCProvider — neither alone
+  // covers every reload path.
+  const shouldFetch = allowFetch && !!token;
+  const cacheKey = !shouldFetch
+    ? null
+    : options?.key
+      ? [url, options?.key]
+      : url;
   const fetchFn = options?.key
     ? async ([url]: [url: string]) => {
         if (!allowFetch) return;

--- a/dashboard/src/utils/config.ts
+++ b/dashboard/src/utils/config.ts
@@ -47,6 +47,28 @@ const loadConfig = (): Config => {
 
   const authority = configJson.authAuthority.replace(/\/+$/, "");
 
+  // Plaintext-HTTP authority/apiOrigin leak the OIDC bearer over the
+  // wire when not on loopback. Loud warning in production so
+  // operators notice if their envsubst dropped the scheme; we don't
+  // hard-error because the dev/test/CI stacks intentionally run on
+  // http://localhost.
+  if (process.env.NODE_ENV === "production") {
+    const isInsecure = (url: string | undefined) =>
+      typeof url === "string" &&
+      url.startsWith("http://") &&
+      !/^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:|\/|$)/.test(url);
+    if (isInsecure(authority)) {
+      console.warn(
+        `[openZro] insecure authority URL "${authority}" — OIDC tokens will be exchanged in plaintext. Set AUTH_AUTHORITY to an https:// origin.`,
+      );
+    }
+    if (isInsecure(configJson.apiOrigin)) {
+      console.warn(
+        `[openZro] insecure apiOrigin "${configJson.apiOrigin}" — bearer tokens will be sent in plaintext. Set OPENZRO_MGMT_API_ENDPOINT to an https:// origin.`,
+      );
+    }
+  }
+
   return {
     auth0Auth: configJson.auth0Auth == "true", // Due to substitution we can't use boolean in the config
     authority: validator.isValidUrl(authority) ? authority : "http://localhost",


### PR DESCRIPTION
## Summary

Three commits stacked: the actual post-login bug fix, plus security hardening on the auth flow surfaced by reviewing what the upstream NetBird v2.15.0 import left lying around.

| # | Commit | Type |
|---|---|---|
| 1 | `fix(dashboard): post-login eternal spinner — wire withCustomHistory hard-nav` | 🔴 Bug fix |
| 2 | `security(dashboard): tighten OIDC auth surface — SPA client_secret, plaintext warn, trusted-domains` | 🟠 Security |
| 3 | `security(dashboard/docker): add baseline security headers to nginx` | 🟠 Security |

Bundle is intentional — all touch the login/auth security perimeter and the audit happened in the same session. Reviewer can read each commit on its own; force-push history shows two earlier blind attempts that were superseded.

## Root cause of the bug

`@axa-fr/react-oidc` swaps `/auth?code=...` for the originally-requested path via native `history.replaceState`. **Next.js App Router does NOT reconcile route segments off `history.replaceState` or a synthetic `popstate` event** — only off its own `router.push/replace` or a hard navigation. `usePathname()` returns the new path but the route tree mounted remains the callback page (FullScreenLoading). The user sees an eternal spinner until F5 forces a fresh resolve.

The lib's `withCustomHistory` shim point was already defined in OIDCProvider but its prop call was commented out since the upstream import. Wire it back in and have it `window.location.replace` to the destination — same mechanism F5 uses, no Next-router race, tokens persist via sessionStorage across the reload.

Validated end-to-end: logout → login lands on `/peers` without F5, zero `Fast Refresh` involvement (proven via instrumentation).

## Security audit findings (this PR's scope)

Most are inherited dashboard debt from the v2.15.0 NetBird import:

| Sev | Finding | Origin | Status |
|---|---|---|---|
| 🔴 | Open-redirect via `window.location.replace` in the new shim | Introduced by this PR | Fixed: same-origin guard on `replaceState` |
| 🟠 | `client_secret` shipped in JS bundle if operator sets `AUTH_CLIENT_SECRET` | Upstream | Removed; PKCE S256 is the auth path for SPAs |
| 🟠 | Stale `OidcTrustedDomains.js` ports never matched `apiOrigin` | Upstream | Aligned with `.local-config.json` |
| 🟠 | Plaintext `http://` allowed for `authority`/`apiOrigin` in prod | Upstream | `console.warn` at config-load (kept loopback exempt) |
| 🟠 | nginx ships zero security headers (CSP/HSTS/X-Frame/etc.) | Upstream | Added HSTS, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy |

**Deferred to a follow-up PR (issue #86):**
- Service Worker enablement for token storage (moves tokens out of JS-readable sessionStorage)
- CSP — requires templating `connect-src` with the operator's IdP + management origins, the existing envsubst pipeline only covers HTML output

**Out of scope for this PR (separate issues to file):**
- Upstream `@axa-fr/oidc-client` state/nonce entropy below OAuth BCP 128-bit threshold (~95/71 bits today)
- `logout("/", { client_id })` extras — only meaningful for the Auth0 logout endpoint, harmless on Dex; leaving as-is

## Test plan

- [x] `tsc --noEmit` clean
- [x] End-to-end: logout → login → `/peers` renders without F5 (validated locally with `[OZ-DBG]` instrumentation, cleaned before commit)
- [x] Open-redirect guard: paths like `//evil.com/x` fall back to `/` (logic review; no live test)
- [ ] **Reviewer**: build dashboard docker image, curl-i the static asset, confirm the 5 security headers show up
- [ ] **Reviewer**: verify `apiOrigin: http://localhost:*` does NOT trigger the production HTTPS warning (loopback exempt)
- [ ] **Reviewer**: verify trusted-domains list in `dashboard/public/local/OidcTrustedDomains.js` matches the dev `apiOrigin`

## Follow-ups (will file separately if approved here)

1. `#86`: Enable Service Worker for token storage
2. CSP via templated nginx config
3. Upstream issue on `@axa-fr/oidc-client` state/nonce entropy

🤖 Generated with [Claude Code](https://claude.com/claude-code)