### PR TITLE
fix(management/scim): propagate group-membership changes to peers — closes #104

### DIFF
--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -3583,6 +3583,61 @@ func TestPropagateUserGroupMemberships(t *testing.T) {
 	})
 }
 
+// TestSCIMRemoveGroupMember_RecoversFromPartialWrite pins openzro
+// #104 review-1: a retry after a partial-write failure (User.AutoGroups
+// already removed by an earlier attempt, but Group.Peers still
+// carries the user's peer) MUST repair Group.Peers — not no-op out
+// because User.AutoGroups is already in the desired state.
+//
+// Setup mirrors the post-partial-write state directly: the test
+// leaves peer1 in Group.Peers (simulating the Group write that
+// didn't commit) while User.AutoGroups is already CLEAN (the user's
+// AutoGroups is empty by default in GetOrCreateAccountByUser — so
+// User looks "already removed"). A retry that short-circuits on
+// "User.AutoGroups already correct" leaves Group.Peers wrong.
+func TestSCIMRemoveGroupMember_RecoversFromPartialWrite(t *testing.T) {
+	manager, err := createManager(t)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	initiatorId := "test-user"
+	dom := "example.com"
+
+	account, err := manager.GetOrCreateAccountByUser(ctx, initiatorId, dom)
+	require.NoError(t, err)
+
+	peer1 := &nbpeer.Peer{
+		ID: "peer1", AccountID: account.Id, UserID: initiatorId,
+		IP: net.IP{1, 1, 1, 1}, DNSLabel: "peer1.domain.test",
+	}
+	require.NoError(t, manager.Store.AddPeerToAccount(ctx, store.LockingStrengthUpdate, peer1))
+
+	// Pre-state: peer in Group.Peers (the Group save the partial-
+	// write left committed) but User.AutoGroups is clean (the User
+	// save that DID commit on the earlier attempt). A no-op
+	// short-circuit on "User.AutoGroups already correct" would
+	// leave Group.Peers stale.
+	group := &types.Group{
+		ID: "scim-group", Name: "SCIM Group", AccountID: account.Id,
+		Issued: types.GroupIssuedIntegration,
+		Peers:  []string{peer1.ID},
+	}
+	require.NoError(t, manager.Store.SaveGroup(ctx, store.LockingStrengthUpdate, group))
+	// User.AutoGroups intentionally left untouched — the default
+	// account user has empty AutoGroups, mirroring the post-half-
+	// write state where the group was already cleared from the
+	// user but not from the group's peer list.
+
+	// Retry the SCIM call. The new transactional shape must
+	// detect the Group.Peers drift and repair it.
+	require.NoError(t, manager.SCIMRemoveGroupMember(ctx, account.Id, initiatorId, group.ID, initiatorId))
+
+	updatedGroup, err := manager.Store.GetGroupByID(ctx, store.LockingStrengthShare, account.Id, group.ID)
+	require.NoError(t, err)
+	require.NotContains(t, updatedGroup.Peers, peer1.ID,
+		"Group.Peers must be repaired on retry even when User.AutoGroups was already correct (#104 review-1)")
+}
+
 // TestSCIMRemoveGroupMember_PropagatesToGroupPeers pins openzro #104:
 // a SCIM remove-member call MUST propagate the User.AutoGroups change
 // into Group.Peers (and trigger NetworkMap fan-out for any connected

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -3583,6 +3583,69 @@ func TestPropagateUserGroupMemberships(t *testing.T) {
 	})
 }
 
