### PR TITLE
fix(relay/cluster): wait for dedup convergence in locator_test startPair

### DIFF
--- a/relay/server/cluster/locator_test.go
+++ b/relay/server/cluster/locator_test.go
@@ -95,7 +95,39 @@ func startPair(t *testing.T, ownsA, ownsB []messages.PeerID) (*PeerLocator, *Pee
 	_, err = transB.Dial(context.Background(), addrA)
 	require.NoError(t, err)
 
+	// Wait for HELLO-driven dedup to converge: each pod must hold
+	// exactly one live stream keyed by the OTHER pod's announced
+	// address. Without this synchronisation a test that calls
+	// Lookup() right after startPair returns can land mid-dedup —
+	// while one of the two racing TCP conns is being closed — and
+	// observe a transient "connection reset by peer" from the
+	// closing peer side. That's the recurring "Client / Unit
+	// (macOS) TestLocator_*" flake; the fix gates the test on the
+	// converged state rather than racing it.
+	waitClusterReady(t, transA, addrB)
+	waitClusterReady(t, transB, addrA)
+
 	return locA, locB, addrA, addrB
+}
+
+// waitClusterReady polls until the transport's streams map holds a
+// single live entry keyed by `expected`, signalling that the dedup
+// in Dial / handleAccepted has settled. 2s is generous — local-
+// loopback dedup completes in single-digit milliseconds in practice;
+// a stall past 2s is a real bug worth surfacing.
+func waitClusterReady(t *testing.T, tr *Transport, expected string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		streams := tr.Streams()
+		if len(streams) == 1 {
+			if _, ok := streams[expected]; ok {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("waitClusterReady: cluster did not converge to {%s} within 2s; got %v", expected, tr.Streams())
 }
 
 func TestLocator_LookupHitsRemote(t *testing.T) {


### PR DESCRIPTION
## Summary

The macOS Client / Unit job has been intermittently failing \`TestLocator_LookupCacheHitSkipsBroadcast\` and \`TestLocator_ConcurrentLookupsShareWaiter\` with \`Received unexpected error: ... connection reset by peer\` (the flake we saw on #84, #85, #95 reruns).

Root cause: \`startPair\` does symmetric dial (A→B and B→A), which opens two TCP conns between the pair. The HELLO-keyed dedup in \`Dial\` / \`handleAccepted\` then closes one of them. Tests that fire \`Lookup()\` before the dedup settles can observe the close as a transient read error.

## Fix

Add \`waitClusterReady\` — polls each transport until its \`Streams()\` map holds exactly one live entry keyed by the OTHER pod's announced address. 2 s budget (loopback dedup converges in single-digit ms in practice; a stall past 2 s is a real bug worth surfacing as a Fatalf).

## Verification

\`\`\`
$ go test -count=100 -race -run TestLocator_ -timeout 5m ./relay/server/cluster
ok  	github.com/openzro/openzro/relay/server/cluster	104.599s
\`\`\`

100/100 with the race detector. Zero flakes.

## Refs

- Pattern follows #93 (ephemeral_test.go waitgroup ordering race) — another inherited test-level race that fixed cleanly once isolated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)