### PR TITLE
fix(management): strip leading "v" from ClientUpdateTargetVersion

### DIFF
--- a/management/server/http/handlers/accounts/accounts_handler.go
+++ b/management/server/http/handlers/accounts/accounts_handler.go
@@ -3,6 +3,7 @@ package accounts
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -183,7 +184,17 @@ func (h *handler) updateAccount(w http.ResponseWriter, r *http.Request) {
 	// (no runtime validation middleware), and an out-of-range ring
 	// would otherwise reach the fail-closed gate as silently "nobody".
 	if req.Settings.ClientUpdateTargetVersion != nil {
-		settings.ClientUpdateTargetVersion = *req.Settings.ClientUpdateTargetVersion
+		// Normalize the conventional Git-tag leading "v" so an
+		// operator who copies a release tag verbatim ("v0.53.1-
+		// alpha.76") doesn't end up with a target the resolver
+		// templates into `releases/download/vv0.53.1-alpha.76/
+		// update-manifest.json` — a non-existent path, fetched as
+		// 404, surfaced in the macOS tray as the cryptic
+		// "manifest fetch failed: ... returned HTTP 404". Forgiving
+		// on input; the directive path stores the stripped form so
+		// the per-version manifest URL resolves.
+		settings.ClientUpdateTargetVersion = strings.TrimPrefix(
+			*req.Settings.ClientUpdateTargetVersion, "v")
 	}
 	if req.Settings.ClientUpdateForce != nil {
 		settings.ClientUpdateForce = *req.Settings.ClientUpdateForce

--- a/management/server/http/handlers/accounts/accounts_handler_test.go
+++ b/management/server/http/handlers/accounts/accounts_handler_test.go
@@ -487,3 +487,73 @@ func TestAccounts_PutRoundTripsFlowTrafficDefaultRange(t *testing.T) {
 		assert.Equal(t, "24h", captured.Extra.FlowTrafficDefaultRange)
 	}
 }
+
+// TestAccounts_PutStripsLeadingVOnClientUpdateTargetVersion locks the
+// fix: an operator who copies the release tag verbatim
+// ("v0.53.1-alpha.76") into the directive must end up with the bare
+// version ("0.53.1-alpha.76") on the stored settings. The selfupdate
+// resolver templates the stored value into
+// `releases/download/v{version}/update-manifest.json` — a leading "v"
+// would resolve to `releases/download/vv0.53.1-...` (HTTP 404, no
+// such asset), which is what surfaced as the cryptic macOS-tray
+// "manifest fetch failed: ... returned HTTP 404" on 2026-05-20.
+func TestAccounts_PutStripsLeadingVOnClientUpdateTargetVersion(t *testing.T) {
+	accountID := "test_account"
+	adminUser := types.NewAdminUser("test_user")
+
+	account := &types.Account{
+		Id:      accountID,
+		Domain:  "example.org",
+		Network: types.NewNetwork(),
+		Users: map[string]*types.User{
+			adminUser.Id: adminUser,
+		},
+		Settings: &types.Settings{
+			PeerLoginExpirationEnabled: false,
+			PeerLoginExpiration:        time.Hour,
+			Extra:                      &types.ExtraSettings{},
+		},
+	}
+	handler := initAccountsTestData(t, account)
+
+	var captured *types.Settings
+	if m, ok := handler.accountManager.(*mock_server.MockAccountManager); ok {
+		m.UpdateAccountSettingsFunc = func(ctx context.Context, accountID, userID string, newSettings *types.Settings) (*types.Settings, error) {
+			captured = newSettings
+			return newSettings, nil
+		}
+	}
+
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"with v prefix is stripped", "v0.53.1-alpha.76", "0.53.1-alpha.76"},
+		{"bare semver passes through", "0.53.1-alpha.76", "0.53.1-alpha.76"},
+		{"empty stays empty", "", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := `{"settings":{"peer_login_expiration":3600,"peer_login_expiration_enabled":false,"client_update_target_version":"` + tc.input + `"}}`
+
+			recorder := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPut, "/api/accounts/"+accountID, bytes.NewBufferString(body))
+			req = nbcontext.SetUserAuthInRequest(req, nbcontext.UserAuth{
+				UserId:    adminUser.Id,
+				AccountId: accountID,
+				Domain:    "example.org",
+			})
+
+			router := mux.NewRouter()
+			router.HandleFunc("/api/accounts/{accountId}", handler.updateAccount).Methods("PUT")
+			router.ServeHTTP(recorder, req)
+
+			assert.Equal(t, http.StatusOK, recorder.Code, "body=%s", recorder.Body.String())
+			if assert.NotNil(t, captured) {
+				assert.Equal(t, tc.want, captured.ClientUpdateTargetVersion)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

An operator who pastes the release tag verbatim (\`v0.53.1-alpha.76\`) into the dashboard's Client Update directive gets a target that the resolver templates into a doubled-v URL — \`releases/download/vv0.53.1-alpha.76/update-manifest.json\` — which 404s. The macOS tray surfaces this as the cryptic \`manifest fetch failed: selfupdate: manifest endpoint returned HTTP 404\` and the operator is left guessing.

Reproduced 2026-05-20: alpha.76 release, operator typed the git tag, no client picked up the directive.

## Fix

\`PUT /accounts/<id>\` strips a single leading \`v\` before storing \`ClientUpdateTargetVersion\`. Bare versions and empty (disabled) pass through unchanged. Forgiving by design — this is the field humans most often paste a tag into, and the resolver behaviour was strict enough that one typo was unrecoverable without redoing the request.

## What this PR is NOT

Broader semver validation (\`latest\`, \`main\`, malformed strings, etc.) is intentionally out of scope. The v-prefix case is the one that's actively burned an operator; the broader validation surface needs its own design pass.

## Test plan

- [x] \`go test ./management/server/http/handlers/accounts/...\` covers three cases: \`v0.53.1-alpha.76\` → stripped, \`0.53.1-alpha.76\` → unchanged, \`""\` → unchanged.
- [ ] On a real cluster, set \`client_update_target_version=v0.53.1-alpha.76\` via the API or dashboard; confirm the stored settings show the bare version and the macOS tray transitions to the install affordance instead of the 404 tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)