### PR TITLE
feat(dashboard/dns-zones): Phase 4 — operator UI for Custom DNS Zones (#108)

### DIFF
--- a/dashboard/src/app/(v2-dashboard)/dns/zone/layout.tsx
+++ b/dashboard/src/app/(v2-dashboard)/dns/zone/layout.tsx
@@ -1,0 +1,8 @@
+import { globalMetaTitle } from "@utils/meta";
+import type { Metadata } from "next";
+import BlankLayout from "@/layouts/BlankLayout";
+
+export const metadata: Metadata = {
+  title: `Zone - DNS - ${globalMetaTitle}`,
+};
+export default BlankLayout;

--- a/dashboard/src/app/(v2-dashboard)/dns/zone/page.tsx
+++ b/dashboard/src/app/(v2-dashboard)/dns/zone/page.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import FullScreenLoading from "@components/ui/FullScreenLoading";
+import { PageNotFound } from "@components/ui/PageNotFound";
+import { RestrictedAccess } from "@components/ui/RestrictedAccess";
+import useRedirect from "@hooks/useRedirect";
+import useFetchApi from "@utils/api";
+import { useSearchParams } from "next/navigation";
+import React from "react";
+import { usePermissions } from "@/contexts/PermissionsProvider";
+import { DNSZone } from "@/interfaces/DNSZone";
+import DNSZoneDetailPage from "@/modules/dns-zones/DNSZoneDetailPage";
+
+export default function DNSZonePage() {
+  const params = useSearchParams();
+  const zoneId = params.get("id");
+  const { permission, isRestricted } = usePermissions();
+
+  // Guard the fetch against the no-id case — useRedirect bounces us
+  // back to /dns/zones below, but until that runs we don't want to
+  // hit `/dns/zones` and end up with the wrong-shape response in the
+  // SWR cache.
+  const {
+    data: zone,
+    isLoading,
+    error,
+  } = useFetchApi<DNSZone>(
+    zoneId ? `/dns/zones/${zoneId}` : "",
+    false,
+    true,
+    !!zoneId,
+  );
+
+  useRedirect("/dns/zones", false, !zoneId || isRestricted);
+
+  if (!permission.dns_zones.read) {
+    return (
+      <div className="space-y-6 p-8">
+        <RestrictedAccess page={"DNS Zone"} />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <PageNotFound
+        title={error?.message}
+        description={
+          "The zone you are attempting to access cannot be found. It may have been deleted, or you may not have permission to view it. Please verify the URL or return to the list."
+        }
+      />
+    );
+  }
+
+  return zone && !isLoading ? (
+    <DNSZoneDetailPage zone={zone} />
+  ) : (
+    <FullScreenLoading />
+  );
+}

--- a/dashboard/src/app/(v2-dashboard)/dns/zones/layout.tsx
+++ b/dashboard/src/app/(v2-dashboard)/dns/zones/layout.tsx
@@ -1,0 +1,8 @@
+import { globalMetaTitle } from "@utils/meta";
+import type { Metadata } from "next";
+import BlankLayout from "@/layouts/BlankLayout";
+
+export const metadata: Metadata = {
+  title: `DNS Zones - DNS - ${globalMetaTitle}`,
+};
+export default BlankLayout;

--- a/dashboard/src/app/(v2-dashboard)/dns/zones/page.tsx
+++ b/dashboard/src/app/(v2-dashboard)/dns/zones/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { RestrictedAccess } from "@components/ui/RestrictedAccess";
+import useFetchApi from "@utils/api";
+import React from "react";
+import { usePermissions } from "@/contexts/PermissionsProvider";
+import { DNSZone } from "@/interfaces/DNSZone";
+import DNSZonesTable from "@/modules/dns-zones/DNSZonesTable";
+
+export default function DNSZones() {
+  const { permission } = usePermissions();
+  const { data: zones, isLoading } = useFetchApi<DNSZone[]>("/dns/zones");
+
+  return (
+    <RestrictedAccess hasAccess={permission.dns_zones.read}>
+      <DNSZonesTable zones={zones} isLoading={isLoading} />
+    </RestrictedAccess>
+  );
+}

--- a/dashboard/src/interfaces/DNSZone.ts
+++ b/dashboard/src/interfaces/DNSZone.ts
@@ -1,0 +1,80 @@
+// Custom DNS Zones — dashboard-side TypeScript mirror of the OpenAPI
+// schema shipped in issue #108 Phase 1.
+//
+// The dashboard does not auto-generate types from the management
+// OpenAPI; this file mirrors the schema by hand, same as
+// interfaces/Nameserver.ts. If drift becomes painful we can adopt
+// codegen later — for now the API surface is small (10 endpoints,
+// 2 main shapes + 2 request bodies).
+
+export type DNSRecordType = "A" | "AAAA" | "CNAME";
+
+// DNSRecord is a single resource record under a zone. v1 supports
+// A / AAAA / CNAME only; the CNAME ↔ A/AAAA mutex is enforced
+// server-side per ADR-0022 D5.
+export interface DNSRecord {
+  id: string;
+  name: string;
+  type: DNSRecordType;
+  content: string;
+  // TTL in seconds. Default 300 server-side when omitted. OpenAPI
+  // declares `minimum: 1` (see Phase 1 review #4 — TTL=0 would bypass
+  // resolver caches and defeat the authoritative-zone purpose).
+  ttl?: number;
+}
+
+// DNSRecordRequest is the create/update body for a record. Same
+// shape as DNSRecord minus the server-assigned id.
+export interface DNSRecordRequest {
+  name: string;
+  type: DNSRecordType;
+  content: string;
+  ttl?: number;
+}
+
+// DNSZone is an operator-managed authoritative DNS namespace
+// distributed to peers in selected groups. Resolution on the agent
+// is authoritative for the zone (NXDOMAIN on miss within the zone
+// — see ADR-0022 D1). The agent does NOT fall through to upstream
+// nameservers for records the zone could carry; this is the
+// "shadow domain" guarantee.
+export interface DNSZone {
+  id: string;
+  // Human-readable name (1-255 chars).
+  name: string;
+  // FQDN apex of the zone (e.g. "internal.example"). Immutable
+  // after creation (ADR-0022 D5). The dashboard renders the domain
+  // input disabled on edit.
+  domain: string;
+  // When false, the zone is NOT distributed to peers — even if it
+  // has records. Useful for "pause without deleting" workflows.
+  // Default true on create.
+  enabled?: boolean;
+  // When true, the agent appends the zone's Domain to the OS DNS
+  // search list (so a bare-name lookup like `db` resolves as
+  // `db.<Domain>`). Default false for user-managed zones; the
+  // synthetic peer zone has this true unconditionally (set
+  // server-side, not exposed in this API).
+  enable_search_domain?: boolean;
+  // Peer group IDs that receive this zone. ≥1 required at
+  // create AND update; the server enforces.
+  distribution_groups: string[];
+  // Records currently registered under the zone. Populated on
+  // GET responses by the server's preload chain. The dashboard
+  // also fetches records via the dedicated records endpoints
+  // when the modal is open; this slice is what comes back on the
+  // list / get path.
+  records: DNSRecord[];
+}
+
+// DNSZoneRequest is the create/update body. Excludes id and
+// records (records are managed via the dedicated /records
+// endpoints, not bundled into the zone PUT body — the server
+// preserves existing records on PUT regardless).
+export interface DNSZoneRequest {
+  name: string;
+  domain: string;
+  enabled?: boolean;
+  enable_search_domain?: boolean;
+  distribution_groups: string[];
+}

--- a/dashboard/src/interfaces/Permission.ts
+++ b/dashboard/src/interfaces/Permission.ts
@@ -12,6 +12,7 @@ export interface Permissions {
     networks: Permission;
     routes: Permission;
     nameservers: Permission;
+    dns_zones: Permission;
     dns: Permission;
 
     users: Permission;

--- a/dashboard/src/layouts/V2DashboardLayout.tsx
+++ b/dashboard/src/layouts/V2DashboardLayout.tsx
@@ -331,6 +331,8 @@ function breadcrumbForPath(path: string | null): OzBreadcrumbSegment[] {
   if (
     path === "/dns" ||
     path === "/dns/nameservers" ||
+    path === "/dns/zones" ||
+    path === "/dns/zone" ||
     path === "/dns/settings"
   ) {
     return [{ label: "Workspace" }, { label: "DNS" }];

--- a/dashboard/src/modules/dns-zones/DNSRecordsSection.tsx
+++ b/dashboard/src/modules/dns-zones/DNSRecordsSection.tsx
@@ -1,0 +1,491 @@
+"use client";
+
+import Badge from "@components/Badge";
+import { notify } from "@components/Notification";
+import { useApiCall } from "@utils/api";
+import cidr from "ip-cidr";
+import {
+  AlertTriangle,
+  Check,
+  PencilLine,
+  PlusCircle,
+  Trash2,
+  X,
+} from "lucide-react";
+import React, { useMemo, useState } from "react";
+import { useSWRConfig } from "swr";
+import OzButton from "@/components/v2/OzButton";
+import OzInput from "@/components/v2/OzInput";
+import { useDialog } from "@/contexts/DialogProvider";
+import { usePermissions } from "@/contexts/PermissionsProvider";
+import {
+  DNSRecord,
+  DNSRecordRequest,
+  DNSRecordType,
+  DNSZone,
+} from "@/interfaces/DNSZone";
+
+// Cloudflare-style record management for a single zone. Operators
+// type only the leaf label (e.g. `www`) and the UI shows the zone
+// suffix (`.zona.internal`) as a fixed adornment. `@` resolves to
+// the apex (the zone domain itself) — Cloudflare convention. Submit
+// always sends the full FQDN to the backend.
+
+const FQDN_RE =
+  /^(?=.{1,253}$)(?:(?!-)[A-Za-z0-9-]{1,63}(?<!-)\.)+[A-Za-z]{2,63}$/;
+const LEAF_LABEL_RE = /^(?=.{1,63}$)(?!-)[A-Za-z0-9-](?:[A-Za-z0-9-]*[A-Za-z0-9])?(?:\.(?!-)[A-Za-z0-9-](?:[A-Za-z0-9-]*[A-Za-z0-9])?)*$/;
+const IPV4_RE =
+  /^(25[0-5]|2[0-4][0-9]|[01]?[0-9]{1,2})(\.(25[0-5]|2[0-4][0-9]|[01]?[0-9]{1,2})){3}$/;
+
+// Strip the zone-domain suffix (and a trailing dot) from a full FQDN
+// so the editor can pre-populate the Name input with just the leaf
+// portion. Apex records (name === zone.domain) render as `@`.
+function leafFromFqdn(fqdn: string, zoneDomain: string): string {
+  if (!fqdn) return "";
+  if (fqdn === zoneDomain) return "@";
+  const suffix = "." + zoneDomain;
+  if (fqdn.endsWith(suffix)) return fqdn.slice(0, -suffix.length);
+  return fqdn;
+}
+
+// Inverse: combine the leaf label the operator typed with the zone
+// domain. `@` is the Cloudflare apex shorthand → return the bare zone.
+function fqdnFromLeaf(leaf: string, zoneDomain: string): string {
+  const trimmed = leaf.trim();
+  if (trimmed === "@" || trimmed === "") return zoneDomain;
+  return `${trimmed}.${zoneDomain}`;
+}
+
+function validateLeaf(leaf: string): string {
+  const trimmed = leaf.trim();
+  if (!trimmed) return "Name is required (use @ for the zone apex)";
+  if (trimmed === "@") return "";
+  if (!LEAF_LABEL_RE.test(trimmed)) {
+    return "Use letters, digits, hyphens, and dots only";
+  }
+  return "";
+}
+
+function validateContent(type: DNSRecordType, content: string): string {
+  if (!content) return "Content is required";
+  switch (type) {
+    case "A":
+      if (!IPV4_RE.test(content)) return "Enter a valid IPv4 address";
+      return "";
+    case "AAAA":
+      if (!cidr.isValidAddress(content) || !content.includes(":")) {
+        return "Enter a valid IPv6 address";
+      }
+      return "";
+    case "CNAME":
+      if (!FQDN_RE.test(content)) return "Enter a valid FQDN";
+      return "";
+  }
+  return "";
+}
+
+function validateTTL(ttl: string): string {
+  if (ttl === "") return "";
+  const n = Number(ttl);
+  if (!Number.isFinite(n) || n < 1) return "TTL must be ≥ 1";
+  return "";
+}
+
+type Props = {
+  zone: DNSZone;
+};
+
+export default function DNSRecordsSection({ zone }: Props) {
+  const { permission } = usePermissions();
+  const { confirm } = useDialog();
+  const { mutate } = useSWRConfig();
+  const recordsApi = useApiCall<DNSRecord>(
+    `/dns/zones/${zone.id}/records`,
+    true,
+  );
+
+  const sorted = useMemo(() => {
+    const records = zone.records ?? [];
+    return [...records].sort((a, b) => {
+      if (a.name === b.name) return a.type.localeCompare(b.type);
+      return a.name.localeCompare(b.name);
+    });
+  }, [zone.records]);
+
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [adding, setAdding] = useState(false);
+
+  const refreshZone = async () => {
+    await mutate(`/dns/zones/${zone.id}`);
+    await mutate("/dns/zones");
+  };
+
+  const remove = async (rec: DNSRecord) => {
+    const choice = await confirm({
+      title: `Delete record ${rec.name}?`,
+      description:
+        "Are you sure you want to remove this record? Peers will lose this entry on the next sync.",
+      confirmText: "Delete",
+      cancelText: "Cancel",
+      type: "danger",
+    });
+    if (!choice) return;
+    notify({
+      title: `Record ${rec.name}`,
+      description: "The record was successfully removed.",
+      loadingMessage: "Deleting the record...",
+      promise: recordsApi.del("", `/${rec.id}`).then(refreshZone),
+    });
+  };
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex items-center justify-between gap-3 px-[18px] py-3.5 border-b border-oz2-border-soft">
+        <div>
+          <h2 className="text-[14px] font-semibold text-oz2-text">
+            DNS Records
+          </h2>
+          <p className="mt-0.5 text-[12px] text-oz2-text-muted">
+            A / AAAA / CNAME records under{" "}
+            <code className="font-mono text-oz2-text-2">{zone.domain}</code>.
+            Use <code className="font-mono text-oz2-text-2">@</code> as the
+            name for the zone apex.
+          </p>
+        </div>
+        <OzButton
+          variant="primary"
+          type="button"
+          disabled={
+            !permission.dns_zones.create || adding || editingId !== null
+          }
+          onClick={() => setAdding(true)}
+        >
+          <PlusCircle size={14} />
+          Add Record
+        </OzButton>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full table-fixed text-[13px]">
+          <colgroup>
+            <col className="w-[80px]" />
+            <col className="w-[30%]" />
+            <col />
+            <col className="w-[100px]" />
+            <col className="w-[100px]" />
+          </colgroup>
+          <thead>
+            <tr className="border-b border-oz2-border-soft bg-oz2-bg-sunken">
+              <ThCell>Type</ThCell>
+              <ThCell>Name</ThCell>
+              <ThCell>Content</ThCell>
+              <ThCell>TTL</ThCell>
+              <ThCell className="text-right pr-4">Actions</ThCell>
+            </tr>
+          </thead>
+          <tbody>
+            {adding && (
+              <RecordEditorRow
+                zone={zone}
+                onCancel={() => setAdding(false)}
+                onSubmit={async (body) => {
+                  await notify({
+                    title: `Record ${body.name}`,
+                    description: "Record created.",
+                    loadingMessage: "Creating record...",
+                    promise: recordsApi.post(body).then(refreshZone),
+                  });
+                  setAdding(false);
+                }}
+              />
+            )}
+
+            {sorted.map((rec) =>
+              editingId === rec.id ? (
+                <RecordEditorRow
+                  key={rec.id}
+                  zone={zone}
+                  initial={rec}
+                  onCancel={() => setEditingId(null)}
+                  onSubmit={async (body) => {
+                    await notify({
+                      title: `Record ${body.name}`,
+                      description: "Record updated.",
+                      loadingMessage: "Updating record...",
+                      promise: recordsApi
+                        .put(body, `/${rec.id}`)
+                        .then(refreshZone),
+                    });
+                    setEditingId(null);
+                  }}
+                />
+              ) : (
+                <RecordRow
+                  key={rec.id}
+                  zone={zone}
+                  rec={rec}
+                  canEdit={
+                    permission.dns_zones.update && !adding && !editingId
+                  }
+                  canDelete={permission.dns_zones.delete && !adding && !editingId}
+                  onEdit={() => setEditingId(rec.id)}
+                  onDelete={() => remove(rec)}
+                />
+              ),
+            )}
+
+            {sorted.length === 0 && !adding && (
+              <tr>
+                <td colSpan={5} className="px-[18px] py-10">
+                  <div className="flex items-start gap-3 rounded-oz2-input border border-oz2-warn/40 bg-oz2-warn-bg/40 px-3 py-2.5 text-[12.5px] text-oz2-warn">
+                    <AlertTriangle size={14} className="mt-[2px] shrink-0" />
+                    <p>
+                      <span className="font-medium">No records yet.</span>{" "}
+                      Peers in distribution groups won&apos;t receive this
+                      zone until you add at least one record.
+                    </p>
+                  </div>
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function ThCell({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <th
+      scope="col"
+      className={
+        "px-4 py-2.5 text-left font-mono text-[11px] font-semibold uppercase tracking-widest text-oz2-text-muted " +
+        (className ?? "")
+      }
+    >
+      {children}
+    </th>
+  );
+}
+
+function RecordRow({
+  zone,
+  rec,
+  canEdit,
+  canDelete,
+  onEdit,
+  onDelete,
+}: {
+  zone: DNSZone;
+  rec: DNSRecord;
+  canEdit: boolean;
+  canDelete: boolean;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const leaf = leafFromFqdn(rec.name, zone.domain);
+  return (
+    <tr className="border-b border-oz2-border-soft last:border-b-0">
+      <td className="px-4 py-2.5">
+        <Badge variant={"gray"} className={"font-mono text-[11px]"}>
+          {rec.type}
+        </Badge>
+      </td>
+      <td className="px-4 py-2.5 font-mono text-[12.5px] text-oz2-text">
+        {leaf === "@" ? (
+          <span className="text-oz2-acc-text">@</span>
+        ) : (
+          <>
+            <span>{leaf}</span>
+            <span className="text-oz2-text-faint">.{zone.domain}</span>
+          </>
+        )}
+      </td>
+      <td className="px-4 py-2.5 font-mono text-[12.5px] text-oz2-text-2 truncate">
+        {rec.content}
+      </td>
+      <td className="px-4 py-2.5 font-mono text-[12px] text-oz2-text-faint">
+        {rec.ttl ?? 300}
+      </td>
+      <td className="px-4 py-2.5">
+        <div className="flex justify-end gap-1.5">
+          <button
+            type="button"
+            aria-label="Edit record"
+            disabled={!canEdit}
+            onClick={onEdit}
+            className="grid h-7 w-7 place-items-center rounded-oz2-input border border-oz2-border bg-oz2-surface text-oz2-text-2 hover:bg-oz2-hover hover:border-oz2-border-strong disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <PencilLine size={13} />
+          </button>
+          <button
+            type="button"
+            aria-label="Delete record"
+            disabled={!canDelete}
+            onClick={onDelete}
+            className="grid h-7 w-7 place-items-center rounded-oz2-input border border-oz2-border bg-oz2-surface text-oz2-text-2 hover:bg-oz2-hover hover:border-oz2-border-strong disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Trash2 size={13} />
+          </button>
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+function RecordEditorRow({
+  zone,
+  initial,
+  onSubmit,
+  onCancel,
+}: {
+  zone: DNSZone;
+  initial?: DNSRecord;
+  onSubmit: (body: DNSRecordRequest) => Promise<void>;
+  onCancel: () => void;
+}) {
+  const [type, setType] = useState<DNSRecordType>(initial?.type ?? "A");
+  const [leaf, setLeaf] = useState<string>(
+    initial ? leafFromFqdn(initial.name, zone.domain) : "",
+  );
+  const [content, setContent] = useState(initial?.content ?? "");
+  const [ttl, setTtl] = useState<string>(
+    initial?.ttl !== undefined ? String(initial.ttl) : "",
+  );
+
+  const fullName = useMemo(() => fqdnFromLeaf(leaf, zone.domain), [
+    leaf,
+    zone.domain,
+  ]);
+
+  // Same-name conflict check for the CNAME ↔ A/AAAA mutex hint.
+  // Compare against the FQDN (leaf + suffix) because that's what
+  // the backend stores.
+  const conflict = useMemo(() => {
+    const same = (zone.records ?? []).filter(
+      (r) => r.id !== initial?.id && r.name === fullName,
+    );
+    if (same.length === 0) return "";
+    if (type === "CNAME" && same.some((r) => r.type !== "CNAME")) {
+      return "An A/AAAA record already exists for this name — CNAME is not allowed.";
+    }
+    if (type !== "CNAME" && same.some((r) => r.type === "CNAME")) {
+      return "A CNAME already exists for this name — A/AAAA is not allowed.";
+    }
+    return "";
+  }, [zone.records, fullName, type, initial?.id]);
+
+  const leafError = useMemo(() => validateLeaf(leaf), [leaf]);
+  const contentError = useMemo(
+    () => (content ? validateContent(type, content) : ""),
+    [type, content],
+  );
+  const ttlError = useMemo(() => validateTTL(ttl), [ttl]);
+
+  const canSubmit =
+    !leafError && !contentError && !ttlError && !conflict && !!content;
+
+  const submit = async () => {
+    const body: DNSRecordRequest = {
+      name: fullName,
+      type,
+      content,
+      ttl: ttl === "" ? undefined : Number(ttl),
+    };
+    await onSubmit(body);
+  };
+
+  const suffixNode = (
+    <span className="ml-1 font-mono text-[11.5px] text-oz2-text-faint">
+      .{zone.domain}
+    </span>
+  );
+
+  return (
+    <>
+      <tr className="border-b border-oz2-border-soft bg-oz2-acc-soft/30">
+        <td className="px-4 py-3 align-top">
+          <select
+            value={type}
+            onChange={(e) => setType(e.target.value as DNSRecordType)}
+            className="h-[34px] w-full rounded-oz2-input border border-oz2-border bg-oz2-surface px-2 font-mono text-[12.5px]"
+          >
+            <option value="A">A</option>
+            <option value="AAAA">AAAA</option>
+            <option value="CNAME">CNAME</option>
+          </select>
+        </td>
+        <td className="px-4 py-3 align-top">
+          <OzInput
+            placeholder={"www  (or @ for apex)"}
+            mono
+            value={leaf}
+            onChange={(e) => setLeaf(e.target.value)}
+            error={leaf ? leafError : ""}
+            suffix={leaf && leaf.trim() !== "@" ? suffixNode : undefined}
+            autoFocus
+          />
+        </td>
+        <td className="px-4 py-3 align-top">
+          <OzInput
+            placeholder={
+              type === "CNAME"
+                ? "target.example.com"
+                : type === "A"
+                  ? "10.0.0.5"
+                  : "fd00::1"
+            }
+            mono
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            error={content ? contentError : ""}
+          />
+        </td>
+        <td className="px-4 py-3 align-top">
+          <OzInput
+            placeholder={"300"}
+            type={"number"}
+            value={ttl}
+            onChange={(e) => setTtl(e.target.value)}
+            error={ttlError}
+          />
+        </td>
+        <td className="px-4 py-3 align-top">
+          <div className="flex justify-end gap-1.5">
+            <button
+              type="button"
+              aria-label="Save record"
+              disabled={!canSubmit}
+              onClick={submit}
+              className="grid h-[34px] w-[34px] shrink-0 place-items-center rounded-oz2-input border border-oz2-acc/40 bg-oz2-acc text-white hover:bg-oz2-acc-hover disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <Check size={15} />
+            </button>
+            <button
+              type="button"
+              aria-label="Cancel"
+              onClick={onCancel}
+              className="grid h-[34px] w-[34px] shrink-0 place-items-center rounded-oz2-input border border-oz2-border bg-oz2-surface text-oz2-text-2 hover:bg-oz2-hover hover:border-oz2-border-strong"
+            >
+              <X size={15} />
+            </button>
+          </div>
+        </td>
+      </tr>
+      {conflict && (
+        <tr className="border-b border-oz2-border-soft bg-oz2-acc-soft/30">
+          <td colSpan={5} className="px-4 pb-3">
+            <p className="text-[11.5px] text-oz2-err">{conflict}</p>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}

--- a/dashboard/src/modules/dns-zones/DNSZoneDetailPage.tsx
+++ b/dashboard/src/modules/dns-zones/DNSZoneDetailPage.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { notify } from "@components/Notification";
+import { TooltipProvider } from "@components/Tooltip";
+import { useApiCall } from "@utils/api";
+import {
+  ArrowLeft,
+  ExternalLinkIcon,
+  Layers,
+  PencilLine,
+  Power,
+  Trash2,
+} from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import React, { useState } from "react";
+import { useSWRConfig } from "swr";
+import OzButton from "@/components/v2/OzButton";
+import OzCard from "@/components/v2/OzCard";
+import { useDialog } from "@/contexts/DialogProvider";
+import { usePermissions } from "@/contexts/PermissionsProvider";
+import { DNSZone } from "@/interfaces/DNSZone";
+import { useV2TopbarRight } from "@/layouts/V2DashboardLayout";
+import DNSRecordsSection from "@/modules/dns-zones/DNSRecordsSection";
+import DNSZoneModal from "@/modules/dns-zones/DNSZoneModal";
+
+type Props = {
+  zone: DNSZone;
+};
+
+export default function DNSZoneDetailPage({ zone }: Props) {
+  const router = useRouter();
+  const { confirm } = useDialog();
+  const { mutate } = useSWRConfig();
+  const { permission } = usePermissions();
+  const zoneRequest = useApiCall<DNSZone>("/dns/zones");
+
+  const [editOpen, setEditOpen] = useState(false);
+
+  const enabled = zone.enabled ?? true;
+  const recordCount = zone.records?.length ?? 0;
+  const groupCount = zone.distribution_groups?.length ?? 0;
+
+  const handleDelete = async () => {
+    const choice = await confirm({
+      title: `Delete '${zone.name}'?`,
+      description:
+        "Are you sure you want to delete this zone? Records under this zone will be removed and peers will lose authoritative resolution for the domain. This action cannot be undone.",
+      confirmText: "Delete",
+      cancelText: "Cancel",
+      type: "danger",
+    });
+    if (!choice) return;
+    notify({
+      title: "Zone " + zone.name,
+      description: "The zone was successfully removed.",
+      loadingMessage: "Deleting the zone...",
+      promise: zoneRequest.del("", `/${zone.id}`).then(() => {
+        mutate("/dns/zones");
+        router.push("/dns/zones");
+      }),
+    });
+  };
+
+  useV2TopbarRight(
+    <div className="flex items-center gap-2">
+      <OzButton
+        variant="default"
+        type="button"
+        onClick={() => router.push("/dns/zones")}
+      >
+        <ArrowLeft size={14} />
+        Back to zones
+      </OzButton>
+      <OzButton
+        variant="default"
+        type="button"
+        disabled={!permission.dns_zones.update}
+        onClick={() => setEditOpen(true)}
+      >
+        <PencilLine size={14} />
+        Edit zone
+      </OzButton>
+      <OzButton
+        variant="default"
+        type="button"
+        disabled={!permission.dns_zones.delete}
+        onClick={handleDelete}
+      >
+        <Trash2 size={14} className="text-oz2-err" />
+        Delete
+      </OzButton>
+    </div>,
+  );
+
+  return (
+    <TooltipProvider delayDuration={250} skipDelayDuration={100}>
+      {editOpen && (
+        <DNSZoneModal
+          preset={zone}
+          open={editOpen}
+          onOpenChange={setEditOpen}
+        />
+      )}
+
+      <div className="px-8 pb-5 pt-8">
+        <Link
+          href="/dns/zones"
+          className="inline-flex items-center gap-1 text-[12px] text-oz2-text-faint transition-colors hover:text-oz2-text-2"
+        >
+          <ExternalLinkIcon size={11} className="rotate-180" />
+          DNS Zones
+        </Link>
+
+        <div className="mt-3 flex max-w-6xl flex-wrap items-start justify-between gap-4">
+          <div className="flex min-w-0 items-start gap-4">
+            <div
+              aria-hidden
+              className="relative grid h-12 w-12 shrink-0 place-items-center rounded-[12px] border border-oz2-border-soft bg-oz2-bg-sunken text-oz2-text-2"
+            >
+              <Layers size={20} />
+              <span
+                className={
+                  "absolute -bottom-1 -right-1 h-3 w-3 rounded-full border-2 border-oz2-bg " +
+                  (enabled ? "bg-oz2-ok" : "bg-oz2-text-faint")
+                }
+              />
+            </div>
+            <div className="min-w-0">
+              <h1 className="text-[24px] font-semibold tracking-tight text-oz2-text">
+                {zone.name}
+              </h1>
+              <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-[12.5px] text-oz2-text-muted">
+                <span className="font-mono text-oz2-text-2">{zone.domain}</span>
+                <span className="text-oz2-text-faint">·</span>
+                <span className="inline-flex items-center gap-1">
+                  <Power size={11} />
+                  {enabled ? "Enabled" : "Disabled"}
+                </span>
+                <span className="text-oz2-text-faint">·</span>
+                <span>
+                  {groupCount} distribution group
+                  {groupCount === 1 ? "" : "s"}
+                </span>
+                <span className="text-oz2-text-faint">·</span>
+                <span>
+                  {recordCount} record{recordCount === 1 ? "" : "s"}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="px-8 pb-12">
+        <OzCard flush className="max-w-6xl">
+          <DNSRecordsSection zone={zone} />
+        </OzCard>
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/dashboard/src/modules/dns-zones/DNSZoneModal.tsx
+++ b/dashboard/src/modules/dns-zones/DNSZoneModal.tsx
@@ -1,0 +1,375 @@
+"use client";
+
+import FancyToggleSwitch from "@components/FancyToggleSwitch";
+import {
+  Modal,
+  ModalClose,
+  ModalContent,
+  ModalFooter,
+} from "@components/modal/Modal";
+import ModalHeader from "@components/modal/ModalHeader";
+import { notify } from "@components/Notification";
+import { PeerGroupSelector } from "@components/PeerGroupSelector";
+import { useApiCall } from "@utils/api";
+import {
+  ExternalLinkIcon,
+  Layers,
+  PlusCircle,
+  Power,
+  Scan,
+  Users,
+} from "lucide-react";
+import React, { useMemo, useState } from "react";
+import { useSWRConfig } from "swr";
+import DNSIcon from "@/assets/icons/DNSIcon";
+import OzButton from "@/components/v2/OzButton";
+import OzInput from "@/components/v2/OzInput";
+import OzLabel, { OzHelpText } from "@/components/v2/OzLabel";
+import {
+  OzTabs as Tabs,
+  OzTabsContent as TabsContent,
+  OzTabsList as TabsList,
+  OzTabsTrigger as TabsTrigger,
+} from "@/components/v2/OzTabs";
+import { usePermissions } from "@/contexts/PermissionsProvider";
+import { DNSZone, DNSZoneRequest } from "@/interfaces/DNSZone";
+import useGroupHelper from "@/modules/groups/useGroupHelper";
+
+type Props = {
+  preset?: DNSZone;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+export default function DNSZoneModal({
+  preset,
+  open,
+  onOpenChange,
+}: Readonly<Props>) {
+  return (
+    <Modal open={open} onOpenChange={onOpenChange} key={open ? 1 : 0}>
+      {open && (
+        <DNSZoneModalContent
+          onSuccess={() => onOpenChange(false)}
+          preset={preset}
+        />
+      )}
+    </Modal>
+  );
+}
+
+type ModalContentProps = {
+  onSuccess?: () => void;
+  preset?: DNSZone;
+};
+
+const FQDN_RE = /^(?=.{1,253}$)(?:(?!-)[A-Za-z0-9-]{1,63}(?<!-)\.)+[A-Za-z]{2,63}$/;
+
+function validateDomain(domain: string): string {
+  if (!domain) return "Domain is required";
+  if (!FQDN_RE.test(domain)) {
+    return "Enter a valid FQDN, e.g. internal.example";
+  }
+  return "";
+}
+
+export function DNSZoneModalContent({
+  onSuccess,
+  preset,
+}: Readonly<ModalContentProps>) {
+  const { permission } = usePermissions();
+  const zoneRequest = useApiCall<DNSZone>("/dns/zones", true);
+  const { mutate } = useSWRConfig();
+
+  const isUpdate = useMemo(() => !!(preset && preset.id), [preset]);
+
+  const [name, setName] = useState(preset?.name || "");
+  const [domain, setDomain] = useState(preset?.domain || "");
+  const [enabled, setEnabled] = useState<boolean>(
+    typeof preset?.enabled === "boolean" ? preset.enabled : true,
+  );
+  const [searchDomain, setSearchDomain] = useState<boolean>(
+    typeof preset?.enable_search_domain === "boolean"
+      ? preset.enable_search_domain
+      : false,
+  );
+  const [groups, setGroups, { save: saveGroups }] = useGroupHelper({
+    initial: preset?.distribution_groups || [],
+  });
+
+  const [tab, setTab] = useState<"zone" | "distribution">("zone");
+
+  const nameError = useMemo(() => {
+    if (!name) return "";
+    if (name.length > 255) return "Name should be less than 255 characters";
+    return "";
+  }, [name]);
+
+  const domainError = useMemo(() => validateDomain(domain), [domain]);
+
+  const canAction = useMemo(() => {
+    return isUpdate
+      ? permission.dns_zones.update
+      : permission.dns_zones.create;
+  }, [isUpdate, permission]);
+
+  // Zone tab → Distribution tab gate. Mirrors the NameserverModal
+  // step-flow: the operator can't advance until the zone metadata is
+  // syntactically valid.
+  const canContinueToDistribution = useMemo(() => {
+    return !!name && !nameError && !domainError;
+  }, [name, nameError, domainError]);
+
+  const canSubmit = useMemo(() => {
+    return canContinueToDistribution && groups.length > 0 && canAction;
+  }, [canContinueToDistribution, groups.length, canAction]);
+
+  const submit = async () => {
+    const savedGroups = await saveGroups();
+    const groupIds = savedGroups.map((g) => g.id).filter(Boolean) as string[];
+
+    const body: DNSZoneRequest = {
+      name,
+      domain,
+      enabled,
+      enable_search_domain: searchDomain,
+      distribution_groups: groupIds,
+    };
+
+    if (isUpdate) {
+      notify({
+        title: "Update DNS Zone",
+        description: "Zone was updated successfully.",
+        loadingMessage: "Updating your zone...",
+        promise: zoneRequest.put(body, `/${preset?.id}`).then(() => {
+          // List + detail share state — invalidate both so the
+          // /dns/zone header (which fetches /dns/zones/${id}) picks
+          // up the new name/enabled/groups/search-domain values
+          // immediately after the modal closes.
+          mutate("/dns/zones");
+          if (preset?.id) mutate(`/dns/zones/${preset.id}`);
+          onSuccess?.();
+        }),
+      });
+    } else {
+      notify({
+        title: "Create DNS Zone",
+        description: "Zone was created successfully.",
+        loadingMessage: "Creating your zone...",
+        promise: zoneRequest.post(body).then(() => {
+          mutate("/dns/zones");
+          onSuccess?.();
+        }),
+      });
+    }
+  };
+
+  return (
+    <ModalContent maxWidthClass={"max-w-xl"}>
+      <ModalHeader
+        icon={<DNSIcon className={"fill-openzro"} />}
+        title={isUpdate ? preset?.name : "Add DNS Zone"}
+        description={
+          "Publish authoritative DNS records to peers in selected groups"
+        }
+        color={"openzro"}
+      />
+
+      <Tabs
+        defaultValue={tab}
+        onValueChange={(v) => setTab(v as typeof tab)}
+        value={tab}
+      >
+        <div className="px-8 pb-3 pt-1">
+          <TabsList>
+            <TabsTrigger value={"zone"}>
+              <Layers
+                size={16}
+                className="text-oz2-text-faint group-data-[state=active]/trigger:text-oz2-acc transition-colors"
+              />
+              Zone
+            </TabsTrigger>
+            <TabsTrigger
+              value={"distribution"}
+              disabled={!isUpdate && !canContinueToDistribution}
+            >
+              <Users
+                size={16}
+                className="text-oz2-text-faint group-data-[state=active]/trigger:text-oz2-acc transition-colors"
+              />
+              Distribution
+            </TabsTrigger>
+          </TabsList>
+        </div>
+
+        {/* ── Zone tab ─────────────────────────────────────────────── */}
+        <TabsContent value={"zone"} className={"pb-8"}>
+          <div className={"px-8 flex flex-col gap-6"}>
+            <div>
+              <OzLabel htmlFor="zone-name">Name</OzLabel>
+              <OzHelpText className="mb-2">
+                A human-readable label for this zone.
+              </OzHelpText>
+              <OzInput
+                id="zone-name"
+                autoFocus={true}
+                error={nameError}
+                placeholder={"e.g., Internal services"}
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                disabled={!canAction}
+              />
+            </div>
+
+            <div>
+              <OzLabel htmlFor="zone-domain">Domain</OzLabel>
+              <OzHelpText className="mb-2">
+                The FQDN apex of this zone (e.g.{" "}
+                <code className="font-mono">internal.example</code>). Immutable
+                after creation — create a new zone if you need to change it.
+              </OzHelpText>
+              <OzInput
+                id="zone-domain"
+                mono
+                error={domain ? domainError : ""}
+                placeholder={"e.g., internal.example"}
+                value={domain}
+                onChange={(e) => setDomain(e.target.value.trim().toLowerCase())}
+                disabled={!canAction || isUpdate}
+              />
+            </div>
+
+            <FancyToggleSwitch
+              value={enabled}
+              onChange={setEnabled}
+              label={
+                <>
+                  <Power size={15} />
+                  Enable Zone
+                </>
+              }
+              helpText={
+                "When disabled, the zone is not distributed to peers — useful for pausing without deleting."
+              }
+              disabled={!canAction}
+            />
+
+            <FancyToggleSwitch
+              value={searchDomain}
+              onChange={setSearchDomain}
+              label={
+                <>
+                  <Scan size={15} />
+                  Append to search domain
+                </>
+              }
+              helpText={
+                "When enabled, peers can resolve bare names against this zone (e.g. 'db' → 'db.<domain>')."
+              }
+              disabled={!canAction}
+            />
+          </div>
+        </TabsContent>
+
+        {/* ── Distribution tab ────────────────────────────────────── */}
+        <TabsContent value={"distribution"} className={"pb-8"}>
+          <div className={"px-8 flex flex-col gap-6"}>
+            <div>
+              <OzLabel>Distribution Groups</OzLabel>
+              <OzHelpText className="mb-2">
+                Peers that belong to any of these groups receive this zone.
+                At least one group is required.
+              </OzHelpText>
+              <PeerGroupSelector
+                onChange={setGroups}
+                values={groups}
+                disabled={!canAction}
+                showResources={false}
+              />
+              {groups.length === 0 && (
+                <p className="mt-2 text-[11.5px] text-oz2-err">
+                  Select at least one distribution group.
+                </p>
+              )}
+            </div>
+          </div>
+        </TabsContent>
+      </Tabs>
+
+      <ModalFooter className={"items-center"}>
+        <div className={"w-full"}>
+          <p className={"text-sm mt-auto text-oz2-text-muted"}>
+            Learn more about{" "}
+            <a
+              href={
+                "https://docs.openzro.io/how-to/manage-dns-in-your-network"
+              }
+              target={"_blank"}
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-oz2-acc-text underline-offset-2 hover:underline"
+            >
+              DNS zones
+              <ExternalLinkIcon size={12} />
+            </a>
+          </p>
+        </div>
+        <div className={"flex gap-3 w-full justify-end"}>
+          {!isUpdate ? (
+            // Step-flow on create: Zone → Distribution → Add Zone.
+            // Records tab is disabled on create (records are managed
+            // post-creation via the dedicated endpoints).
+            <>
+              {tab === "zone" && (
+                <>
+                  <ModalClose asChild={true}>
+                    <OzButton variant={"default"}>Cancel</OzButton>
+                  </ModalClose>
+                  <OzButton
+                    variant={"primary"}
+                    disabled={!canContinueToDistribution}
+                    onClick={() => setTab("distribution")}
+                  >
+                    Continue
+                  </OzButton>
+                </>
+              )}
+              {tab === "distribution" && (
+                <>
+                  <OzButton
+                    variant={"default"}
+                    onClick={() => setTab("zone")}
+                  >
+                    Back
+                  </OzButton>
+                  <OzButton
+                    variant={"primary"}
+                    disabled={!canSubmit}
+                    onClick={submit}
+                  >
+                    <PlusCircle size={16} />
+                    Add Zone
+                  </OzButton>
+                </>
+              )}
+            </>
+          ) : (
+            // Edit: any tab saves directly. Records sub-CRUD is
+            // self-contained inside its tab.
+            <>
+              <ModalClose asChild={true}>
+                <OzButton variant={"default"}>Cancel</OzButton>
+              </ModalClose>
+              <OzButton
+                variant={"primary"}
+                disabled={!canSubmit}
+                onClick={submit}
+              >
+                Save Changes
+              </OzButton>
+            </>
+          )}
+        </div>
+      </ModalFooter>
+    </ModalContent>
+  );
+}

--- a/dashboard/src/modules/dns-zones/DNSZonesTable.tsx
+++ b/dashboard/src/modules/dns-zones/DNSZonesTable.tsx
@@ -1,0 +1,739 @@
+"use client";
+
+import { TooltipProvider } from "@components/Tooltip";
+import {
+  Column,
+  ColumnDef,
+  FilterFn,
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  PaginationState,
+  Row,
+  SortingFn,
+  SortingState,
+  useReactTable,
+} from "@tanstack/react-table";
+import { BookOpen, Globe, PlusCircle, ShieldCheck } from "lucide-react";
+import { useRouter } from "next/navigation";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { useSWRConfig } from "swr";
+import OzButton from "@/components/v2/OzButton";
+import OzCard from "@/components/v2/OzCard";
+import OzEmptyState from "@/components/v2/OzEmptyState";
+import {
+  OzTable,
+  OzTableBody,
+  OzTableCell,
+  OzTableHead,
+  OzTableHeader,
+  OzTableRow,
+} from "@/components/v2/OzTable";
+import { usePermissions } from "@/contexts/PermissionsProvider";
+import { DNSZone } from "@/interfaces/DNSZone";
+import { useV2TopbarRight } from "@/layouts/V2DashboardLayout";
+import DnsTabs from "@/modules/dns/v2/DnsTabs";
+import DNSZoneActionCell from "@/modules/dns-zones/cells/DNSZoneActionCell";
+import DNSZoneActiveCell from "@/modules/dns-zones/cells/DNSZoneActiveCell";
+import DNSZoneDistributionCell from "@/modules/dns-zones/cells/DNSZoneDistributionCell";
+import DNSZoneNameCell from "@/modules/dns-zones/cells/DNSZoneNameCell";
+import DNSZoneRecordsCell from "@/modules/dns-zones/cells/DNSZoneRecordsCell";
+import DNSZoneModal from "@/modules/dns-zones/DNSZoneModal";
+
+interface Props {
+  zones: DNSZone[] | undefined;
+  isLoading: boolean;
+}
+
+type EnabledFilter = "all" | "enabled";
+
+const noopFilter: FilterFn<unknown> = () => true;
+const noopSort: SortingFn<unknown> = () => 0;
+const NOOP_FILTER_FNS = {
+  fuzzy: noopFilter,
+  dateRange: noopFilter,
+  exactMatch: noopFilter,
+  arrIncludesSomeExact: noopFilter,
+};
+const NOOP_SORTING_FNS = { checkbox: noopSort };
+
+export default function DNSZonesTable({ zones, isLoading }: Props) {
+  const router = useRouter();
+  const { mutate } = useSWRConfig();
+  const { permission } = usePermissions();
+
+  // Track the row being edited by id (kebab → Edit opens the modal).
+  // Row click goes to the detail page instead; that's where records
+  // live now.
+  const [editZoneId, setEditZoneId] = useState<string | null>(null);
+  const [openCreate, setOpenCreate] = useState(false);
+
+  useV2TopbarRight(
+    <OzButton
+      variant="primary"
+      type="button"
+      disabled={!permission.dns_zones.create}
+      onClick={() => setOpenCreate(true)}
+    >
+      <PlusCircle size={14} />
+      Add Zone
+    </OzButton>,
+  );
+
+  const [search, setSearch] = useState("");
+  const [enabledFilter, setEnabledFilter] = useState<EnabledFilter>("all");
+  const [refreshing, setRefreshing] = useState(false);
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: "name", desc: false },
+  ]);
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 10,
+  });
+
+  const all = useMemo(() => zones ?? [], [zones]);
+
+  const counts = useMemo(() => {
+    let enabled = 0;
+    let disabled = 0;
+    for (const z of all) {
+      // Treat undefined as enabled (server default true). Phase 1
+      // backend never returns it unset, but a defensive default keeps
+      // legacy responses sane.
+      if (z.enabled ?? true) enabled += 1;
+      else disabled += 1;
+    }
+    return { total: all.length, enabled, disabled };
+  }, [all]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return all.filter((z) => {
+      if (enabledFilter === "enabled" && !(z.enabled ?? true)) return false;
+      if (!q) return true;
+      const haystack = [
+        z.name,
+        z.domain,
+        z.records?.map((r) => `${r.name} ${r.content}`).join(" "),
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(q);
+    });
+  }, [all, search, enabledFilter]);
+
+  useEffect(() => {
+    setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+  }, [search, enabledFilter]);
+
+  const columns = useMemo<ColumnDef<DNSZone>[]>(
+    () => [
+      {
+        id: "name",
+        accessorFn: (z) => z.name ?? "",
+        sortingFn: "text",
+        header: ({ column }) => <SortHeader column={column} label="Name" />,
+        cell: ({ row }) => <DNSZoneNameCell zone={row.original} />,
+      },
+      {
+        id: "enabled",
+        accessorFn: (z) => z.enabled ?? true,
+        sortingFn: "basic",
+        header: ({ column }) => <SortHeader column={column} label="Active" />,
+        cell: ({ row }) => <DNSZoneActiveCell zone={row.original} />,
+      },
+      {
+        id: "records",
+        accessorFn: (z) => z.records?.length ?? 0,
+        sortingFn: "basic",
+        header: ({ column }) => <SortHeader column={column} label="Records" />,
+        cell: ({ row }) => <DNSZoneRecordsCell zone={row.original} />,
+      },
+      {
+        id: "groups",
+        accessorFn: (z) => z.distribution_groups?.length ?? 0,
+        sortingFn: "basic",
+        header: ({ column }) => (
+          <SortHeader column={column} label="Distribution Groups" />
+        ),
+        cell: ({ row }) => <DNSZoneDistributionCell zone={row.original} />,
+      },
+      {
+        id: "actions",
+        size: 40,
+        enableSorting: false,
+        header: () => null,
+        cell: ({ row }) => (
+          <DNSZoneActionCell
+            zone={row.original}
+            onEdit={() => setEditZoneId(row.original.id)}
+          />
+        ),
+      },
+    ],
+    [],
+  );
+
+  const table = useReactTable({
+    data: filtered,
+    columns,
+    state: { sorting, pagination },
+    onSortingChange: setSorting,
+    onPaginationChange: setPagination,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getRowId: (z) => z.id ?? "",
+    filterFns: NOOP_FILTER_FNS,
+    sortingFns: NOOP_SORTING_FNS,
+  });
+
+  const refreshClick = () => {
+    setRefreshing(true);
+    mutate("/dns/zones").finally(() => setRefreshing(false));
+  };
+
+  const handleRowClick = (row: Row<DNSZone>, event: React.MouseEvent) => {
+    const target = event.target as HTMLElement;
+    if (
+      target.closest(
+        "button, a, [role='switch'], input, select, [data-stop-row-click]",
+      )
+    ) {
+      return;
+    }
+    // Row click navigates to the zone detail page (records live
+    // there, Cloudflare-style). Zone metadata editing is reachable
+    // from the kebab menu or the detail-page "Edit zone" CTA.
+    router.push(`/dns/zone?id=${row.original.id}`);
+  };
+
+  const pageInfo = table.getState().pagination;
+  const total = filtered.length;
+  const pageStart =
+    total === 0 ? 0 : pageInfo.pageIndex * pageInfo.pageSize + 1;
+  const pageEnd = Math.min(total, (pageInfo.pageIndex + 1) * pageInfo.pageSize);
+
+  const isColdStart = !isLoading && all.length === 0;
+
+  // Resolve the editing zone from the live `zones` array each render —
+  // when /dns/zones is revalidated after a record CRUD inside the
+  // modal, this picks up the fresh records slice without forcing the
+  // modal to close. If the row was deleted from under us, the lookup
+  // returns undefined and the modal closes naturally.
+  const editZone = useMemo(
+    () => (editZoneId ? all.find((z) => z.id === editZoneId) ?? null : null),
+    [editZoneId, all],
+  );
+
+  return (
+    <TooltipProvider delayDuration={250} skipDelayDuration={100}>
+      <div className="space-y-6 p-8">
+        <header>
+          <h1 className="text-[24px] font-semibold tracking-tight">DNS</h1>
+          <p className="mt-1 max-w-2xl text-[14px] text-oz2-text-muted">
+            Operator-managed authoritative DNS zones distributed to peers in
+            selected groups. Learn more about{" "}
+            <a
+              href="https://docs.openzro.io/how-to/manage-dns-in-your-network"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-oz2-acc-text underline-offset-2 hover:underline"
+            >
+              DNS zones
+            </a>
+            .
+          </p>
+        </header>
+
+        <DnsTabs />
+
+        {openCreate && (
+          <DNSZoneModal
+            open={openCreate}
+            onOpenChange={(next) => setOpenCreate(next)}
+          />
+        )}
+
+        {editZone && (
+          <DNSZoneModal
+            preset={editZone}
+            open={Boolean(editZone)}
+            onOpenChange={(next) => {
+              if (!next) setEditZoneId(null);
+            }}
+          />
+        )}
+
+        {isColdStart ? (
+          <DNSZonesEmptyState
+            canCreate={permission.dns_zones.create}
+            onCreate={() => setOpenCreate(true)}
+          />
+        ) : (
+          <>
+            <div className="flex flex-wrap items-center gap-2.5">
+              <div className="inline-flex h-8 w-[280px] items-center gap-2 rounded-oz2-input border border-oz2-border bg-oz2-surface px-2.5">
+                <span className="text-oz2-text-faint">{ICONS.search}</span>
+                <input
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Search by name, domain or record…"
+                  className="h-full flex-1 border-0 bg-transparent text-[12.5px] outline-none placeholder:text-oz2-text-faint"
+                />
+              </div>
+
+              <SegmentedTabs
+                value={enabledFilter}
+                onChange={setEnabledFilter}
+                options={[
+                  { id: "all", label: "All", count: counts.total },
+                  { id: "enabled", label: "Enabled", count: counts.enabled },
+                ]}
+              />
+
+              <PageSizeCombobox
+                value={pageInfo.pageSize}
+                onChange={(n) => table.setPageSize(n)}
+              />
+
+              <button
+                type="button"
+                onClick={refreshClick}
+                aria-label="Refresh zones"
+                className="grid h-8 w-8 place-items-center rounded-oz2-input border border-oz2-border bg-oz2-surface text-oz2-text-2 hover:border-oz2-border-strong hover:bg-oz2-hover"
+              >
+                <span className={refreshing ? "animate-spin text-oz2-acc" : ""}>
+                  {ICONS.refresh}
+                </span>
+              </button>
+
+              <span className="ml-auto font-mono text-[11px] uppercase tracking-[0.04em] text-oz2-text-faint">
+                {counts.total} zone
+                {counts.total === 1 ? "" : "s"}
+              </span>
+            </div>
+
+            <OzCard flush>
+              <OzTable>
+                <OzTableHeader>
+                  {table.getHeaderGroups().map((headerGroup) => (
+                    <OzTableRow
+                      key={headerGroup.id}
+                      className="hover:bg-transparent"
+                    >
+                      {headerGroup.headers.map((header) => (
+                        <OzTableHead
+                          key={header.id}
+                          style={
+                            header.column.columnDef.size
+                              ? { width: header.column.columnDef.size }
+                              : undefined
+                          }
+                        >
+                          {header.isPlaceholder
+                            ? null
+                            : flexRender(
+                                header.column.columnDef.header,
+                                header.getContext(),
+                              )}
+                        </OzTableHead>
+                      ))}
+                    </OzTableRow>
+                  ))}
+                </OzTableHeader>
+                <OzTableBody>
+                  {table.getRowModel().rows.map((row) => (
+                    <OzTableRow
+                      key={row.id}
+                      onClick={(e) => handleRowClick(row, e)}
+                      className="cursor-pointer"
+                    >
+                      {row.getVisibleCells().map((cell) => (
+                        <OzTableCell
+                          key={cell.id}
+                          data-cell-id={cell.column.id}
+                        >
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext(),
+                          )}
+                        </OzTableCell>
+                      ))}
+                    </OzTableRow>
+                  ))}
+                  {table.getRowModel().rows.length === 0 && (
+                    <OzTableRow className="hover:bg-transparent">
+                      <OzTableCell
+                        colSpan={columns.length}
+                        className="px-[18px] py-12 text-center text-oz2-text-muted"
+                      >
+                        {isLoading
+                          ? "Loading zones…"
+                          : "No zones match your filter."}
+                      </OzTableCell>
+                    </OzTableRow>
+                  )}
+                </OzTableBody>
+              </OzTable>
+
+              <div className="flex flex-wrap items-center justify-between gap-3 border-t border-oz2-border-soft bg-oz2-bg-sunken px-[18px] py-3 text-[13.5px]">
+                <span className="text-oz2-text-muted">
+                  {total === 0
+                    ? "0 zones"
+                    : `Showing ${pageStart}–${pageEnd} of ${total}`}
+                </span>
+                <Pager
+                  page={pageInfo.pageIndex + 1}
+                  totalPages={Math.max(1, table.getPageCount())}
+                  onChange={(p) => table.setPageIndex(p - 1)}
+                />
+              </div>
+            </OzCard>
+          </>
+        )}
+      </div>
+    </TooltipProvider>
+  );
+}
+
+function DNSZonesEmptyState({
+  canCreate,
+  onCreate,
+}: {
+  canCreate: boolean;
+  onCreate: () => void;
+}) {
+  return (
+    <OzEmptyState
+      title="Create DNS Zone"
+      description="Authoritative DNS zones let you publish internal hostnames to peers in selected groups — no external nameservers needed."
+      primaryAction={
+        <OzButton
+          variant="primary"
+          type="button"
+          disabled={!canCreate}
+          onClick={onCreate}
+        >
+          <PlusCircle size={14} />
+          Add Zone
+        </OzButton>
+      }
+      learnMore={
+        <>
+          Learn more about{" "}
+          <a
+            href="https://docs.openzro.io/how-to/manage-dns-in-your-network"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-oz2-acc-text underline-offset-2 hover:underline"
+          >
+            DNS zones
+          </a>
+          .
+        </>
+      }
+      helperCards={[
+        {
+          icon: <BookOpen size={16} />,
+          title: "Authoritative resolution",
+          description:
+            "Peers answer queries inside the zone locally with NXDOMAIN on miss — no upstream fall-through.",
+          href: "https://docs.openzro.io/how-to/manage-dns-in-your-network",
+        },
+        {
+          icon: <Globe size={16} />,
+          title: "A / AAAA / CNAME",
+          description:
+            "Publish IPv4, IPv6 and alias records under a custom domain. Per-record TTL configurable.",
+          href: "https://docs.openzro.io/how-to/manage-dns-in-your-network",
+        },
+        {
+          icon: <ShieldCheck size={16} />,
+          title: "Scope by group",
+          description:
+            "Distribute each zone only to the peer groups that need it. Toggle off to pause without deleting.",
+          href: "https://docs.openzro.io/how-to/manage-dns-in-your-network",
+        },
+      ]}
+    />
+  );
+}
+
+function SortHeader({
+  column,
+  label,
+}: {
+  column: Column<DNSZone, unknown>;
+  label: string;
+}) {
+  if (!column.getCanSort()) {
+    return <span>{label}</span>;
+  }
+  const sorted = column.getIsSorted();
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        column.toggleSorting();
+      }}
+      className="-mx-1 inline-flex h-5 items-center gap-1.5 rounded px-1 text-left font-mono text-[11.5px] font-semibold uppercase tracking-widest text-oz2-text-muted transition-colors hover:text-oz2-text"
+    >
+      {label}
+      <span
+        className={
+          "text-oz2-text-faint transition-opacity " +
+          (sorted ? "text-oz2-text opacity-100" : "opacity-50")
+        }
+      >
+        {sorted === "asc"
+          ? ICONS.sortAsc
+          : sorted === "desc"
+            ? ICONS.sortDesc
+            : ICONS.sortIdle}
+      </span>
+    </button>
+  );
+}
+
+function SegmentedTabs<T extends string>({
+  value,
+  onChange,
+  options,
+}: {
+  value: T;
+  onChange: (next: T) => void;
+  options: { id: T; label: string; count?: number }[];
+}) {
+  return (
+    <div
+      role="tablist"
+      className="inline-flex h-8 items-center rounded-oz2-input bg-oz2-bg-sunken p-1 text-oz2-text-muted"
+    >
+      {options.map((opt) => {
+        const active = opt.id === value;
+        return (
+          <button
+            key={opt.id}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            onClick={() => onChange(opt.id)}
+            className={
+              "inline-flex h-full items-center gap-1.5 whitespace-nowrap rounded-[6px] px-3 text-[13px] font-medium transition-colors " +
+              (active
+                ? "bg-oz2-surface text-oz2-text shadow-oz2-sm"
+                : "hover:text-oz2-text")
+            }
+          >
+            {opt.label}
+            {typeof opt.count === "number" && (
+              <span className="font-mono text-[11.5px] text-oz2-text-faint">
+                {opt.count}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function PageSizeCombobox({
+  value,
+  onChange,
+}: {
+  value: number;
+  onChange: (next: number) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const choices = [10, 25, 50, 100, 1000];
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="inline-flex h-8 items-center gap-1.5 rounded-oz2-input border border-oz2-border bg-oz2-surface px-3 text-[13px] font-medium text-oz2-text-2 hover:bg-oz2-hover hover:border-oz2-border-strong"
+      >
+        <span className="text-oz2-text-faint">Rows:</span>
+        <span className="font-mono">{value}</span>
+        <span className="text-oz2-text-faint">{ICONS.chevDown}</span>
+      </button>
+      {open && (
+        <div className="absolute right-0 top-full z-30 mt-1 min-w-[110px] overflow-hidden rounded-oz2-input border border-oz2-border bg-oz2-bg-elev shadow-oz2-md">
+          <ul className="py-1">
+            {choices.map((c) => (
+              <li key={c}>
+                <button
+                  type="button"
+                  onClick={() => {
+                    onChange(c);
+                    setOpen(false);
+                  }}
+                  className={
+                    "flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left text-[13.5px] hover:bg-oz2-hover " +
+                    (c === value ? "text-oz2-acc-text" : "text-oz2-text")
+                  }
+                >
+                  <span className="font-mono">{c}</span>
+                  <span className="text-oz2-text-faint">rows</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Pager({
+  page,
+  totalPages,
+  onChange,
+}: {
+  page: number;
+  totalPages: number;
+  onChange: (next: number) => void;
+}) {
+  const canPrev = page > 1;
+  const canNext = page < totalPages;
+  return (
+    <div className="flex items-center gap-1">
+      <PagerBtn
+        disabled={!canPrev}
+        onClick={() => onChange(page - 1)}
+        aria-label="Previous page"
+      >
+        <span className="rotate-90">{ICONS.chevDown}</span>
+      </PagerBtn>
+      <span className="px-2 font-mono text-[13px] tabular-nums text-oz2-text-muted">
+        {page} / {totalPages}
+      </span>
+      <PagerBtn
+        disabled={!canNext}
+        onClick={() => onChange(page + 1)}
+        aria-label="Next page"
+      >
+        <span className="-rotate-90">{ICONS.chevDown}</span>
+      </PagerBtn>
+    </div>
+  );
+}
+
+function PagerBtn({
+  disabled,
+  onClick,
+  children,
+  ...props
+}: {
+  disabled?: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+} & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "onClick">) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className={
+        "grid h-7 w-7 place-items-center rounded-oz2-input border border-oz2-border bg-oz2-surface text-oz2-text-2 transition-colors " +
+        (disabled
+          ? "opacity-40"
+          : "hover:border-oz2-border-strong hover:bg-oz2-hover")
+      }
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}
+
+const baseIcon = (path: React.ReactNode) => (
+  <svg
+    viewBox="0 0 24 24"
+    width={16}
+    height={16}
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.7}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    {path}
+  </svg>
+);
+
+const ICONS = {
+  search: baseIcon(
+    <>
+      <circle cx={11} cy={11} r={7} />
+      <path d="m20 20-3.5-3.5" />
+    </>,
+  ),
+  chevDown: baseIcon(<path d="m6 9 6 6 6-6" />),
+  refresh: baseIcon(
+    <>
+      <path d="M21 12a9 9 0 1 1-3.5-7.1" />
+      <path d="M21 4v5h-5" />
+    </>,
+  ),
+  sortAsc: (
+    <svg
+      viewBox="0 0 24 24"
+      width={11}
+      height={11}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="m18 15-6-6-6 6" />
+    </svg>
+  ),
+  sortDesc: (
+    <svg
+      viewBox="0 0 24 24"
+      width={11}
+      height={11}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="m6 9 6 6 6-6" />
+    </svg>
+  ),
+  sortIdle: (
+    <svg
+      viewBox="0 0 24 24"
+      width={11}
+      height={11}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="m6 9 6-6 6 6M6 15l6 6 6-6" />
+    </svg>
+  ),
+};

--- a/dashboard/src/modules/dns-zones/cells/DNSZoneActionCell.tsx
+++ b/dashboard/src/modules/dns-zones/cells/DNSZoneActionCell.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@components/DropdownMenu";
+import { notify } from "@components/Notification";
+import { useApiCall } from "@utils/api";
+import { MoreVertical, PencilLine, Trash2 } from "lucide-react";
+import * as React from "react";
+import { useSWRConfig } from "swr";
+import { useDialog } from "@/contexts/DialogProvider";
+import { usePermissions } from "@/contexts/PermissionsProvider";
+import { DNSZone } from "@/interfaces/DNSZone";
+
+type Props = {
+  zone: DNSZone;
+  onEdit?: () => void;
+};
+
+export default function DNSZoneActionCell({ zone, onEdit }: Readonly<Props>) {
+  const { confirm } = useDialog();
+  const zoneRequest = useApiCall<DNSZone>("/dns/zones");
+  const { mutate } = useSWRConfig();
+  const { permission } = usePermissions();
+
+  const deleteZone = async () => {
+    notify({
+      title: "Zone " + zone.name,
+      description: "The zone was successfully removed.",
+      promise: zoneRequest.del("", `/${zone.id}`).then(() => {
+        mutate("/dns/zones");
+      }),
+      loadingMessage: "Deleting the zone...",
+    });
+  };
+
+  const handleConfirm = async () => {
+    const choice = await confirm({
+      title: `Delete '${zone.name}'?`,
+      description:
+        "Are you sure you want to delete this zone? Records under this zone will be removed and peers will lose authoritative resolution for the domain. This action cannot be undone.",
+      confirmText: "Delete",
+      cancelText: "Cancel",
+      type: "danger",
+    });
+    if (!choice) return;
+    deleteZone().then();
+  };
+
+  return (
+    <div className="flex justify-end pr-2">
+      <DropdownMenu modal={false}>
+        <DropdownMenuTrigger
+          asChild
+          onClick={(e) => {
+            e.stopPropagation();
+            e.preventDefault();
+          }}
+        >
+          <button
+            type="button"
+            aria-label="Row actions"
+            className="grid h-8 w-8 place-items-center rounded-oz2-input border border-oz2-border bg-oz2-surface text-oz2-text-2 transition-colors hover:bg-oz2-hover hover:border-oz2-border-strong"
+          >
+            <MoreVertical size={14} className="shrink-0" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-44">
+          {onEdit && (
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.stopPropagation();
+                onEdit();
+              }}
+            >
+              <div className="flex items-center gap-3">
+                <PencilLine size={14} className="shrink-0" />
+                Edit
+              </div>
+            </DropdownMenuItem>
+          )}
+          <DropdownMenuItem
+            disabled={!permission.dns_zones.delete}
+            onClick={(e) => {
+              e.stopPropagation();
+              handleConfirm();
+            }}
+            variant="danger"
+          >
+            <div className="flex items-center gap-3">
+              <Trash2 size={14} className="shrink-0" />
+              Delete
+            </div>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/dashboard/src/modules/dns-zones/cells/DNSZoneActiveCell.tsx
+++ b/dashboard/src/modules/dns-zones/cells/DNSZoneActiveCell.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { notify } from "@components/Notification";
+import { ToggleSwitch } from "@components/ToggleSwitch";
+import { useApiCall } from "@utils/api";
+import React from "react";
+import { useSWRConfig } from "swr";
+import { usePermissions } from "@/contexts/PermissionsProvider";
+import { DNSZone, DNSZoneRequest } from "@/interfaces/DNSZone";
+
+type Props = {
+  zone: DNSZone;
+};
+
+export default function DNSZoneActiveCell({ zone }: Readonly<Props>) {
+  const zoneRequest = useApiCall<DNSZone>("/dns/zones");
+  const { mutate } = useSWRConfig();
+  const { permission } = usePermissions();
+
+  const checked = zone.enabled ?? true;
+
+  const update = async (next: boolean) => {
+    const body: DNSZoneRequest = {
+      name: zone.name,
+      domain: zone.domain,
+      enabled: next,
+      enable_search_domain: zone.enable_search_domain,
+      distribution_groups: zone.distribution_groups,
+    };
+    notify({
+      title: zone.name,
+      description:
+        "Zone was successfully" + (next ? " enabled" : " disabled") + ".",
+      loadingMessage: "Updating your zone...",
+      promise: zoneRequest.put(body, `/${zone.id}`).then(() => {
+        mutate("/dns/zones");
+      }),
+    });
+  };
+
+  return (
+    <div className={"flex"}>
+      <ToggleSwitch
+        disabled={!permission.dns_zones.update}
+        checked={checked}
+        size={"small"}
+        onClick={() => update(!checked)}
+      />
+    </div>
+  );
+}

--- a/dashboard/src/modules/dns-zones/cells/DNSZoneDistributionCell.tsx
+++ b/dashboard/src/modules/dns-zones/cells/DNSZoneDistributionCell.tsx
@@ -1,0 +1,19 @@
+import MultipleGroups from "@components/ui/MultipleGroups";
+import * as React from "react";
+import { useGroups } from "@/contexts/GroupsProvider";
+import { DNSZone } from "@/interfaces/DNSZone";
+import { Group } from "@/interfaces/Group";
+
+type Props = {
+  zone: DNSZone;
+};
+
+export default function DNSZoneDistributionCell({ zone }: Props) {
+  const { groups } = useGroups();
+
+  const allGroups = zone.distribution_groups
+    .map((id) => groups?.find((g) => g.id == id))
+    .filter((g) => g != undefined) as Group[];
+
+  return <MultipleGroups groups={allGroups} />;
+}

--- a/dashboard/src/modules/dns-zones/cells/DNSZoneNameCell.tsx
+++ b/dashboard/src/modules/dns-zones/cells/DNSZoneNameCell.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { DNSZone } from "@/interfaces/DNSZone";
+import ActiveInactiveRow from "@/modules/common-table-rows/ActiveInactiveRow";
+
+type Props = {
+  zone: DNSZone;
+};
+
+export default function DNSZoneNameCell({ zone }: Props) {
+  const enabled = zone.enabled ?? true;
+  return (
+    <div className={"flex min-w-[270px] max-w-[270px]"}>
+      <div
+        className={
+          "flex items-center gap-2 dark:text-neutral-300 text-neutral-500 hover:text-neutral-900 dark:hover:text-neutral-100 transition-all hover:bg-neutral-100 dark:hover:bg-nb-gray-800/60 py-2 px-3 rounded-md cursor-pointer"
+        }
+      >
+        <ActiveInactiveRow
+          active={enabled}
+          inactiveDot={"gray"}
+          text={zone.name}
+        >
+          <span className="mt-1 font-mono text-[11.5px] text-oz2-text-faint">
+            {zone.domain}
+          </span>
+        </ActiveInactiveRow>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/modules/dns-zones/cells/DNSZoneRecordsCell.tsx
+++ b/dashboard/src/modules/dns-zones/cells/DNSZoneRecordsCell.tsx
@@ -1,0 +1,26 @@
+import Badge from "@components/Badge";
+import { FileText } from "lucide-react";
+import React from "react";
+import { DNSZone } from "@/interfaces/DNSZone";
+
+type Props = {
+  zone: DNSZone;
+};
+
+export default function DNSZoneRecordsCell({ zone }: Props) {
+  const count = zone.records?.length ?? 0;
+  if (count === 0) {
+    return (
+      <Badge variant={"gray"} className={"font-mono"}>
+        <FileText size={10} className={"mr-1"} />
+        Empty
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant={"gray"} className={"font-mono"}>
+      <FileText size={10} className={"mr-1"} />
+      {count} record{count === 1 ? "" : "s"}
+    </Badge>
+  );
+}

--- a/dashboard/src/modules/dns/v2/DnsTabs.tsx
+++ b/dashboard/src/modules/dns/v2/DnsTabs.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import classNames from "classnames";
-import { Globe, Settings2 } from "lucide-react";
+import { Globe, Layers, Settings2 } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import React from "react";
@@ -35,6 +35,14 @@ export default function DnsTabs() {
       href: "/dns/nameservers",
       match: (p) => p === "/dns/nameservers" || p === "/dns",
       visible: permission.nameservers.read,
+    },
+    {
+      id: "zones",
+      label: "DNS Zones",
+      icon: <Layers size={14} />,
+      href: "/dns/zones",
+      match: (p) => p === "/dns/zones",
+      visible: permission.dns_zones.read,
     },
     {
       id: "settings",


### PR DESCRIPTION
## Summary

Ships the operator-facing dashboard CRUD for the authoritative DNS zones
introduced in [#108](https://github.com/openzro/openzro/issues/108)
Phases 1-3. Without this surface the feature is only reachable via the
REST API.

### Routes
- `/dns/zones` — list page (3rd tab inside DNS, alongside Nameservers
  and DNS Settings).
- `/dns/zone?id=…` — per-zone detail page with header (meta + Edit /
  Delete in the topbar) and records section.

### Modal vs. detail page
Zone modal stays narrow on purpose — **Zone** tab (Name, Domain,
Enabled, SearchDomainEnabled) and **Distribution** tab
(`PeerGroupSelector`). Records sub-CRUD lives on the **detail page**,
not in the modal, so the form has room and the Cloudflare-style name
input (leaf label + `.<zone.domain>` suffix adornment, `@` for the
apex) fits naturally.

Records are managed via the dedicated `/api/dns/zones/{id}/records`
endpoints; the zone `PUT` body never bundles records (Phase 1 backend
ignores them on save anyway).

### UX guarantees pinned to ADR-0022
- **D5 immutability** — domain input is disabled on edit, with copy
  pointing the operator at "create a new zone instead".
- **D5 empty-zone contract** — list row badges "Empty"; detail page +
  records section warn that peers won't receive the zone until at
  least one record exists.
- **Source=UNSPECIFIED legacy compat** is invisible here (handled
  server-side in Phase 2); the dashboard only consumes the
  user-managed view.

### Create step-flow
`Cancel` → `Continue` → `Add Zone` mirrors the NameserverModal
pattern so the operator never lands on a greyed-out submit without
knowing why. `Continue` is gated on Name + Domain syntactic
validation; `Add Zone` on ≥1 distribution group.

### SWR consistency
Records sub-CRUD revalidates both `/dns/zones` and
`/dns/zones/${id}` so the detail page header stays consistent with
the list. Modal `PUT` does the same — fixes the stale-header case
flagged during local re-smoke. Detail-page fetch is now gated on a
non-empty `zoneId` via `useFetchApi`'s `allowFetch` arg.

### Granular RBAC
Records buttons split by `permission.dns_zones.{create,update,delete}`
so custom roles see exactly what they can do. Zone metadata buttons
use the matching `create / update / delete`.

## License posture

BSD-3 (dashboard). New components are clean-room — no upstream NetBird
dashboard diff consulted. NetBird has no equivalent surface; Custom
DNS Zones is openZro-original per ADR-0022.

## Out of scope (deferred per the plan)

- Cypress E2E tests (#52 harness still pending).
- RFC 1035 bulk import, wildcard records (ADR-0022 explicit
  "out of scope" list).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` — no new warnings on touched files
- [x] `npm run build` — `/dns/zones` and `/dns/zone` both emitted
- [x] Local dev server smoke: routes 200 OK
- [x] Authenticated UI walk-through (operator-confirmed)
  - [x] Create zone via step-flow (Zone → Distribution → Add Zone)
  - [x] Row click navigates to detail page
  - [x] Add A record via Cloudflare-style form, `@` apex works
  - [x] Edit zone from detail page header → header updates without reload
  - [x] Toggle enabled → list reflects immediately
  - [x] Delete zone from detail page → bounces back to list

🤖 Generated with [Claude Code](https://claude.com/claude-code)