+// TestSCIMRemoveGroupMember_PropagatesToGroupPeers pins openzro #104:
+// a SCIM remove-member call MUST propagate the User.AutoGroups change
+// into Group.Peers (and trigger NetworkMap fan-out for any connected
+// peer) so the IdP-driven offboarding actually narrows peer reach.
+// Before the fix the call only persisted User.AutoGroups; the policy
+// resolver reads Group.Peers, so the peer's NetworkMap stayed wide
+// open until some other account mutation bumped the serial.
+func TestSCIMRemoveGroupMember_PropagatesToGroupPeers(t *testing.T) {
+	manager, err := createManager(t)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	initiatorId := "test-user"
+	dom := "example.com"
+
+	account, err := manager.GetOrCreateAccountByUser(ctx, initiatorId, dom)
+	require.NoError(t, err)
+
+	// One user-owned peer; the SCIM path's propagation only kicks in
+	// when the user actually has peers (the len==0 short-circuit
+	// matches the dashboard SaveUser path).
+	peer1 := &nbpeer.Peer{
+		ID: "peer1", AccountID: account.Id, UserID: initiatorId,
+		IP: net.IP{1, 1, 1, 1}, DNSLabel: "peer1.domain.test",
+	}
+	require.NoError(t, manager.Store.AddPeerToAccount(ctx, store.LockingStrengthUpdate, peer1))
+
+	// Pre-state: a group with the peer in Peers, and the user's
+	// AutoGroups carries the group ID — mirrors what a previous SCIM
+	// add-member would have produced once #104 lands.
+	group := &types.Group{
+		ID: "scim-group", Name: "SCIM Group", AccountID: account.Id,
+		Issued: types.GroupIssuedIntegration,
+		Peers:  []string{peer1.ID},
+	}
+	require.NoError(t, manager.Store.SaveGroup(ctx, store.LockingStrengthUpdate, group))
+
+	user, err := manager.Store.GetUserByUserID(ctx, store.LockingStrengthShare, initiatorId)
+	require.NoError(t, err)
+	user.AutoGroups = append(user.AutoGroups, group.ID)
+	require.NoError(t, manager.Store.SaveUser(ctx, store.LockingStrengthUpdate, user))
+
+	// Exercise the SCIM remove path. The initiator is the account
+	// owner (created by GetOrCreateAccountByUser) so the permission
+	// gate at requireSCIMGroupPermission passes without extra
+	// fixture work.
+	require.NoError(t, manager.SCIMRemoveGroupMember(ctx, account.Id, initiatorId, group.ID, initiatorId))
+
+	// User.AutoGroups must lose the group (existing behavior).
+	updatedUser, err := manager.Store.GetUserByUserID(ctx, store.LockingStrengthShare, initiatorId)
+	require.NoError(t, err)
+	require.NotContains(t, updatedUser.AutoGroups, group.ID,
+		"AutoGroups must drop the group on SCIM remove")
+
+	// Group.Peers must lose peer1 — the #104 regression target.
+	// Pre-fix this assertion would FAIL because Group.Peers stayed
+	// at [peer1] indefinitely.
+	updatedGroup, err := manager.Store.GetGroupByID(ctx, store.LockingStrengthShare, account.Id, group.ID)
+	require.NoError(t, err)
+	require.NotContains(t, updatedGroup.Peers, peer1.ID,
+		"Group.Peers must drop the user's peer on SCIM remove (#104)")
+}
+
 func TestDefaultAccountManager_GetAccountOnboarding(t *testing.T) {
 	manager, err := createManager(t)
 	require.NoError(t, err)

--- a/management/server/group_scim.go
+++ b/management/server/group_scim.go
@@ -44,16 +44,15 @@ func (am *DefaultAccountManager) SCIMCreateGroup(ctx context.Context, accountID,
 	if err := am.SaveGroup(ctx, accountID, callerID, group, true); err != nil {
 		return nil, err
 	}
-	changed, err := am.applyGroupMembers(ctx, accountID, group.ID, memberUserIDs, nil)
+	propagated, err := am.applySCIMGroupMembers(ctx, accountID, group.ID, memberUserIDs, nil)
 	if err != nil {
 		return nil, err
 	}
-	// Fan out NetworkMap when any membership actually moved (#104).
-	// The SaveGroup above only fans out when the new (empty) group
-	// is already referenced by a policy / route, which is impossible
-	// for a fresh group — so this is the only path that can produce
-	// a fan-out on SCIMCreateGroup with pre-seeded members.
-	if changed {
+	// SaveGroup above only fans out for a group already referenced
+	// by a policy / route — impossible for a fresh group — so this
+	// is the only path that can produce a fan-out on SCIMCreateGroup
+	// with pre-seeded members.
+	if propagated {
 		am.UpdateAccountPeers(ctx, accountID)
 	}
 	return group, nil
@@ -84,16 +83,15 @@ func (am *DefaultAccountManager) SCIMReplaceGroup(ctx context.Context, accountID
 	if err != nil {
 		return nil, err
 	}
-	changed, err := am.applyGroupMembers(ctx, accountID, groupID, memberUserIDs, prev)
+	propagated, err := am.applySCIMGroupMembers(ctx, accountID, groupID, memberUserIDs, prev)
 	if err != nil {
 		return nil, err
 	}
-	// Fan out NetworkMap when any membership actually moved (#104).
 	// SaveGroup above already fans out for a rename if the group
 	// affects peers, but the membership diff is a separate axis —
 	// a PUT can leave the display name untouched while moving 50
 	// users in or out, and the peer reach must reflect both.
-	if changed {
+	if propagated {
 		am.UpdateAccountPeers(ctx, accountID)
 	}
 	return group, nil
@@ -107,32 +105,51 @@ func (am *DefaultAccountManager) SCIMReplaceGroup(ctx context.Context, accountID
 // IdP would silently leave the user's peers reaching the group's
 // destinations until some other account mutation bumped the serial.
 func (am *DefaultAccountManager) SCIMAddGroupMember(ctx context.Context, accountID, callerID, groupID, userID string) error {
-	unlock := am.Store.AcquireWriteLockByUID(ctx, accountID)
-	defer unlock()
-	if err := am.requireSCIMGroupPermission(ctx, accountID, callerID, operations.Update); err != nil {
-		return err
-	}
-	changed, err := am.modifyUserAutoGroup(ctx, accountID, userID, groupID, true)
-	if err != nil {
-		return err
-	}
-	if changed {
-		am.UpdateAccountPeers(ctx, accountID)
-	}
-	return nil
+	return am.scimSingleUserMembership(ctx, accountID, callerID, groupID, userID, true)
 }
 
 func (am *DefaultAccountManager) SCIMRemoveGroupMember(ctx context.Context, accountID, callerID, groupID, userID string) error {
+	return am.scimSingleUserMembership(ctx, accountID, callerID, groupID, userID, false)
+}
+
+// scimSingleUserMembership is the shared body of SCIMAddGroupMember
+// + SCIMRemoveGroupMember. Wraps the User + Group.Peers + serial
+// writes in a single transaction so a partial-write failure leaves
+// no torn state (#104 review-1: SaveUser succeeding while a later
+// Group.Peers / serial save fails used to leave the user "removed"
+// in their AutoGroups while the group still listed their peers,
+// because the retry path no-op'd on User.AutoGroups already being
+// correct). IncrementNetworkSerial runs inside the same transaction
+// so concurrent SCIM membership changes can't emit different
+// NetworkMaps under the same serial (#104 review-2).
+func (am *DefaultAccountManager) scimSingleUserMembership(ctx context.Context, accountID, callerID, groupID, userID string, add bool) error {
 	unlock := am.Store.AcquireWriteLockByUID(ctx, accountID)
 	defer unlock()
 	if err := am.requireSCIMGroupPermission(ctx, accountID, callerID, operations.Update); err != nil {
 		return err
 	}
-	changed, err := am.modifyUserAutoGroup(ctx, accountID, userID, groupID, false)
+
+	var propagated bool
+	err := am.Store.ExecuteInTransaction(ctx, func(tx store.Store) error {
+		ctx := ctx
+		settings, err := tx.GetAccountSettings(ctx, store.LockingStrengthShare, accountID)
+		if err != nil {
+			return err
+		}
+		groupsMap, err := loadGroupsMap(ctx, tx, accountID)
+		if err != nil {
+			return err
+		}
+		groupsTouched := newGroupSet()
+		if err := am.applyUserAutoGroupInTx(ctx, tx, accountID, settings, groupsMap, groupsTouched, userID, groupID, add); err != nil {
+			return err
+		}
+		return am.commitSCIMGroupChanges(ctx, tx, accountID, groupsMap, groupsTouched, &propagated)
+	})
 	if err != nil {
 		return err
 	}
-	if changed {
+	if propagated {
 		am.UpdateAccountPeers(ctx, accountID)
 	}
 	return nil
@@ -160,7 +177,9 @@ func (am *DefaultAccountManager) SCIMRenameGroup(ctx context.Context, accountID,
 }
 
 // SCIMDeleteGroup removes the Group and clears its ID from every
-// member's AutoGroups list.
+// member's AutoGroups list — in a single transaction so a failure
+// mid-way doesn't leave half-cleaned User.AutoGroups records that a
+// retry's no-op check would skip (#104 review-1).
 func (am *DefaultAccountManager) SCIMDeleteGroup(ctx context.Context, accountID, callerID, groupID string) error {
 	unlock := am.Store.AcquireWriteLockByUID(ctx, accountID)
 	defer unlock()
@@ -174,13 +193,31 @@ func (am *DefaultAccountManager) SCIMDeleteGroup(ctx context.Context, accountID,
 	if err != nil {
 		return err
 	}
-	for _, uid := range prev {
-		// Errors here are intentionally swallowed (same as before
-		// #104): one user's AutoGroups corruption shouldn't block the
-		// rest of the cleanup. The DeleteGroup below already triggers
-		// fan-out when the group affects peers, so the per-user
-		// SaveUser changes will be visible in the next NetworkMap.
-		_, _ = am.modifyUserAutoGroup(ctx, accountID, uid, groupID, false)
+
+	var propagated bool
+	err = am.Store.ExecuteInTransaction(ctx, func(tx store.Store) error {
+		ctx := ctx
+		settings, err := tx.GetAccountSettings(ctx, store.LockingStrengthShare, accountID)
+		if err != nil {
+			return err
+		}
+		groupsMap, err := loadGroupsMap(ctx, tx, accountID)
+		if err != nil {
+			return err
+		}
+		groupsTouched := newGroupSet()
+		for _, uid := range prev {
+			if err := am.applyUserAutoGroupInTx(ctx, tx, accountID, settings, groupsMap, groupsTouched, uid, groupID, false); err != nil {
+				return err
+			}
+		}
+		return am.commitSCIMGroupChanges(ctx, tx, accountID, groupsMap, groupsTouched, &propagated)
+	})
+	if err != nil {
+		return err
+	}
+	if propagated {
+		am.UpdateAccountPeers(ctx, accountID)
 	}
 	return am.DeleteGroup(ctx, accountID, callerID, groupID)
 }
@@ -255,67 +292,161 @@ func (am *DefaultAccountManager) usersInGroup(ctx context.Context, accountID, gr
 	return out, nil
 }
 
-// applyGroupMembers reconciles members from the desired list against
-// previous list. Users in `next` not in `prev` get the group added;
-// users in `prev` not in `next` get it removed. Bulk-friendly — one
-// SaveUser per affected user, no work for unchanged users.
-//
-// Returns changed=true when at least one user's AutoGroups actually
-// moved; the caller can use that to fire a SINGLE NetworkMap fan-out
-// after the whole batch (rather than once per modified user, which
-// would amplify the fan-out cost on big SCIM PUT operations).
-func (am *DefaultAccountManager) applyGroupMembers(ctx context.Context, accountID, groupID string, next, prev []string) (changed bool, err error) {
+// applySCIMGroupMembers reconciles members from the desired list
+// against the previous list inside a single transaction. Users in
+// `next` not in `prev` get the group added; users in `prev` not in
+// `next` get it removed. Loads account settings + groups ONCE for
+// the whole batch (#104 review-3), mutates the in-memory groupsMap
+// across users, and writes SaveGroups + IncrementNetworkSerial
+// exactly once at the end. Returns propagated=true when any
+// User.AutoGroups change actually moved Group.Peers (the signal the
+// caller uses to fire one UpdateAccountPeers per SCIM operation).
+func (am *DefaultAccountManager) applySCIMGroupMembers(ctx context.Context, accountID, groupID string, next, prev []string) (bool, error) {
 	want := stringSet(next)
 	have := stringSet(prev)
-	for uid := range want {
-		if _, ok := have[uid]; ok {
-			continue
-		}
-		moved, err := am.modifyUserAutoGroup(ctx, accountID, uid, groupID, true)
+
+	var propagated bool
+	err := am.Store.ExecuteInTransaction(ctx, func(tx store.Store) error {
+		ctx := ctx
+		settings, err := tx.GetAccountSettings(ctx, store.LockingStrengthShare, accountID)
 		if err != nil {
-			return changed, err
+			return err
 		}
-		changed = changed || moved
-	}
-	for uid := range have {
-		if _, ok := want[uid]; ok {
-			continue
-		}
-		moved, err := am.modifyUserAutoGroup(ctx, accountID, uid, groupID, false)
+		groupsMap, err := loadGroupsMap(ctx, tx, accountID)
 		if err != nil {
-			return changed, err
+			return err
 		}
-		changed = changed || moved
-	}
-	return changed, nil
+		groupsTouched := newGroupSet()
+
+		for uid := range want {
+			if _, ok := have[uid]; ok {
+				continue
+			}
+			if err := am.applyUserAutoGroupInTx(ctx, tx, accountID, settings, groupsMap, groupsTouched, uid, groupID, true); err != nil {
+				return err
+			}
+		}
+		for uid := range have {
+			if _, ok := want[uid]; ok {
+				continue
+			}
+			if err := am.applyUserAutoGroupInTx(ctx, tx, accountID, settings, groupsMap, groupsTouched, uid, groupID, false); err != nil {
+				return err
+			}
+		}
+		return am.commitSCIMGroupChanges(ctx, tx, accountID, groupsMap, groupsTouched, &propagated)
+	})
+	return propagated, err
 }
 
-// modifyUserAutoGroup adds or removes a single group ID from a user's
-// AutoGroups list AND propagates the membership to the affected
-// group's Peers list when GroupsPropagationEnabled. Returns
-// propagated=true when the change is meaningful to peer reach (User
-// row was actually moved, propagation is enabled, and the user has
-// at least one peer); the SCIM entrypoints fire UpdateAccountPeers
-// on propagated=true so the rest of the account's NetworkMap
-// reflects the IdP's new picture in the same Sync cycle.
+// applyUserAutoGroupInTx performs one user's AutoGroups delta inside
+// an existing transaction. Adds/removes the group ID from User.
+// AutoGroups, persists the user when actually changed, and — when
+// GroupsPropagationEnabled — runs updateUserPeersInGroups against
+// the shared groupsMap to keep Group.Peers in sync. The shared
+// groupsTouched set records which group IDs the caller must
+// persist (the caller batches the SaveGroups + IncrementNetwork-
+// Serial at commit time so the whole transaction emits ONE serial
+// bump regardless of how many users moved).
 //
-// Mirrors the dashboard's processUserUpdate path (user.go:697-707):
-// SaveUser, then if GroupsPropagationEnabled, updateUserPeersInGroups
-// + SaveGroups. Closes openzro #104 — without the Group.Peers sync
-// here, NetworkMap recomputation reads stale group membership
-// because the policy resolver iterates Group.Peers, not
-// User.AutoGroups (see GetPeerNetworkMap in account.go).
-func (am *DefaultAccountManager) modifyUserAutoGroup(ctx context.Context, accountID, userID, groupID string, add bool) (propagated bool, err error) {
-	user, err := am.Store.GetUserByUserID(ctx, store.LockingStrengthUpdate, userID)
+// Crucially this routine does NOT short-circuit when User.AutoGroups
+// is already in the desired state — it still runs the Group.Peers
+// reconciliation (idempotent via updateUserPeersInGroups). That
+// closes the partial-write recovery hole #104 review-1 flagged: a
+// retry must repair Group.Peers even when User.AutoGroups was
+// already correct from an earlier half-completed attempt.
+func (am *DefaultAccountManager) applyUserAutoGroupInTx(
+	ctx context.Context,
+	tx store.Store,
+	accountID string,
+	settings *types.Settings,
+	groupsMap map[string]*types.Group,
+	groupsTouched groupSet,
+	userID, groupID string,
+	add bool,
+) error {
+	user, err := tx.GetUserByUserID(ctx, store.LockingStrengthUpdate, userID)
 	if err != nil {
-		return false, err
+		return err
 	}
 	if user.AccountID != accountID {
-		return false, status.NewUserNotFoundError(userID)
+		return status.NewUserNotFoundError(userID)
 	}
+
+	next, userChanged := mutateAutoGroups(user.AutoGroups, groupID, add)
+	if userChanged {
+		user.AutoGroups = next
+		if err := tx.SaveUser(ctx, store.LockingStrengthUpdate, user); err != nil {
+			return err
+		}
+	}
+
+	if !settings.GroupsPropagationEnabled {
+		return nil
+	}
+	userPeers, err := tx.GetUserPeers(ctx, store.LockingStrengthShare, accountID, userID)
+	if err != nil {
+		return err
+	}
+	if len(userPeers) == 0 {
+		return nil
+	}
+
+	var addGroups, removeGroups []string
+	if add {
+		addGroups = []string{groupID}
+	} else {
+		removeGroups = []string{groupID}
+	}
+	updatedGroups, err := updateUserPeersInGroups(groupsMap, userPeers, addGroups, removeGroups)
+	if err != nil {
+		return fmt.Errorf("update user peers in groups: %w", err)
+	}
+	for _, g := range updatedGroups {
+		groupsTouched[g.ID] = struct{}{}
+	}
+	return nil
+}
+
+// commitSCIMGroupChanges writes the groups touched in this
+// transaction and bumps the network serial — both inside the
+// transaction so concurrent SCIM operations can't sneak conflicting
+// NetworkMaps under the same serial (#104 review-2). Sets *propagated
+// to true when at least one group was touched so the caller knows
+// to fire UpdateAccountPeers after the transaction commits.
+func (am *DefaultAccountManager) commitSCIMGroupChanges(
+	ctx context.Context,
+	tx store.Store,
+	accountID string,
+	groupsMap map[string]*types.Group,
+	groupsTouched groupSet,
+	propagated *bool,
+) error {
+	if len(groupsTouched) == 0 {
+		return nil
+	}
+	groupsToSave := make([]*types.Group, 0, len(groupsTouched))
+	for gid := range groupsTouched {
+		groupsToSave = append(groupsToSave, groupsMap[gid])
+	}
+	if err := tx.SaveGroups(ctx, store.LockingStrengthUpdate, accountID, groupsToSave); err != nil {
+		return fmt.Errorf("save groups: %w", err)
+	}
+	if err := tx.IncrementNetworkSerial(ctx, store.LockingStrengthUpdate, accountID); err != nil {
+		return fmt.Errorf("increment network serial: %w", err)
+	}
+	*propagated = true
+	return nil
+}
+
+// mutateAutoGroups builds the new AutoGroups list after adding or
+// removing groupID. Pure (no store access) so it stays trivially
+// testable. Returns changed=false when the input already matched
+// the target state.
+func mutateAutoGroups(curr []string, groupID string, add bool) (next []string, changed bool) {
 	have := false
-	out := make([]string, 0, len(user.AutoGroups))
-	for _, g := range user.AutoGroups {
+	out := make([]string, 0, len(curr))
+	for _, g := range curr {
 		if g == groupID {
 			have = true
 			if add {
@@ -328,67 +459,29 @@ func (am *DefaultAccountManager) modifyUserAutoGroup(ctx context.Context, accoun
 	if add && !have {
 		out = append(out, groupID)
 	}
-	// No-op short-circuit: the AutoGroups slice would be identical
-	// after the rewrite. Avoid the SaveUser write AND signal the
-	// caller that no fan-out is needed.
-	if add == have {
-		return false, nil
-	}
-	user.AutoGroups = out
-	if err := am.Store.SaveUser(ctx, store.LockingStrengthUpdate, user); err != nil {
-		return false, err
-	}
+	return out, add != have
+}
 
-	// Propagate the AutoGroups delta into Group.Peers so the next
-	// NetworkMap recomputation reflects the IdP-driven change.
-	// Mirrors the gate the dashboard user-update uses at
-	// user.go:614 + the propagation block at user.go:697-707 —
-	// settings.GroupsPropagationEnabled is honored verbatim so an
-	// operator who opted out keeps their previous behavior.
-	settings, err := am.Store.GetAccountSettings(ctx, store.LockingStrengthShare, accountID)
+// groupSet is a tiny alias for the set of group IDs touched in a
+// SCIM transaction. Named so the helper signatures stay readable.
+type groupSet map[string]struct{}
+
+func newGroupSet() groupSet { return groupSet{} }
+
+// loadGroupsMap reads every group in the account and returns it
+// keyed by ID. Used once per SCIM transaction so the per-user
+// Group.Peers reconciliation can mutate the same map across all
+// modified users.
+func loadGroupsMap(ctx context.Context, tx store.Store, accountID string) (map[string]*types.Group, error) {
+	groups, err := tx.GetAccountGroups(ctx, store.LockingStrengthShare, accountID)
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-	if !settings.GroupsPropagationEnabled {
-		return false, nil
+	out := make(map[string]*types.Group, len(groups))
+	for _, g := range groups {
+		out[g.ID] = g
 	}
-	userPeers, err := am.Store.GetUserPeers(ctx, store.LockingStrengthShare, accountID, userID)
-	if err != nil {
-		return false, err
-	}
-	if len(userPeers) == 0 {
-		return false, nil
-	}
-	accountGroups, err := am.Store.GetAccountGroups(ctx, store.LockingStrengthShare, accountID)
-	if err != nil {
-		return false, err
-	}
-	groupsMap := make(map[string]*types.Group, len(accountGroups))
-	for _, g := range accountGroups {
-		groupsMap[g.ID] = g
-	}
-	var addGroups, removeGroups []string
-	if add {
-		addGroups = []string{groupID}
-	} else {
-		removeGroups = []string{groupID}
-	}
-	updatedGroups, err := updateUserPeersInGroups(groupsMap, userPeers, addGroups, removeGroups)
-	if err != nil {
-		return false, fmt.Errorf("modify user peers in groups: %w", err)
-	}
-	if len(updatedGroups) == 0 {
-		// SaveUser already flipped User.AutoGroups; the user's peers
-		// were just not in the affected group (e.g. operator removed
-		// a user whose peers had never joined the group's Peers list
-		// for some reason). Nothing for the fan-out to do — same
-		// terminal state.
-		return false, nil
-	}
-	if err := am.Store.SaveGroups(ctx, store.LockingStrengthUpdate, accountID, updatedGroups); err != nil {
-		return false, fmt.Errorf("save groups: %w", err)
-	}
-	return true, nil
+	return out, nil
 }
 
 func (am *DefaultAccountManager) requireSCIMGroupPermission(ctx context.Context, accountID, callerID string, op operations.Operation) error {

--- a/management/server/group_scim.go
+++ b/management/server/group_scim.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/openzro/openzro/management/server/account"
@@ -43,8 +44,17 @@ func (am *DefaultAccountManager) SCIMCreateGroup(ctx context.Context, accountID,
 	if err := am.SaveGroup(ctx, accountID, callerID, group, true); err != nil {
 		return nil, err
 	}
-	if err := am.applyGroupMembers(ctx, accountID, group.ID, memberUserIDs, nil); err != nil {
+	changed, err := am.applyGroupMembers(ctx, accountID, group.ID, memberUserIDs, nil)
+	if err != nil {
 		return nil, err
+	}
+	// Fan out NetworkMap when any membership actually moved (#104).
+	// The SaveGroup above only fans out when the new (empty) group
+	// is already referenced by a policy / route, which is impossible
+	// for a fresh group — so this is the only path that can produce
+	// a fan-out on SCIMCreateGroup with pre-seeded members.
+	if changed {
+		am.UpdateAccountPeers(ctx, accountID)
 	}
 	return group, nil
 }
@@ -74,20 +84,42 @@ func (am *DefaultAccountManager) SCIMReplaceGroup(ctx context.Context, accountID
 	if err != nil {
 		return nil, err
 	}
-	if err := am.applyGroupMembers(ctx, accountID, groupID, memberUserIDs, prev); err != nil {
+	changed, err := am.applyGroupMembers(ctx, accountID, groupID, memberUserIDs, prev)
+	if err != nil {
 		return nil, err
+	}
+	// Fan out NetworkMap when any membership actually moved (#104).
+	// SaveGroup above already fans out for a rename if the group
+	// affects peers, but the membership diff is a separate axis —
+	// a PUT can leave the display name untouched while moving 50
+	// users in or out, and the peer reach must reflect both.
+	if changed {
+		am.UpdateAccountPeers(ctx, accountID)
 	}
 	return group, nil
 }
 
 // SCIMAddGroupMember and SCIMRemoveGroupMember support PATCH ops.
+// Both trigger NetworkMap fan-out when membership actually moves
+// (openzro #104): a user added to / removed from a group via the IdP
+// must have their peers' reach recomputed in the same Sync cycle as
+// any dashboard-side group edit — without it an offboarding via the
+// IdP would silently leave the user's peers reaching the group's
+// destinations until some other account mutation bumped the serial.
 func (am *DefaultAccountManager) SCIMAddGroupMember(ctx context.Context, accountID, callerID, groupID, userID string) error {
 	unlock := am.Store.AcquireWriteLockByUID(ctx, accountID)
 	defer unlock()
 	if err := am.requireSCIMGroupPermission(ctx, accountID, callerID, operations.Update); err != nil {
 		return err
 	}
-	return am.modifyUserAutoGroup(ctx, accountID, userID, groupID, true)
+	changed, err := am.modifyUserAutoGroup(ctx, accountID, userID, groupID, true)
+	if err != nil {
+		return err
+	}
+	if changed {
+		am.UpdateAccountPeers(ctx, accountID)
+	}
+	return nil
 }
 
 func (am *DefaultAccountManager) SCIMRemoveGroupMember(ctx context.Context, accountID, callerID, groupID, userID string) error {
@@ -96,7 +128,14 @@ func (am *DefaultAccountManager) SCIMRemoveGroupMember(ctx context.Context, acco
 	if err := am.requireSCIMGroupPermission(ctx, accountID, callerID, operations.Update); err != nil {
 		return err
 	}
-	return am.modifyUserAutoGroup(ctx, accountID, userID, groupID, false)
+	changed, err := am.modifyUserAutoGroup(ctx, accountID, userID, groupID, false)
+	if err != nil {
+		return err
+	}
+	if changed {
+		am.UpdateAccountPeers(ctx, accountID)
+	}
+	return nil
 }
 
 // SCIMRenameGroup updates only the display name. Used by PATCH
@@ -136,7 +175,12 @@ func (am *DefaultAccountManager) SCIMDeleteGroup(ctx context.Context, accountID,
 		return err
 	}
 	for _, uid := range prev {
-		_ = am.modifyUserAutoGroup(ctx, accountID, uid, groupID, false)
+		// Errors here are intentionally swallowed (same as before
+		// #104): one user's AutoGroups corruption shouldn't block the
+		// rest of the cleanup. The DeleteGroup below already triggers
+		// fan-out when the group affects peers, so the per-user
+		// SaveUser changes will be visible in the next NetworkMap.
+		_, _ = am.modifyUserAutoGroup(ctx, accountID, uid, groupID, false)
 	}
 	return am.DeleteGroup(ctx, accountID, callerID, groupID)
 }
@@ -215,37 +259,59 @@ func (am *DefaultAccountManager) usersInGroup(ctx context.Context, accountID, gr
 // previous list. Users in `next` not in `prev` get the group added;
 // users in `prev` not in `next` get it removed. Bulk-friendly — one
 // SaveUser per affected user, no work for unchanged users.
-func (am *DefaultAccountManager) applyGroupMembers(ctx context.Context, accountID, groupID string, next, prev []string) error {
+//
+// Returns changed=true when at least one user's AutoGroups actually
+// moved; the caller can use that to fire a SINGLE NetworkMap fan-out
+// after the whole batch (rather than once per modified user, which
+// would amplify the fan-out cost on big SCIM PUT operations).
+func (am *DefaultAccountManager) applyGroupMembers(ctx context.Context, accountID, groupID string, next, prev []string) (changed bool, err error) {
 	want := stringSet(next)
 	have := stringSet(prev)
 	for uid := range want {
 		if _, ok := have[uid]; ok {
 			continue
 		}
-		if err := am.modifyUserAutoGroup(ctx, accountID, uid, groupID, true); err != nil {
-			return err
+		moved, err := am.modifyUserAutoGroup(ctx, accountID, uid, groupID, true)
+		if err != nil {
+			return changed, err
 		}
+		changed = changed || moved
 	}
 	for uid := range have {
 		if _, ok := want[uid]; ok {
 			continue
 		}
-		if err := am.modifyUserAutoGroup(ctx, accountID, uid, groupID, false); err != nil {
-			return err
+		moved, err := am.modifyUserAutoGroup(ctx, accountID, uid, groupID, false)
+		if err != nil {
+			return changed, err
 		}
+		changed = changed || moved
 	}
-	return nil
+	return changed, nil
 }
 
 // modifyUserAutoGroup adds or removes a single group ID from a user's
-// AutoGroups list. No-op if already in the desired state.
-func (am *DefaultAccountManager) modifyUserAutoGroup(ctx context.Context, accountID, userID, groupID string, add bool) error {
+// AutoGroups list AND propagates the membership to the affected
+// group's Peers list when GroupsPropagationEnabled. Returns
+// propagated=true when the change is meaningful to peer reach (User
+// row was actually moved, propagation is enabled, and the user has
+// at least one peer); the SCIM entrypoints fire UpdateAccountPeers
+// on propagated=true so the rest of the account's NetworkMap
+// reflects the IdP's new picture in the same Sync cycle.
+//
+// Mirrors the dashboard's processUserUpdate path (user.go:697-707):
+// SaveUser, then if GroupsPropagationEnabled, updateUserPeersInGroups
+// + SaveGroups. Closes openzro #104 — without the Group.Peers sync
+// here, NetworkMap recomputation reads stale group membership
+// because the policy resolver iterates Group.Peers, not
+// User.AutoGroups (see GetPeerNetworkMap in account.go).
+func (am *DefaultAccountManager) modifyUserAutoGroup(ctx context.Context, accountID, userID, groupID string, add bool) (propagated bool, err error) {
 	user, err := am.Store.GetUserByUserID(ctx, store.LockingStrengthUpdate, userID)
 	if err != nil {
-		return err
+		return false, err
 	}
 	if user.AccountID != accountID {
-		return status.NewUserNotFoundError(userID)
+		return false, status.NewUserNotFoundError(userID)
 	}
 	have := false
 	out := make([]string, 0, len(user.AutoGroups))
@@ -262,8 +328,67 @@ func (am *DefaultAccountManager) modifyUserAutoGroup(ctx context.Context, accoun
 	if add && !have {
 		out = append(out, groupID)
 	}
+	// No-op short-circuit: the AutoGroups slice would be identical
+	// after the rewrite. Avoid the SaveUser write AND signal the
+	// caller that no fan-out is needed.
+	if add == have {
+		return false, nil
+	}
 	user.AutoGroups = out
-	return am.Store.SaveUser(ctx, store.LockingStrengthUpdate, user)
+	if err := am.Store.SaveUser(ctx, store.LockingStrengthUpdate, user); err != nil {
+		return false, err
+	}
+
+	// Propagate the AutoGroups delta into Group.Peers so the next
+	// NetworkMap recomputation reflects the IdP-driven change.
+	// Mirrors the gate the dashboard user-update uses at
+	// user.go:614 + the propagation block at user.go:697-707 —
+	// settings.GroupsPropagationEnabled is honored verbatim so an
+	// operator who opted out keeps their previous behavior.
+	settings, err := am.Store.GetAccountSettings(ctx, store.LockingStrengthShare, accountID)
+	if err != nil {
+		return false, err
+	}
+	if !settings.GroupsPropagationEnabled {
+		return false, nil
+	}
+	userPeers, err := am.Store.GetUserPeers(ctx, store.LockingStrengthShare, accountID, userID)
+	if err != nil {
+		return false, err
+	}
+	if len(userPeers) == 0 {
+		return false, nil
+	}
+	accountGroups, err := am.Store.GetAccountGroups(ctx, store.LockingStrengthShare, accountID)
+	if err != nil {
+		return false, err
+	}
+	groupsMap := make(map[string]*types.Group, len(accountGroups))
+	for _, g := range accountGroups {
+		groupsMap[g.ID] = g
+	}
+	var addGroups, removeGroups []string
+	if add {
+		addGroups = []string{groupID}
+	} else {
+		removeGroups = []string{groupID}
+	}
+	updatedGroups, err := updateUserPeersInGroups(groupsMap, userPeers, addGroups, removeGroups)
+	if err != nil {
+		return false, fmt.Errorf("modify user peers in groups: %w", err)
+	}
+	if len(updatedGroups) == 0 {
+		// SaveUser already flipped User.AutoGroups; the user's peers
+		// were just not in the affected group (e.g. operator removed
+		// a user whose peers had never joined the group's Peers list
+		// for some reason). Nothing for the fan-out to do — same
+		// terminal state.
+		return false, nil
+	}
+	if err := am.Store.SaveGroups(ctx, store.LockingStrengthUpdate, accountID, updatedGroups); err != nil {
+		return false, fmt.Errorf("save groups: %w", err)
+	}
+	return true, nil
 }
 
 func (am *DefaultAccountManager) requireSCIMGroupPermission(ctx context.Context, accountID, callerID string, op operations.Operation) error {


### PR DESCRIPTION
## Summary

Closes #104. The SCIM group-membership path (Okta SCIM / Microsoft Entra SCIM / Google Workspace) only persisted \`User.AutoGroups\` and returned — it never reached \`Group.Peers\`, which is the field the policy resolver actually reads at NetworkMap recomputation. A user removed from an integration-issued group via the IdP kept full peer reach for the policies that referenced the group, with no fan-out to recompute. Unbounded offboarding-lag window — typically hours, until any other account mutation bumped the network serial.

## Fix shape

Mirrors the dashboard's \`processUserUpdate\` path ([management/server/user.go:697-707](management/server/user.go#L697-L707)):

1. \`modifyUserAutoGroup\` keeps persisting \`User.AutoGroups\` (existing).
2. When \`settings.GroupsPropagationEnabled\` is on, also load the user's peers + the account's group map, run \`updateUserPeersInGroups\` to diff \`Group.Peers\`, and \`SaveGroups\` any affected groups.
3. Return \`propagated bool\` describing whether the change is meaningful to peer reach (User row moved AND propagation enabled AND user has at least one peer AND a \`Group.Peers\` list actually changed).
4. The five SCIM entrypoints — \`SCIMCreateGroup\`, \`SCIMReplaceGroup\`, \`SCIMAddGroupMember\`, \`SCIMRemoveGroupMember\`, and the batch loop in \`applyGroupMembers\` — fire \`UpdateAccountPeers\` exactly once per SCIM operation when \`propagated\` is true. Batch operations aggregate the bool across the per-user loop so a PUT moving N users produces one fan-out, not N.

## Why mirror the dashboard pattern

Operator behaviour around groups-propagation is configurable via \`settings.GroupsPropagationEnabled\` (default \`true\`). Following the same gate the dashboard uses means an operator who explicitly disabled propagation keeps their current behaviour on the SCIM path too — no surprise behaviour change. SCIM-with-propagation-on is the common case and was the documented expectation that turned out to be unmet.

## Regression test

\`TestSCIMRemoveGroupMember_PropagatesToGroupPeers\` in \`account_test.go\`:

- Pre-state: peer in \`Group.Peers\`, user in \`AutoGroups\`, one peer linked to the user.
- Action: \`SCIMRemoveGroupMember(userID, groupID)\`.
- Asserts: \`User.AutoGroups\` drops the group (existing behaviour) AND \`Group.Peers\` drops the peer (new behaviour from this fix).

Pre-fix the second assertion fails because \`Group.Peers\` stayed \`[peer1]\` forever after the SCIM call.

## Discovered via

External review of openzro/docs#8 (the per-IdP group-sync docs PR). The original docs said \"membership removal drops peers immediately in the next NetworkMap fan-out\" — the reviewer correctly observed the code didn't actually trigger that fan-out. \"Issue first, docs to match\" landed last session as commit-ready-but-honest docs + issue #104 tracking the code half.

## Test plan

- [x] \`TestSCIMRemoveGroupMember_PropagatesToGroupPeers\` passes \`-race\`
- [x] Existing SCIM handler tests (\`./management/server/http/handlers/scim/...\`) + group / user tests on \`management/server\` pass \`-race\`
- [x] \`make fmt.check\` clean on touched files
- [x] \`golangci-lint run\` clean on touched packages
- [ ] CI: confirm the \`-race\` flake in \`TestGroupAccountPeersUpdate\` (pre-existing — same shape reproduces on plain main with \`-count=5\`) doesn't get blamed on this PR

Closes #104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)