### PR TITLE
feat(client): Linux/Windows update info-only surface

### DIFF
--- a/client/server/selfupdate.go
+++ b/client/server/selfupdate.go
@@ -258,6 +258,13 @@ type autoInstallState struct {
 // for this gen, and the latch is only consumed if the install really
 // begins under the SAME still-current force directive that triggered
 // it — otherwise it is released so the next directive can retry.
+//
+// Platform gating lives at the call site (updatePreflightScheduler):
+// the silent-install pipeline is darwin-only because Updater.RunOnce
+// fail-closes with ErrUnsupportedPlatform elsewhere. Keeping the
+// state machine pure here means the per-generation / concurrent /
+// supersede-mid-flight semantics stay unit-testable on every
+// platform — the platform decision happens before we even enter.
 func (s *Server) maybeAutoInstall(target string, force, available bool, gen uint64) {
 	if !force || !available || target == "" {
 		return
@@ -553,7 +560,17 @@ func (s *Server) updatePreflightScheduler(kick <-chan struct{}) {
 		// now (review-1 #1), latched per directive generation
 		// (review-2 #1). No-op otherwise; self-guards repeat/concurrent
 		// attempts and releases the latch if superseded before start.
-		if published {
+		//
+		// Darwin-only: the install pipeline (Updater.RunOnce) fail-
+		// closes with ErrUnsupportedPlatform on non-darwin. Without
+		// this gate every force directive on Linux/Windows would burn
+		// its attempt latch with a guaranteed-failed install —
+		// surfacing as repeated "auto-install X failed" log spam plus
+		// a stuck autoInstall.lastErr in the daemon state. The
+		// preflight verdict still surfaces on all platforms (info-only:
+		// Windows .msi link, Linux badge); only the silent-install
+		// scheduler is platform-gated.
+		if published && runtime.GOOS == "darwin" {
 			s.maybeAutoInstall(pf.forTarget, live.force, pf.available, live.gen)
 		}
 
@@ -636,17 +653,22 @@ func isTransientFetchErr(err error) bool {
 // decides silent-vs-prompt at install time. AutoInstallEnabled is
 // pinned true so the gate reports pure version+pin+staged
 // eligibility rather than the surface-only short-circuit.
+//
+// available=true is now the source of truth for both the macOS
+// auto-install path (Update RPC → download/verify/pkg-install) and
+// the Linux/Windows info-only surface (tray badge + Windows .msi
+// link). The platform gate that used to short-circuit non-darwin
+// to "macOS-only" was removed: the install side
+// (selfupdate.Updater.RunOnce) still fail-closes with
+// ErrUnsupportedPlatform on non-darwin, but the preflight verdict
+// now reaches the UI so the tray icon flips and Windows gets a
+// direct .msi download CTA.
 func (s *Server) computeUpdatePreflight(ctx context.Context, target string, _ bool) updatePreflight {
 	pf := updatePreflight{forTarget: target, done: true}
 
-	// A cleared directive is the same truth on every platform — answer
-	// it before the macOS-only gate so the UI shows the real reason.
+	// A cleared directive is the same truth on every platform.
 	if target == "" {
 		pf.reason = "no directive (operator cleared the target)"
-		return pf
-	}
-	if runtime.GOOS != "darwin" {
-		pf.reason = "self-update is macOS-only in phase 1"
 		return pf
 	}
 
@@ -691,15 +713,40 @@ func (s *Server) computeUpdatePreflight(ctx context.Context, target string, _ bo
 		return pf
 	}
 
+	// Authoritative: true mirrors the install path's
+	// buildSelfUpdateConfig — both flows are the management-directive
+	// surface (#5 Q2), so the preflight verdict and the actual install
+	// MUST agree on staged_rollout being skipped. The server already
+	// evaluated the operator's subset/ring for this peer; a second
+	// client-side dice roll here would only double-gate and could hide
+	// the CTA from a peer the server explicitly selected. Without
+	// alignment, a manifest with staged_rollout=10% would suppress the
+	// macOS Install CTA / the Windows .msi Download CTA while the
+	// install path (Authoritative=true) would have happily succeeded
+	// if invoked.
 	d := selfupdate.Evaluate(selfupdate.GateInput{
-		Current:            version.OpenzroVersion(),
+		Current:            s.currentVersion(),
 		Manifest:           m,
 		AutoInstallEnabled: true,
 		ClientID:           s.clientUpdateBucketID(),
+		Authoritative:      true,
 	})
 	pf.available = d.Eligible
 	pf.reason = d.Reason
 	return pf
+}
+
+// currentVersion returns the running client version for gate
+// evaluation. Production goes through version.OpenzroVersion() (set
+// at build time); tests can substitute a parseable semver via
+// s.currentVersionFn so the gate's version + staged_rollout +
+// Authoritative logic stays exercisable (the production "development"
+// fallback fails go-version parsing before any other check runs).
+func (s *Server) currentVersion() string {
+	if s.currentVersionFn != nil {
+		return s.currentVersionFn()
+	}
+	return version.OpenzroVersion()
 }
 
 // clientUpdateBucketID snapshots the stable staged-rollout bucket id

--- a/client/server/selfupdate_test.go
+++ b/client/server/selfupdate_test.go
@@ -2,9 +2,12 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
@@ -102,14 +105,100 @@ func TestBuildUpdateState(t *testing.T) {
 		if st.GetTargetVersion() != "9.9.9" || !st.GetForce() {
 			t.Fatalf("round-trip mismatch: %q force=%v", st.GetTargetVersion(), st.GetForce())
 		}
-		// macOS-only in this phase OR template not configured — either
-		// way the safe default is NOT available, never an accidental
-		// "yes" off an unconfigured path.
+		// Template not configured — the safe default is NOT available,
+		// never an accidental "yes" off an unconfigured path. (Used to
+		// also cover the macOS-only phase-1 short-circuit; that gate
+		// was removed once Linux/Windows landed the info-only surface.)
 		if st.GetAvailable() {
 			t.Fatalf("must fail closed, got available with decision %q", st.GetLastDecision())
 		}
 		if st.GetLastDecision() == "" {
 			t.Fatal("a not-available verdict must still carry a reason")
+		}
+	})
+
+	t.Run("authoritative skips staged_rollout in preflight (alignment with install path)", func(t *testing.T) {
+		// Regression for openZro #5 Q2: the management-directive flow
+		// MUST skip the manifest's staged_rollout in the preflight too,
+		// not just at install time. buildSelfUpdateConfig already sets
+		// Authoritative=true; the preflight was missing the same flag,
+		// so a peer the server picked but the manifest rolled to 0%/X%
+		// would never see the CTA even though the install would have
+		// succeeded. This test pins both directions: staged_rollout=0
+		// (refusal without Authoritative) still resolves to available
+		// here because the gate input is authoritative.
+		zero := 0
+		body, jerr := json.Marshal(selfupdate.Manifest{
+			Version:       "9.9.9",
+			StagedRollout: &zero,
+			// ParseManifest requires at least one artifact. We do not
+			// reach install here — preflight only fetches + gates —
+			// but the manifest must still be well-formed to pass parse.
+			Artifacts: map[string]selfupdate.Artifact{
+				"linux/amd64": {
+					URL:    "https://example.invalid/openzro-9.9.9-linux-amd64.tar.gz",
+					SHA256: "0000000000000000000000000000000000000000000000000000000000000000",
+				},
+			},
+		})
+		if jerr != nil {
+			t.Fatalf("manifest marshal: %v", jerr)
+		}
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write(body)
+		}))
+		t.Cleanup(srv.Close)
+		t.Setenv("OPENZRO_UPDATE_MANIFEST_TEMPLATE", srv.URL+"/{version}/manifest.json")
+
+		s := &Server{
+			// Inject a parseable lower version so the gate runs past
+			// the cur-vs-next check. Production uses version.
+			// OpenzroVersion() which is "development" in tests — that
+			// fails parsing before staged_rollout / Authoritative can
+			// matter.
+			currentVersionFn: func() string { return "0.20.0" },
+		}
+		s.onUpdateDirective("9.9.9", false)
+		st := waitPreflightDone(t, s)
+
+		if !st.GetAvailable() {
+			t.Fatalf("Authoritative must bypass staged_rollout=0; got reason %q",
+				st.GetLastDecision())
+		}
+		if !strings.Contains(st.GetLastDecision(), "management-directed") {
+			t.Fatalf("authoritative reason should mention management-directed, got %q",
+				st.GetLastDecision())
+		}
+	})
+
+	t.Run("non-darwin reaches the manifest fetch (no macOS-only short-circuit)", func(t *testing.T) {
+		// 404 server: the manifest fetch will fail, but the failure
+		// SHAPE proves the preflight reached the fetch path. With the
+		// old runtime.GOOS != "darwin" early-return the decision was
+		// "self-update is macOS-only in phase 1" on every non-darwin
+		// run; this test pins the regression so that gate cannot quietly
+		// come back.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.NotFound(w, r)
+		}))
+		t.Cleanup(srv.Close)
+		t.Setenv("OPENZRO_UPDATE_MANIFEST_TEMPLATE", srv.URL+"/{version}/manifest.json")
+
+		s := &Server{}
+		s.onUpdateDirective("9.9.9", false)
+		st := waitPreflightDone(t, s)
+
+		if st.GetAvailable() {
+			t.Fatal("a 404 manifest must never resolve to available")
+		}
+		if strings.Contains(st.GetLastDecision(), "macOS-only") {
+			t.Fatalf("the darwin early-return must stay removed, got %q",
+				st.GetLastDecision())
+		}
+		if !strings.Contains(st.GetLastDecision(), "manifest") {
+			t.Fatalf("decision must reflect the manifest path, got %q",
+				st.GetLastDecision())
 		}
 	})
 

