### PR TITLE
fix(management): close race in TestCleanupSchedulingBehaviorIsBatched mock

### DIFF
--- a/management/server/ephemeral_test.go
+++ b/management/server/ephemeral_test.go
@@ -43,10 +43,18 @@ func (a *MockAccountManager) DeletePeer(_ context.Context, accountID, peerID, us
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.deletePeerCalls++
+	// Apply the side effect (peer removal from the store) BEFORE
+	// signaling the WaitGroup. Otherwise the test's wg.Wait() can
+	// return as soon as the 10th Done() lands, while the 10th
+	// goroutine is still parked one instruction short of the delete()
+	// call. The test then reads mockStore.account.Peers and asserts
+	// len == 0 — but peer-N is still in the map, so the assertion
+	// fails intermittently (always on the last peer because the race
+	// window is the gap between Done and delete on the LAST goroutine).
+	delete(a.store.account.Peers, peerID)
 	if a.wg != nil {
 		a.wg.Done()
 	}
-	delete(a.store.account.Peers, peerID)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- The Management Unit (postgres) job has been intermittently failing on \`management/server/ephemeral_test.go:200\` with \`map[peer-9:0xc003060c88]" should have 0 item(s), but has 1\` — always the last peer in the slice.
- Root cause: \`MockAccountManager.DeletePeer\` signals its WaitGroup (\`a.wg.Done()\`) BEFORE applying the side effect (\`delete(a.store.account.Peers, peerID)\`). The test's \`mockAM.wg.Wait()\` unblocks the moment the 10th Done lands; that goroutine is parked one statement short of \`delete()\`. The main goroutine wakes, reads the map, and finds the last peer still there. Always the last one because the race window is the gap between Done and delete on the LAST goroutine to Done.
- Fix: do the delete BEFORE the Done so the side effect the test observes is committed by the time \`wg.Wait\` returns.

## Origin

Inherited from upstream \`netbirdio/netbird@f0e1368a\` (the original "added cleanupWindow for collecting several ephemeral peers to delete" patch). It was a latent race that only surfaced now that the Docker Hub rate-limit + sudo env-strip + Docker login flakes (closed by #87 / #89 / #90 / #92) stopped masking real test reds.

## Verification

\`\`\`
$ go test -count=100 -race -run TestCleanupSchedulingBehaviorIsBatched -timeout 5m ./management/server
ok  	github.com/openzro/openzro/management/server	112.329s
\`\`\`

100/100 with the race detector. Zero flakes.

## Test plan

- [ ] Merge
- [ ] Next push to main / next management PR triggers Linux Management Unit; expect green across all three store backends now

🤖 Generated with [Claude Code](https://claude.com/claude-code)