### PR TITLE
test(management): stabilise two pre-existing flakes — closes #97

### DIFF
--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -1477,6 +1477,18 @@ func TestAccountManager_NetworkUpdates_DeleteGroup(t *testing.T) {
 		return
 	}
 
+	// Drain every frame the setup steps queued — SaveGroup,
+	// DeletePolicy (default), SavePolicy each publish a NetworkMap
+	// update to peer1. Without draining, the convergence loop below
+	// could land on the DeletePolicy(default) frame (which already
+	// has RemotePeers=0 because peer1 has no active policy at that
+	// moment) and return BEFORE DeleteGroup actually fires — a false
+	// pass. 200ms is comfortably above the local fan-out latency
+	// (a few hundred microseconds in practice). Review of PR #102
+	// caught this race shape — the earlier convergence-only loop
+	// fixed message ordering but kept the buffered-frame ambiguity.
+	drainUpdateChannel(updMsg, 200*time.Millisecond)
+
 	// clean policy is pre requirement for delete group
 	if err := manager.DeletePolicy(context.Background(), account.Id, policy.ID, userID); err != nil {
 		t.Errorf("delete default rule: %v", err)
@@ -1489,18 +1501,11 @@ func TestAccountManager_NetworkUpdates_DeleteGroup(t *testing.T) {
 	}
 
 	// Read messages until the network map converges to 0 remote peers
-	// for peer1 — the post-state of DeleteGroup (peer1 no longer in
-	// any group with peer2/peer3, so they are not visible).
-	//
-	// The earlier single-shot `message := <-updMsg` racing on the
-	// channel was the #97 flake source: SaveGroup / SavePolicy from
-	// the test setup also publish updates, and depending on consumer
-	// scheduling the goroutine could read the in-flight SavePolicy
-	// frame (RemotePeers=2, groupA→groupA bidirectional) before the
-	// post-DeleteGroup frame (RemotePeers=0) arrived. Same shape of
-	// fix as the cluster locator `waitClusterReady` helper in #96:
-	// converge on the observed steady state with a deadline rather
-	// than race the first message.
+	// for peer1 — the post-state of DeleteGroup. With the pre-action
+	// drain above, every frame the loop sees was caused by either
+	// DeletePolicy(policy) or DeleteGroup, never by leftover setup
+	// noise; so the FIRST RemotePeers=0 frame is provably caused by
+	// one of the steps under test.
 	deadline := time.NewTimer(5 * time.Second)
 	defer deadline.Stop()
 	for {
@@ -1511,6 +1516,28 @@ func TestAccountManager_NetworkUpdates_DeleteGroup(t *testing.T) {
 			}
 		case <-deadline.C:
 			t.Fatalf("network map did not converge to 0 remote peers within 5s — last frame still had peers in the map")
+		}
+	}
+}
+
+// drainUpdateChannel reads every queued frame off ch and discards
+// them, returning after a short idle window with no new arrivals.
+// Used to gate test assertions against setup-step noise — the test
+// only cares about the network map AFTER the under-test action
+// fires, so any frame already in the buffer is by definition stale.
+func drainUpdateChannel(ch <-chan *UpdateMessage, idle time.Duration) {
+	t := time.NewTimer(idle)
+	defer t.Stop()
+	for {
+		select {
+		case <-ch:
+			// Reset the idle window: more frames may follow.
+			if !t.Stop() {
+				<-t.C
+			}
+			t.Reset(idle)
+		case <-t.C:
+			return
 		}
 	}
 }

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -1477,18 +1477,6 @@ func TestAccountManager_NetworkUpdates_DeleteGroup(t *testing.T) {
 		return
 	}
 
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-
-		message := <-updMsg
-		networkMap := message.Update.GetNetworkMap()
-		if len(networkMap.RemotePeers) != 0 {
-			t.Errorf("mismatch peers count: 0 expected, got %v", len(networkMap.RemotePeers))
-		}
-	}()
-
 	// clean policy is pre requirement for delete group
 	if err := manager.DeletePolicy(context.Background(), account.Id, policy.ID, userID); err != nil {
 		t.Errorf("delete default rule: %v", err)
@@ -1500,7 +1488,31 @@ func TestAccountManager_NetworkUpdates_DeleteGroup(t *testing.T) {
 		return
 	}
 
-	wg.Wait()
+	// Read messages until the network map converges to 0 remote peers
+	// for peer1 — the post-state of DeleteGroup (peer1 no longer in
+	// any group with peer2/peer3, so they are not visible).
+	//
+	// The earlier single-shot `message := <-updMsg` racing on the
+	// channel was the #97 flake source: SaveGroup / SavePolicy from
+	// the test setup also publish updates, and depending on consumer
+	// scheduling the goroutine could read the in-flight SavePolicy
+	// frame (RemotePeers=2, groupA→groupA bidirectional) before the
+	// post-DeleteGroup frame (RemotePeers=0) arrived. Same shape of
+	// fix as the cluster locator `waitClusterReady` helper in #96:
+	// converge on the observed steady state with a deadline rather
+	// than race the first message.
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
+	for {
+		select {
+		case message := <-updMsg:
+			if len(message.Update.GetNetworkMap().RemotePeers) == 0 {
+				return // converged to the post-DeleteGroup state
+			}
+		case <-deadline.C:
+			t.Fatalf("network map did not converge to 0 remote peers within 5s — last frame still had peers in the map")
+		}
+	}
 }
 
 func TestAccountManager_DeletePeer(t *testing.T) {

--- a/management/server/store/sql_store_test.go
+++ b/management/server/store/sql_store_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/sha256"
 	b64 "encoding/base64"
 	"fmt"
-	"math/rand"
 	"net"
 	"net/netip"
 	"os"
@@ -87,7 +86,7 @@ func runLargeTest(t *testing.T, store Store) {
 	account.SetupKeys[setupKey.Key] = setupKey
 	const numPerAccount = 6000
 	for n := 0; n < numPerAccount; n++ {
-		netIP := randomIPv4()
+		netIP := sequentialIPv4(n)
 		peerID := fmt.Sprintf("%s-peer-%d", account.Id, n)
 
 		peer := &nbpeer.Peer{
@@ -210,13 +209,19 @@ func runLargeTest(t *testing.T, store Store) {
 	}
 }
 
-func randomIPv4() net.IP {
-	rand.New(rand.NewSource(time.Now().UnixNano()))
-	b := make([]byte, 4)
-	for i := range b {
-		b[i] = byte(rand.Intn(256))
-	}
-	return net.IP(b)
+// sequentialIPv4 maps an iteration counter to a unique 10.x.y.z
+// address inside 10.0.0.0/8 (~16M addresses). The previous helper —
+// randomIPv4 — built each peer's address from a 32-bit unseeded
+// (and never-assigned) rand.NewSource, so 6000 calls under
+// Test_SaveAccount_Large produced a birthday-paradox collision
+// roughly once every ~250 runs, surfacing as a "duplicate key value
+// violates unique constraint idx_account_ip" flake on Postgres
+// (#97). Sequential addressing eliminates the collision class
+// entirely without changing what the test exercises (the
+// SaveAccount path; routes and nameservers reuse the IP only as a
+// payload string).
+func sequentialIPv4(n int) net.IP {
+	return net.IPv4(10, byte((n>>16)&0xff), byte((n>>8)&0xff), byte(n&0xff))
 }
 
 func Test_SaveAccount(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #97. Two test-level convergence fixes — same shape as #93 / #96.

| Flake | File | Root cause | Fix |
|---|---|---|---|
| \`Test_SaveAccount_Large\` (postgres + mysql) | \`management/server/store/sql_store_test.go\` | \`randomIPv4\` built each peer's address off the unseeded global rand; 6000-peer birthday collision ≈ 0.4%/run, surfacing as \`duplicate key value violates unique constraint idx_account_ip\` | Deterministic \`sequentialIPv4(n)\` mapping into \`10.0.0.0/8\` (16M unique addresses). No other callers of \`randomIPv4\` to migrate. |
| \`TestAccountManager_NetworkUpdates_DeleteGroup\` (postgres) | \`management/server/account_test.go\` | Single-shot \`message := <-updMsg\` raced the setup steps (SaveGroup / DeletePolicy / SavePolicy) which also publish NetworkMap frames. Goroutine could land on the SavePolicy frame (RemotePeers=2) instead of post-DeleteGroup (RemotePeers=0) | Convergence loop with 5s deadline (same pattern as \`waitClusterReady\` from #96): drain frames until one shows the expected post-state, fail loudly if it never converges |

## Verification

Local:

\`\`\`
go test -timeout 5m -count=5 -run '^Test_SaveAccount_Large$' \\
    ./management/server/store/...        # 60s wall, 5/5 PASS
go test -race -timeout 5m -count=10 -run '^TestAccountManager_NetworkUpdates_DeleteGroup$' \\
    ./management/server/...              # 10s wall, 10/10 PASS
make fmt.check                           # clean
golangci-lint run ./management/server/...  # clean
\`\`\`

## Out of scope

The (rare) \`TestServer_Up\` \`-race\` flake on Windows is a separate issue in \`client/server\` — different package, different race shape (\`fwmark\` / WireGuard concurrent-up). Not a Management/Unit flake; not addressed here.

Closes #97. Refs #93, #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)