### PR TITLE
ci: drop Docker Hub login steps from management tests (now on ECR Public)

### DIFF
--- a/.github/workflows/golang-test-linux.yml
+++ b/.github/workflows/golang-test-linux.yml
@@ -374,30 +374,12 @@ jobs:
       - name: check git status
         run: git --no-pager diff --exit-code
 
-      # Authenticated Docker Hub pulls so testcontainers (postgres/
-      # mysql) don't hit the anonymous rate limit — "Failed to get
-      # image auth … mysql:8.0" was the pre-existing Management red.
-      # Adapted from netbirdio/netbird's BSD-licensed
-      # golang-test-linux.yml (test_management job). The Test step
-      # runs `go test -exec sudo …`, so root's docker config needs
-      # the login too. Gated on the secret being present, so fork
-      # PRs / forks without it skip cleanly (fall back to anon pulls)
-      # instead of failing.
-      - name: Login to Docker Hub
-        if: ${{ env.DOCKERHUB_USERNAME != '' }}
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Docker login for root user
-        if: ${{ env.DOCKERHUB_USERNAME != '' }}
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: echo "$DOCKERHUB_TOKEN" | sudo docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+      # Docker Hub auth removed: #87 routes testcontainers pulls
+      # through ECR Public's anonymous mirror, and #89 makes those
+      # env vars survive the `sudo` allow-list. No path in this job
+      # touches docker.io anymore, so the login was strictly liability
+      # — it added a step that could fail (and did, with "email must
+      # be verified") for zero benefit.
 
       - name: Test
         run: |
@@ -449,30 +431,12 @@ jobs:
       - name: check git status
         run: git --no-pager diff --exit-code
 
-      # Authenticated Docker Hub pulls so testcontainers (postgres/
-      # mysql) don't hit the anonymous rate limit — "Failed to get
-      # image auth … mysql:8.0" was the pre-existing Management red.
-      # Adapted from netbirdio/netbird's BSD-licensed
-      # golang-test-linux.yml (test_management job). The Test step
-      # runs `go test -exec sudo …`, so root's docker config needs
-      # the login too. Gated on the secret being present, so fork
-      # PRs / forks without it skip cleanly (fall back to anon pulls)
-      # instead of failing.
-      - name: Login to Docker Hub
-        if: ${{ env.DOCKERHUB_USERNAME != '' }}
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Docker login for root user
-        if: ${{ env.DOCKERHUB_USERNAME != '' }}
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: echo "$DOCKERHUB_TOKEN" | sudo docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+      # Docker Hub auth removed: #87 routes testcontainers pulls
+      # through ECR Public's anonymous mirror, and #89 makes those
+      # env vars survive the `sudo` allow-list. No path in this job
+      # touches docker.io anymore, so the login was strictly liability
+      # — it added a step that could fail (and did, with "email must
+      # be verified") for zero benefit.
 
       - name: Test
         run: |
@@ -551,30 +515,12 @@ jobs:
       - name: check git status
         run: git --no-pager diff --exit-code
 
-      # Authenticated Docker Hub pulls so testcontainers (postgres/
-      # mysql) don't hit the anonymous rate limit — "Failed to get
-      # image auth … mysql:8.0" was the pre-existing Management red.
-      # Adapted from netbirdio/netbird's BSD-licensed
-      # golang-test-linux.yml (test_management job). The Test step
-      # runs `go test -exec sudo …`, so root's docker config needs
-      # the login too. Gated on the secret being present, so fork
-      # PRs / forks without it skip cleanly (fall back to anon pulls)
-      # instead of failing.
-      - name: Login to Docker Hub
-        if: ${{ env.DOCKERHUB_USERNAME != '' }}
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Docker login for root user
-        if: ${{ env.DOCKERHUB_USERNAME != '' }}
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: echo "$DOCKERHUB_TOKEN" | sudo docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+      # Docker Hub auth removed: #87 routes testcontainers pulls
+      # through ECR Public's anonymous mirror, and #89 makes those
+      # env vars survive the `sudo` allow-list. No path in this job
+      # touches docker.io anymore, so the login was strictly liability
+      # — it added a step that could fail (and did, with "email must
+      # be verified") for zero benefit.
 
       - name: Test
         run: |
@@ -629,30 +575,12 @@ jobs:
       - name: check git status
         run: git --no-pager diff --exit-code
 
-      # Authenticated Docker Hub pulls so testcontainers (postgres/
-      # mysql) don't hit the anonymous rate limit — "Failed to get
-      # image auth … mysql:8.0" was the pre-existing Management red.
-      # Adapted from netbirdio/netbird's BSD-licensed
-      # golang-test-linux.yml (test_management job). The Test step
-      # runs `go test -exec sudo …`, so root's docker config needs
-      # the login too. Gated on the secret being present, so fork
-      # PRs / forks without it skip cleanly (fall back to anon pulls)
-      # instead of failing.
-      - name: Login to Docker Hub
-        if: ${{ env.DOCKERHUB_USERNAME != '' }}
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Docker login for root user
-        if: ${{ env.DOCKERHUB_USERNAME != '' }}
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: echo "$DOCKERHUB_TOKEN" | sudo docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+      # Docker Hub auth removed: #87 routes testcontainers pulls
+      # through ECR Public's anonymous mirror, and #89 makes those
+      # env vars survive the `sudo` allow-list. No path in this job
+      # touches docker.io anymore, so the login was strictly liability
+      # — it added a step that could fail (and did, with "email must
+      # be verified") for zero benefit.
 
       - name: Test
         run: |


### PR DESCRIPTION
## Summary

Follow-up to #87 (ECR Public mirror) + #89 (preserve TESTCONTAINERS_* env across sudo). After those landed, no path in the Linux management jobs touches docker.io anymore — but the \`Login to Docker Hub\` + \`Docker login for root user\` steps are still wired in and currently failing with:

\`\`\`
Error response from daemon: Get \"https://registry-1.docker.io/v2/\": unauthorized: email must be verified before using account
\`\`\`

Job exits in ~40s before tests even start. Bug fix work is being blocked on a Docker Hub account state we don't need anymore.

## Change

Remove the 9-line explanatory comment + the two login steps from all four management jobs (Unit, Benchmark, Benchmark (API), Integration). 24 lines of new comment replacing 96 lines of dead login plumbing.

Even if the Docker Hub email were re-verified, the login would still be pointless — ECR Public anonymous pulls aren't rate-limited at any scale this CI consumes (500/sec, 5 TB/month).

## Test plan

- [ ] Merge this PR
- [ ] Rebase #84 onto new main → CI re-runs without Docker Hub login step → Management Unit jobs land green

🤖 Generated with [Claude Code](https://claude.com/claude-code)