### PR TITLE
ci: route testcontainers pulls through ECR Public to dodge Docker Hub rate limit

### DIFF
--- a/.github/workflows/golang-test-linux.yml
+++ b/.github/workflows/golang-test-linux.yml
@@ -10,6 +10,26 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || github.actor_id }}
   cancel-in-progress: true
 
+# Reroute testcontainers' Docker Hub pulls through ECR Public's mirror
+# so the Management matrix (postgres/mysql/redis) stops blowing the
+# Docker Hub pull rate limit on burst re-runs. The Hub prefix is
+# applied automatically by testcontainers-go to any bare image name
+# (mysql:8.0 -> public.ecr.aws/docker/library/mysql:8.0, same for
+# postgres:16-alpine, redis:7, etc.) — zero source changes.
+#
+# Ryuk's image (testcontainers/ryuk) lives in a different ECR Public
+# namespace (public.ecr.aws/testcontainers/ryuk) that the prefix
+# wouldn't reach, and testcontainers-go v0.42.0 has no env to
+# override the ryuk image alone. Disable Ryuk: it's only a fallback
+# garbage collector for containers a crashed test left behind, and
+# GitHub Actions runners are ephemeral — the VM destroys whatever
+# Ryuk would have killed when the job ends.
+#
+# See dashboard/.../README or future ADR for the rate-limit context.
+env:
+  TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: public.ecr.aws/docker/library
+  TESTCONTAINERS_RYUK_DISABLED: "true"
+
 jobs:
   build-cache:
     name: "Build Cache"


### PR DESCRIPTION
## Summary

- Management matrix (postgres/mysql/redis) sporadically fails with `toomanyrequests: You have reached your pull rate limit as '***'` when CI re-runs hit Docker Hub's per-account burst even on our paid org. Burned ~1h on #81 force-merge.
- Reroute testcontainers' image pulls through **ECR Public's Docker mirror** (no rate limit on anonymous pulls, no auth needed, same content-addressable layers).
- Zero source changes — two env vars on the workflow do all the rewriting via testcontainers-go's built-in `prependHubRegistry` substitutor.

## Mechanism

`TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX=public.ecr.aws/docker/library` makes the lib prepend that prefix to any image without an explicit registry:

| Original (Go source) | Rewritten by testcontainers-go |
|---|---|
| `mysql:8.0` | `public.ecr.aws/docker/library/mysql:8.0` |
| `postgres:16-alpine` | `public.ecr.aws/docker/library/postgres:16-alpine` |
| `redis:7` | `public.ecr.aws/docker/library/redis:7` |

`TESTCONTAINERS_RYUK_DISABLED=true` because Ryuk lives at `public.ecr.aws/testcontainers/ryuk` (different ECR namespace, single prefix can't reach), and testcontainers-go v0.42.0 has no per-image override. Ryuk is only a fallback GC; ephemeral GitHub runners clean themselves up.

## Why this isn't a Go code change

The substitution happens at pull time inside `testcontainers-go/options.go:225` (`prependHubRegistry.Substitute`). Existing image name strings in `management/server/testutil/store.go` and `management/server/cache/store_test.go` stay readable as the canonical Docker Hub names — operators and developers don't need to remember the mirror path.

## Verification

- [ ] After merge: trigger CI on this PR + a peers/management touching PR; confirm Management jobs no longer hit Docker Hub rate limit.
- [ ] `docker pull public.ecr.aws/docker/library/postgres:16-alpine` succeeds from a clean machine (sanity check that ECR Public hosts the image).
- [ ] No regression in local dev (`make test.go`) — env vars are workflow-scoped, not Go-scoped.

## Follow-ups (separate PRs)

1. DSOS application when openZro completes 6 months. At that point we could revert to Docker Hub direct (or stay on ECR — both work).
2. Consider removing the now-redundant Docker Hub auth steps (`Login to Docker Hub` / `Docker login for root user`) — left in this PR as belt-and-suspenders in case some future test fetches a non-mirrored image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)