--- a/client/server/server.go
+++ b/client/server/server.go
@@ -126,6 +126,15 @@ type Server struct {
 
 	profileManager   profilemanager.ServiceManager
 	profilesDisabled bool
+
+	// currentVersionFn returns the running client version. Production
+	// callers leave this nil and the daemon falls back to
+	// version.OpenzroVersion() (set at goreleaser build time). Tests
+	// override it to inject a parseable semver so the gate's version
+	// comparison can be exercised — the production version is
+	// "development" in tests, which the go-version parser rejects
+	// before any other gate logic runs.
+	currentVersionFn func() string
 }
 
 type oauthAuthFlow struct {

--- a/client/ui/client_ui.go
+++ b/client/ui/client_ui.go
@@ -237,6 +237,7 @@ type serviceClient struct {
 	mVersionDaemon     *systray.MenuItem
 	mUpdateStatus      *systray.MenuItem
 	mInstallUpdate     *systray.MenuItem
+	mDownloadUpdate    *systray.MenuItem
 	mQuit              *systray.MenuItem
 	mNetworks          *systray.MenuItem
 	mAllowSSH          *systray.MenuItem
@@ -868,8 +869,17 @@ func (s *serviceClient) onTrayReady() {
 	// #5: ask the privileged daemon to download+verify+install the
 	// update (rollout-gated). Only shown for a non-force directive
 	// (forced installs are silent); label carries the target version.
+	// macOS-only — Windows/Linux can't auto-install (no signed pkg
+	// pipeline, package-manager landscape respectively).
 	s.mInstallUpdate = s.mAbout.AddSubMenuItem("Install update now", "Download, verify and install the update via the daemon")
 	s.mInstallUpdate.Hide()
+
+	// Windows-only counterpart: a Download CTA that opens the direct
+	// MSI asset URL in the default browser. Linux has no CTA — the
+	// tray icon badge is the entire signal (apt/dnf/pacman handle
+	// install). Hidden on init; applyUpdateStateLocked decides.
+	s.mDownloadUpdate = s.mAbout.AddSubMenuItem("Download update", "Open the MSI installer download page")
+	s.mDownloadUpdate.Hide()
 
 	systray.AddSeparator()
 	s.mQuit = systray.AddMenuItem("Quit", quitMenuDescr)
@@ -1102,40 +1112,99 @@ func protoConfigToConfig(cfg *proto.GetConfigResponse) *profilemanager.Config {
 // us may be nil (no directive / post-restart): the getters are
 // nil-safe and yield the not-available, menus-hidden state.
 //
-// The manual "Install update now" item is shown ONLY for a NON-force
-// directive (review-#1): when the operator forced the update the
-// daemon installs it silently, so a manual CTA would be misleading.
-// #5 R5: the status line + the CTA label surface the target version
-// and the daemon's decision reason.
+// Decision is delegated to decideUpdateMenu (pure, testable); this
+// method is the thin glue that turns the verdict into Show/Hide/
+// SetTitle calls on the opaque systray items.
 func (s *serviceClient) applyUpdateStateLocked(us *proto.UpdateState) {
-	available := us.GetAvailable()
-	s.isUpdateIconActive = available
+	s.isUpdateIconActive = us.GetAvailable()
+	v := decideUpdateMenu(runtime.GOOS, us)
+	applyUpdateMenuItem(s.mUpdateStatus, v.statusShown, v.statusTitle, v.statusTooltip)
+	applyUpdateMenuItem(s.mInstallUpdate, v.installShown, v.installTitle, v.installTooltip)
+	applyUpdateMenuItem(s.mDownloadUpdate, v.downloadShown, v.downloadTitle, v.downloadTooltip)
+}
+
+// updateMenuVerdict is the per-platform decision about how the
+// update items in the About submenu should render. Pure data so
+// the platform branching is testable without a live systray.
+type updateMenuVerdict struct {
+	statusShown   bool
+	statusTitle   string
+	statusTooltip string
+
+	installShown   bool
+	installTitle   string
+	installTooltip string
+
+	downloadShown   bool
+	downloadTitle   string
+	downloadTooltip string
+}
+
+// decideUpdateMenu maps (goos, daemon update state) → which items
+// in the About submenu show, with what labels and tooltips:
+//
+//   - macOS: status line + "Install openZro X" CTA wired to the
+//     daemon Update RPC. Force directives hide the CTA (the daemon
+//     installs silently).
+//   - Windows: status line + "Download openZro X (.msi)" CTA that
+//     opens the MSI asset URL in the browser. No silent install on
+//     Windows — info-only by design.
+//   - Linux + others: badge-only. The package manager (apt/dnf/
+//     pacman/…) is the install path; a tray CTA would be redundant.
+//
+// us may be nil; all getters are nil-safe and yield the menus-hidden
+// "no directive yet" verdict.
+func decideUpdateMenu(goos string, us *proto.UpdateState) updateMenuVerdict {
 	target := us.GetTargetVersion()
 	decision := us.GetLastDecision()
+	available := us.GetAvailable()
+	force := us.GetForce()
 
-	if target != "" {
-		s.mUpdateStatus.SetTitle("Update: " + target)
-		if decision != "" {
-			s.mUpdateStatus.SetTooltip(decision)
-		}
-		s.mUpdateStatus.Show()
-	} else {
-		s.mUpdateStatus.Hide()
-	}
-
-	if available && !us.GetForce() {
-		label := "Install update now"
+	var v updateMenuVerdict
+	switch goos {
+	case "darwin":
 		if target != "" {
-			label = "Install openZro " + target
+			v.statusShown = true
+			v.statusTitle = "Update: " + target
+			v.statusTooltip = decision
 		}
-		s.mInstallUpdate.SetTitle(label)
-		if decision != "" {
-			s.mInstallUpdate.SetTooltip(decision)
+		if available && !force {
+			v.installShown = true
+			if target != "" {
+				v.installTitle = "Install openZro " + target
+			} else {
+				v.installTitle = "Install update now"
+			}
+			v.installTooltip = decision
 		}
-		s.mInstallUpdate.Show()
-	} else {
-		s.mInstallUpdate.Hide()
+	case "windows":
+		if target != "" {
+			v.statusShown = true
+			v.statusTitle = "Update: " + target
+			v.statusTooltip = decision
+		}
+		if available && target != "" {
+			v.downloadShown = true
+			v.downloadTitle = "Download openZro " + target + " (.msi)"
+			v.downloadTooltip = decision
+		}
 	}
+	return v
+}
+
+// applyUpdateMenuItem is the opaque-systray glue: SetTitle + optional
+// SetTooltip + Show when shown, Hide otherwise. Kept tiny so the
+// pure decideUpdateMenu carries the policy and this stays mechanical.
+func applyUpdateMenuItem(item *systray.MenuItem, show bool, title, tooltip string) {
+	if !show {
+		item.Hide()
+		return
+	}
+	item.SetTitle(title)
+	if tooltip != "" {
+		item.SetTooltip(tooltip)
+	}
+	item.Show()
 }
 
 // onSessionExpire sends a notification to the user when the session expires.

--- a/client/ui/client_ui_test.go
+++ b/client/ui/client_ui_test.go
@@ -1,0 +1,168 @@
+//go:build !(linux && 386)
+
+package main
+
+import (
+	"testing"
+
+	"github.com/openzro/openzro/client/proto"
+)
+
+// TestDecideUpdateMenu pins the per-platform tray surface of the
+// management-driven update directive (#5): macOS gets a daemon-
+// install CTA, Windows gets a direct-MSI download CTA, Linux gets
+// nothing (badge-only — package manager is the install path).
+func TestDecideUpdateMenu(t *testing.T) {
+	eligible := &proto.UpdateState{
+		TargetVersion: "0.53.1-alpha.79",
+		Force:         false,
+		Available:     true,
+		LastDecision:  "eligible for 0.53.1-alpha.79 (management-directed)",
+	}
+	forced := &proto.UpdateState{
+		TargetVersion: "0.53.1-alpha.79",
+		Force:         true,
+		Available:     true,
+		LastDecision:  "eligible for 0.53.1-alpha.79 (management-directed)",
+	}
+	noUpdate := &proto.UpdateState{
+		TargetVersion: "0.53.1-alpha.79",
+		Available:     false,
+		LastDecision:  "already at or above 0.53.1-alpha.79",
+	}
+	cleared := &proto.UpdateState{
+		// no directive — empty target, not available
+		LastDecision: "no directive (operator cleared the target)",
+	}
+
+	t.Run("darwin: eligible non-force shows status + install", func(t *testing.T) {
+		v := decideUpdateMenu("darwin", eligible)
+		if !v.statusShown {
+			t.Error("status line must show whenever a target is set")
+		}
+		if v.statusTitle != "Update: 0.53.1-alpha.79" {
+			t.Errorf("status title %q must carry the target", v.statusTitle)
+		}
+		if !v.installShown {
+			t.Error("install CTA must show for available && !force on darwin")
+		}
+		if v.installTitle != "Install openZro 0.53.1-alpha.79" {
+			t.Errorf("install title %q must include target", v.installTitle)
+		}
+		if v.downloadShown {
+			t.Error("download CTA must stay hidden on darwin")
+		}
+	})
+
+	t.Run("darwin: forced directive hides the install CTA", func(t *testing.T) {
+		// Force-mode means the daemon installs silently; surfacing a
+		// manual CTA would be misleading.
+		v := decideUpdateMenu("darwin", forced)
+		if !v.statusShown {
+			t.Error("status line stays — operator wants to know what's coming")
+		}
+		if v.installShown {
+			t.Error("install CTA must be hidden when force=true")
+		}
+	})
+
+	t.Run("darwin: not-available hides install but shows status", func(t *testing.T) {
+		v := decideUpdateMenu("darwin", noUpdate)
+		if !v.statusShown {
+			t.Error("status line must still show — operator sees the decided reason")
+		}
+		if v.installShown {
+			t.Error("install CTA must be hidden when available=false")
+		}
+	})
+
+	t.Run("windows: eligible shows status + download (no install)", func(t *testing.T) {
+		v := decideUpdateMenu("windows", eligible)
+		if !v.statusShown {
+			t.Error("status line must show")
+		}
+		if v.installShown {
+			t.Error("install CTA must stay hidden on windows (no auto-install)")
+		}
+		if !v.downloadShown {
+			t.Error("download CTA must show for available on windows")
+		}
+		if v.downloadTitle != "Download openZro 0.53.1-alpha.79 (.msi)" {
+			t.Errorf("download title %q must include target + .msi suffix", v.downloadTitle)
+		}
+	})
+
+	t.Run("windows: forced directive still shows download (info-only)", func(t *testing.T) {
+		// On Windows there is no silent install path, so a force
+		// directive doesn't change the surface — the operator still
+		// needs to download + run the MSI manually.
+		v := decideUpdateMenu("windows", forced)
+		if !v.downloadShown {
+			t.Error("download CTA must show on windows regardless of force")
+		}
+		if v.installShown {
+			t.Error("install CTA must never show on windows")
+		}
+	})
+
+	t.Run("windows: not-available hides download but shows status", func(t *testing.T) {
+		v := decideUpdateMenu("windows", noUpdate)
+		if !v.statusShown {
+			t.Error("status line stays — operator sees the decided reason")
+		}
+		if v.downloadShown {
+			t.Error("download CTA must be hidden when available=false")
+		}
+	})
+
+	t.Run("linux: badge-only, all menu items hidden", func(t *testing.T) {
+		// Linux installs via package manager (apt/dnf/pacman); the
+		// tray icon variant is the entire signal.
+		v := decideUpdateMenu("linux", eligible)
+		if v.statusShown || v.installShown || v.downloadShown {
+			t.Errorf("linux must keep all items hidden, got %+v", v)
+		}
+	})
+
+	t.Run("linux: same on every state", func(t *testing.T) {
+		for _, us := range []*proto.UpdateState{eligible, forced, noUpdate, cleared} {
+			v := decideUpdateMenu("linux", us)
+			if v.statusShown || v.installShown || v.downloadShown {
+				t.Errorf("linux badge-only invariant broken for %+v: verdict %+v", us, v)
+			}
+		}
+	})
+
+	t.Run("cleared directive: empty target hides status on every platform", func(t *testing.T) {
+		for _, goos := range []string{"darwin", "windows", "linux"} {
+			v := decideUpdateMenu(goos, cleared)
+			if v.statusShown {
+				t.Errorf("%s: cleared directive must hide status line, got title %q",
+					goos, v.statusTitle)
+			}
+			if v.installShown || v.downloadShown {
+				t.Errorf("%s: cleared directive must hide all CTAs", goos)
+			}
+		}
+	})
+
+	t.Run("nil state is the no-directive verdict", func(t *testing.T) {
+		// The status struct may be nil between daemon restart and the
+		// first preflight publish; getters are nil-safe in proto and
+		// the verdict must collapse to all-hidden.
+		v := decideUpdateMenu("darwin", nil)
+		if v.statusShown || v.installShown || v.downloadShown {
+			t.Errorf("nil state must yield all-hidden, got %+v", v)
+		}
+	})
+
+	t.Run("unknown goos: no CTA, conservative default", func(t *testing.T) {
+		// Anything that isn't darwin/windows falls through to the
+		// Linux/default branch — badge-only. Pins the freebsd/openbsd
+		// path even though those clients don't ship today.
+		v := decideUpdateMenu("freebsd", eligible)
+		if v.statusShown || v.installShown || v.downloadShown {
+			t.Errorf("unknown goos must default to badge-only, got %+v", v)
+		}
+	})
+}

--- a/client/ui/event_handler.go
+++ b/client/ui/event_handler.go
@@ -6,8 +6,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
+	"runtime"
 	"time"
 
 	"fyne.io/fyne/v2"
@@ -57,6 +59,8 @@ func (h *eventHandler) listen(ctx context.Context) {
 			h.handleGitHubClick()
 		case <-h.client.mInstallUpdate.ClickedCh:
 			h.handleInstallUpdateClick()
+		case <-h.client.mDownloadUpdate.ClickedCh:
+			h.handleDownloadUpdateClick()
 		case <-h.client.mNetworks.ClickedCh:
 			h.handleNetworksClick()
 		case <-h.client.mNotifications.ClickedCh:
@@ -221,6 +225,71 @@ func (h *eventHandler) handleInstallUpdateClick() {
 			h.client.app.SendNotification(fyne.NewNotification("No update applied", resp.GetReason()))
 		default:
 			h.client.app.SendNotification(fyne.NewNotification("Update", resp.GetReason()))
+		}
+	}()
+}
+
+// handleDownloadUpdateClick opens the direct MSI asset URL for the
+// currently directed target version in the default browser. Windows-
+// only path: macOS uses handleInstallUpdateClick (daemon-driven
+// auto-install), Linux uses the tray badge alone (no CTA). The
+// browser handles the download, the user runs the MSI manually —
+// info-only by design (the package-manager landscape on non-darwin
+// makes a daemon-driven install unsafe).
+//
+// Target snapshot comes from a live Status fetch, mirroring the
+// install handler (handleInstallUpdateClick at line 178) — the menu
+// item is only shown when target != "", but the live read insulates
+// us from a directive that moved between Show() and click.
+func (h *eventHandler) handleDownloadUpdateClick() {
+	go func() {
+		conn, err := h.client.getSrvClient(defaultFailTimeout)
+		if err != nil {
+			log.Errorf("download update: cannot reach daemon: %v", err)
+			return
+		}
+		st, err := conn.Status(h.client.ctx, &proto.StatusRequest{})
+		if err != nil {
+			log.Errorf("download update: status fetch failed: %v", err)
+			return
+		}
+		us := st.GetUpdateState()
+		target := us.GetTargetVersion()
+		if target == "" {
+			log.Warn("download update: clicked with empty target — directive cleared mid-click")
+			return
+		}
+		// Recheck the rollout-gated verdict — the menu shows the CTA
+		// only when applyUpdateStateLocked saw available=true, but the
+		// daemon polls every ~2s. Between the menu Show() and the user
+		// click, the directive could have moved or the manifest's
+		// rollout could have retracted; bail rather than opening the
+		// browser at a stale URL.
+		if !us.GetAvailable() {
+			log.Warnf("download update: clicked with available=false (decision %q) — directive moved mid-click",
+				us.GetLastDecision())
+			return
+		}
+
+		// Only windows_amd64 is shipped today. The check stays here
+		// (not in the menu apply) so a future arm64 build can extend
+		// the URL builder without changing apply call sites.
+		if runtime.GOARCH != "amd64" {
+			log.Warnf("download update: no MSI asset for windows/%s", runtime.GOARCH)
+			return
+		}
+
+		// Mirror the path-escape pattern from
+		// version/selfupdate/manifest.go::ResolveManifestTemplateURL —
+		// the directive target is operator-supplied and could in
+		// principle carry path-unsafe characters; PathEscape on each
+		// segment keeps the URL well-formed.
+		tag := url.PathEscape("v" + target)
+		filename := "openzro_" + url.PathEscape(target) + "_windows_amd64.msi"
+		assetURL := "https://github.com/openzro/openzro/releases/download/" + tag + "/" + filename
+
+		if err := openURL(assetURL); err != nil {
+			log.Errorf("download update: failed to open browser at %s: %v", assetURL, err)
 		}
 	}()
 }


### PR DESCRIPTION
## Summary

Closes the gap that left Linux and Windows operators with **no signal at all** when the management self-update directive (#5) published a new target version. The daemon now runs the preflight on every platform; the UI surfaces a per-platform CTA that matches each OS's native install pattern.

## Per-platform UX

| Platform | Tray icon | About submenu |
|---|---|---|
| **macOS** | flips to update variant | "Update: vX" + "Install openZro vX" (existing auto-install via daemon RPC) |
| **Windows** | flips to update variant | "Update: vX" + "Download openZro vX (.msi)" → opens direct MSI URL in browser |
| **Linux** | flips to update variant | *(nothing — apt/dnf/pacman handle the install)* |

The MSI URL is `https://github.com/openzro/openzro/releases/download/v{target}/openzro_{target}_windows_amd64.msi` — matches the goreleaser artifact name from `release-binaries.yml`.

## Daemon changes (`client/server/`)

- **Drop the darwin-only early-return** in `computeUpdatePreflight`. Preflight (manifest fetch + rollout gate) now runs on every platform; the install pipeline (`Updater.RunOnce`) keeps its own `ErrUnsupportedPlatform` gate so nothing dangerous can escape.
- **Add `Authoritative: true`** to the preflight `GateInput` to mirror `buildSelfUpdateConfig`. The two flows now agree on skipping `staged_rollout` on the management-directive path (#5 Q2). Pre-existing bug fix: a manifest with `staged_rollout=N%` would have hidden the CTA from a peer the server already selected.
- **Gate the `maybeAutoInstall` scheduler call** on `runtime.GOOS == "darwin"`. `maybeAutoInstall` itself stays a pure state machine; the platform decision lives at the call site so the per-generation / concurrent-install latch semantics remain unit-testable on every platform.
- **Add `Server.currentVersion()` helper + nil-safe `currentVersionFn` field** as a test seam (production \"development\" version is unparseable by go-version, blocking direct preflight tests).

## UI changes (`client/ui/`)

- New `mDownloadUpdate` menu item (Windows-targeted, hidden on init).
- Extract `decideUpdateMenu(goos, *proto.UpdateState) updateMenuVerdict` — pure function. `applyUpdateStateLocked` becomes thin glue.
- `handleDownloadUpdateClick` path-escapes the directive target into the MSI URL and calls the existing `openURL` helper. **Revalidates `UpdateState.Available`** against a live Status RPC before opening the browser (defense for the ~2s window between menu poll and click).

## Tests

- `TestBuildUpdateState` gains two sub-tests:
  - **\"non-darwin reaches the manifest fetch\"** — pins the regression so the macOS-only early-return cannot quietly come back.
  - **\"authoritative skips staged_rollout in preflight\"** — mock manifest with `staged_rollout=0`; the preflight still resolves to `available=true`, proving `Authoritative: true` flows through `Evaluate`.
- New `client/ui/client_ui_test.go` with `TestDecideUpdateMenu` — 10 cells covering darwin × {eligible/forced/not-available}, windows × the same triad, linux/freebsd × all states (badge-only), cleared directive cross-platform, and nil `UpdateState`.

## Test plan

- [x] \`make fmt.check\` clean on touched files
- [x] \`golangci-lint run ./client/server/... ./client/ui/...\` clean
- [x] \`go test -race -timeout 3m ./client/server/... ./client/ui/... ./version/selfupdate/...\` passes (\`TestServer_Up\` -race flake is pre-existing on main, unrelated)
- [ ] Linux client manual: directive applied → tray icon flips, About submenu has no new entries
- [ ] macOS client manual: directive applied → existing Install CTA flow unchanged
- [ ] Windows client manual: directive applied → tray icon flips, About shows \"Download openZro X (.msi)\", clicking opens the MSI URL in the default browser

## Out of scope

- Auto-install on Linux/Windows. Package-manager landscape (apt/dnf/pacman/winget/etc.) makes daemon-driven installs unsafe.
- Fyne toast / dialog. Tray-menu only matches the macOS discovery model and avoids notification fatigue.
- Windows arm64 .msi. No such asset shipped today — the click handler fail-closes (logs + returns) on non-amd64 Windows; fix when the artifact exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)