### PR TITLE
fix(dashboard/dns-zones): widen TTL column so 5-digit values fit

### DIFF
--- a/dashboard/src/modules/dns-zones/DNSRecordsSection.tsx
+++ b/dashboard/src/modules/dns-zones/DNSRecordsSection.tsx
@@ -171,7 +171,9 @@ export default function DNSRecordsSection({ zone }: Props) {
             <col className="w-[80px]" />
             <col className="w-[30%]" />
             <col />
-            <col className="w-[100px]" />
+            {/* TTL — 130px fits 5-digit TTL (e.g. 86400) plus the
+                numeric input spinner. 100px clipped the value. */}
+            <col className="w-[130px]" />
             <col className="w-[100px]" />
           </colgroup>
           <thead>


### PR DESCRIPTION
## Summary

The records table on `/dns/zone` reserved 100px for the TTL column.
That clipped 5-digit TTLs (`86400` / 1 day, `28800` / 8h, etc.) once
the numeric input's spinner buttons were rendered. Bumps the column
to 130px so the value stays fully visible during edit.

Caught in lab smoke after #114 shipped.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` clean
- [ ] Manual: open \`/dns/zone?id=<zone>\`, click **Add Record**, type \`86400\` — value visible in full.

🤖 Generated with [Claude Code](https://claude.com/claude-code)