### PR TITLE
ci: preserve TESTCONTAINERS_* env vars across `sudo -exec` (follow-up to #87)

### DIFF
--- a/.github/workflows/golang-test-linux.yml
+++ b/.github/workflows/golang-test-linux.yml
@@ -405,7 +405,7 @@ jobs:
           OPENZRO_STORE_ENGINE=${{ matrix.store }} \
             CI=true \
           go test -tags=devcert \
-            -exec "sudo --preserve-env=CI,OPENZRO_STORE_ENGINE" \
+            -exec "sudo --preserve-env=CI,OPENZRO_STORE_ENGINE,TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX,TESTCONTAINERS_RYUK_DISABLED" \
             -timeout 20m ./management/...
 
   benchmark:
@@ -480,7 +480,7 @@ jobs:
           OPENZRO_STORE_ENGINE=${{ matrix.store }} \
           CI=true \
           go test -tags devcert -run=^$ -bench=. \
-          -exec 'sudo --preserve-env=CI,OPENZRO_STORE_ENGINE' \
+          -exec 'sudo --preserve-env=CI,OPENZRO_STORE_ENGINE,TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX,TESTCONTAINERS_RYUK_DISABLED' \
           -timeout 20m ./management/...
 
   api_benchmark:
@@ -585,7 +585,7 @@ jobs:
           go test -tags=benchmark \
             -run=^$ \
             -bench=. \
-            -exec 'sudo --preserve-env=CI,OPENZRO_STORE_ENGINE,GIT_BRANCH,GITHUB_RUN_ID' \
+            -exec 'sudo --preserve-env=CI,OPENZRO_STORE_ENGINE,GIT_BRANCH,GITHUB_RUN_ID,TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX,TESTCONTAINERS_RYUK_DISABLED' \
             -timeout 20m ./management/...
 
   api_integration_test:
@@ -660,5 +660,5 @@ jobs:
           OPENZRO_STORE_ENGINE=${{ matrix.store }} \
           CI=true \
           go test -tags=integration \
-          -exec 'sudo --preserve-env=CI,OPENZRO_STORE_ENGINE' \
+          -exec 'sudo --preserve-env=CI,OPENZRO_STORE_ENGINE,TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX,TESTCONTAINERS_RYUK_DISABLED' \
           -timeout 20m ./management/...


### PR DESCRIPTION
## Summary

Follow-up to #87. The ECR Public mirror env vars were set at workflow level but never reached the Go test process — \`go test -exec 'sudo --preserve-env=CI,OPENZRO_STORE_ENGINE' ...\` strips everything not in the allow-list.

Add \`TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX,TESTCONTAINERS_RYUK_DISABLED\` to all four \`--preserve-env=\` lists in the management test invocations.

## Why this is needed

Symptom on post-#87 reruns:

\`\`\`
TESTCONTAINERS_HUB_IMAGE_NAME_PREFIX: public.ecr.aws/docker/library  # in env block
TESTCONTAINERS_RYUK_DISABLED: true                                    # in env block
...
🐳 Creating container for image testcontainers/ryuk:0.7.0  # ← ryuk still runs
Failed to pull image: toomanyrequests: ... dckr_jti_*    # ← still Docker Hub
\`\`\`

testcontainers-go reads \`os.Getenv\` from the Go process. sudo's default is to strip env vars; only what's listed in \`--preserve-env\` is forwarded. Our two vars were not listed → empty config → no substitution → no Ryuk disable.

## Test plan

- [ ] Merge this PR
- [ ] Rebase #84 / #85 onto new main
- [ ] Force-push triggers fresh CI runs; Management Unit jobs should now pull from \`public.ecr.aws/docker/library/*\` and skip Ryuk

🤖 Generated with [Claude Code](https://claude.com/claude-code)