### PR TITLE
fix(client/ui): cache systray setters to stop the 2s repaint flicker

### DIFF
--- a/client/ui/client_ui.go
+++ b/client/ui/client_ui.go
@@ -291,6 +291,16 @@ type serviceClient struct {
 	wNetworks            fyne.Window
 	wProfiles            fyne.Window
 
+	// trayCache memoises the last value applied to each systray
+	// setter that updateStatus / setConnectingStatus /
+	// setDisconnectedStatus / applyUpdateStateLocked would otherwise
+	// re-fire on every 2s tick. Each helper that pushes a property
+	// out to fyne.io/systray checks this cache first and skips the
+	// call when the value is unchanged. Eliminates the repaint-per-
+	// tick that GTK/X11 + KDE Plasma render as visible flicker
+	// (steals the user's hover/selection mid-menu).
+	trayCache trayStateCache
+
 	eventManager *event.Manager
 
 	exitNodeMu           sync.Mutex
@@ -299,6 +309,65 @@ type serviceClient struct {
 	mExitNodeDeselectAll *systray.MenuItem
 	logFile              string
 	wLoginURL            fyne.Window
+}
+
+// trayStateCache holds the last-applied value for every systray
+// property that updateStatus and friends would otherwise unconditionally
+// re-set on every poll tick. `initialized` flips to true after the
+// first apply — before that, every field is treated as "needs apply"
+// regardless of whether the desired value happens to equal the zero
+// value (avoids the "first Enable() never fires because !want==false"
+// trap). mExitTouched does the same job specifically for mExit, which
+// is driven by updateExitNodes outside the connected/connecting/
+// disconnected switch and therefore may be set before applyTray runs.
+//
+// mu is independent from serviceClient.updateIndicationLock because
+// setDisconnectedStatus is called both from inside the lock (normal
+// tick path) and from outside (the RPC-failed branch at the top of
+// updateStatus). A dedicated short-held mutex keeps the cache
+// thread-safe in both call sites.
+type trayStateCache struct {
+	mu            sync.Mutex
+	initialized   bool
+	iconKey       string
+	tooltip       string
+	statusTitle   string
+	statusIconKey string
+	mUpDisabled   bool
+	mDownDisabled bool
+	mNetDisabled  bool
+	mExitDisabled bool
+	mExitTouched  bool
+	updateItems   map[string]updateItemState
+}
+
+// updateItemState memoises one row of the About-submenu update group.
+// applyUpdateMenuItem re-fires SetTitle/SetTooltip/Show/Hide on three
+// items every 2s; without caching that's six SetTitle + three Hide/Show
+// per tick on a typical session.
+type updateItemState struct {
+	shown   bool
+	title   string
+	tooltip string
+}
+
+// desiredTrayState is the full set of properties one branch of
+// updateStatus wants to push to the tray. nil-able fields opt the
+// helper out of touching a given property (used for mExit, which is
+// driven by updateExitNodes outside the connected/connecting/
+// disconnected switch).
+type desiredTrayState struct {
+	iconKey         string
+	iconBytes       []byte
+	iconMacOSBytes  []byte
+	tooltip         string
+	statusTitle     string
+	statusIconKey   string // empty → don't touch
+	statusIconBytes []byte
+	mUpDisabled     bool
+	mDownDisabled   bool
+	mNetDisabled    bool
+	mExitDisabled   *bool // nil → leave alone
 }
 
 type menuHandler struct {
@@ -712,17 +781,20 @@ func (s *serviceClient) updateStatus() error {
 		case status.Status == string(internal.StatusConnected):
 			s.connected = true
 			s.sendNotification = true
-			if s.isUpdateIconActive {
-				systray.SetTemplateIcon(iconUpdateConnectedMacOS, s.icUpdateConnected)
-			} else {
-				systray.SetTemplateIcon(iconConnectedMacOS, s.icConnected)
-			}
-			systray.SetTooltip("Openzro (Connected)")
-			s.mStatus.SetTitle("Connected")
-			s.mStatus.SetIcon(s.icConnectedDot)
-			s.mUp.Disable()
-			s.mDown.Enable()
-			s.mNetworks.Enable()
+			iconKey, iconBytes, iconMacOS := s.connectedIcon()
+			s.applyTray(desiredTrayState{
+				iconKey:         iconKey,
+				iconBytes:       iconBytes,
+				iconMacOSBytes:  iconMacOS,
+				tooltip:         "Openzro (Connected)",
+				statusTitle:     "Connected",
+				statusIconKey:   "connected-dot",
+				statusIconBytes: s.icConnectedDot,
+				mUpDisabled:     true,
+				mDownDisabled:   false,
+				mNetDisabled:    false,
+				// mExit driven by updateExitNodes goroutine below.
+			})
 			go s.updateExitNodes()
 		case status.Status == string(internal.StatusConnecting):
 			s.setConnectingStatus()
@@ -764,30 +836,137 @@ func (s *serviceClient) updateStatus() error {
 
 func (s *serviceClient) setDisconnectedStatus() {
 	s.connected = false
-	if s.isUpdateIconActive {
-		systray.SetTemplateIcon(iconUpdateDisconnectedMacOS, s.icUpdateDisconnected)
-	} else {
-		systray.SetTemplateIcon(iconDisconnectedMacOS, s.icDisconnected)
-	}
-	systray.SetTooltip("Openzro (Disconnected)")
-	s.mStatus.SetTitle("Disconnected")
-	s.mStatus.SetIcon(s.icDisconnectedDot)
-	s.mDown.Disable()
-	s.mUp.Enable()
-	s.mNetworks.Disable()
-	s.mExitNode.Disable()
+	exitDisabled := true
+	iconKey, iconBytes, iconMacOS := s.disconnectedIcon()
+	s.applyTray(desiredTrayState{
+		iconKey:         iconKey,
+		iconBytes:       iconBytes,
+		iconMacOSBytes:  iconMacOS,
+		tooltip:         "Openzro (Disconnected)",
+		statusTitle:     "Disconnected",
+		statusIconKey:   "disconnected-dot",
+		statusIconBytes: s.icDisconnectedDot,
+		mUpDisabled:     false,
+		mDownDisabled:   true,
+		mNetDisabled:    true,
+		mExitDisabled:   &exitDisabled,
+	})
 	go s.updateExitNodes()
 }
 
 func (s *serviceClient) setConnectingStatus() {
 	s.connected = false
-	systray.SetTemplateIcon(iconConnectingMacOS, s.icConnecting)
-	systray.SetTooltip("Openzro (Connecting)")
-	s.mStatus.SetTitle("Connecting")
-	s.mUp.Disable()
-	s.mDown.Enable()
-	s.mNetworks.Disable()
-	s.mExitNode.Disable()
+	exitDisabled := true
+	s.applyTray(desiredTrayState{
+		iconKey:        "connecting",
+		iconBytes:      s.icConnecting,
+		iconMacOSBytes: iconConnectingMacOS,
+		tooltip:        "Openzro (Connecting)",
+		statusTitle:    "Connecting",
+		// statusIconKey left empty → don't touch mStatus.SetIcon.
+		// The pre-refactor code never set the dot icon on
+		// Connecting either, so behavior is preserved.
+		mUpDisabled:   true,
+		mDownDisabled: false,
+		mNetDisabled:  true,
+		mExitDisabled: &exitDisabled,
+	})
+}
+
+// connectedIcon returns the cache key + byte slices for the connected
+// icon, branching on whether an update is currently available.
+func (s *serviceClient) connectedIcon() (string, []byte, []byte) {
+	if s.isUpdateIconActive {
+		return "connected-update", s.icUpdateConnected, iconUpdateConnectedMacOS
+	}
+	return "connected", s.icConnected, iconConnectedMacOS
+}
+
+// disconnectedIcon returns the cache key + byte slices for the
+// disconnected icon, branching on whether an update is currently
+// available.
+func (s *serviceClient) disconnectedIcon() (string, []byte, []byte) {
+	if s.isUpdateIconActive {
+		return "disconnected-update", s.icUpdateDisconnected, iconUpdateDisconnectedMacOS
+	}
+	return "disconnected", s.icDisconnected, iconDisconnectedMacOS
+}
+
+// applyTray pushes `desired` to the systray, skipping any setter
+// whose value matches the last-applied entry in s.trayCache. Safe to
+// call from any goroutine; the cache has its own mutex independent
+// of serviceClient.updateIndicationLock.
+func (s *serviceClient) applyTray(d desiredTrayState) {
+	s.trayCache.mu.Lock()
+	defer s.trayCache.mu.Unlock()
+
+	first := !s.trayCache.initialized
+
+	if first || s.trayCache.iconKey != d.iconKey {
+		systray.SetTemplateIcon(d.iconMacOSBytes, d.iconBytes)
+		s.trayCache.iconKey = d.iconKey
+	}
+	if first || s.trayCache.tooltip != d.tooltip {
+		systray.SetTooltip(d.tooltip)
+		s.trayCache.tooltip = d.tooltip
+	}
+	if first || s.trayCache.statusTitle != d.statusTitle {
+		s.mStatus.SetTitle(d.statusTitle)
+		s.trayCache.statusTitle = d.statusTitle
+	}
+	if d.statusIconKey != "" && (first || s.trayCache.statusIconKey != d.statusIconKey) {
+		s.mStatus.SetIcon(d.statusIconBytes)
+		s.trayCache.statusIconKey = d.statusIconKey
+	}
+	if first || s.trayCache.mUpDisabled != d.mUpDisabled {
+		setMenuItemEnabled(s.mUp, !d.mUpDisabled)
+		s.trayCache.mUpDisabled = d.mUpDisabled
+	}
+	if first || s.trayCache.mDownDisabled != d.mDownDisabled {
+		setMenuItemEnabled(s.mDown, !d.mDownDisabled)
+		s.trayCache.mDownDisabled = d.mDownDisabled
+	}
+	if first || s.trayCache.mNetDisabled != d.mNetDisabled {
+		setMenuItemEnabled(s.mNetworks, !d.mNetDisabled)
+		s.trayCache.mNetDisabled = d.mNetDisabled
+	}
+	if d.mExitDisabled != nil {
+		want := *d.mExitDisabled
+		if !s.trayCache.mExitTouched || s.trayCache.mExitDisabled != want {
+			setMenuItemEnabled(s.mExitNode, !want)
+			s.trayCache.mExitDisabled = want
+			s.trayCache.mExitTouched = true
+		}
+	}
+
+	s.trayCache.initialized = true
+}
+
+// setMenuItemEnabled is a tiny wrapper that maps the bool we cache
+// (enabled? true/false) to the two distinct systray.MenuItem methods.
+func setMenuItemEnabled(item *systray.MenuItem, enabled bool) {
+	if enabled {
+		item.Enable()
+	} else {
+		item.Disable()
+	}
+}
+
+// setExitNodeEnabledCached toggles mExitNode via the shared trayCache
+// so the goroutine spawned by updateExitNodes (re-fired every 2s
+// during a connected session) only pushes Enable/Disable when the
+// desired state actually flipped. Without the cache the unconditional
+// Enable/Disable at the end of updateExitNodes repaints the menu on
+// every tick and steals the user's mouse hover.
+func (s *serviceClient) setExitNodeEnabledCached(enabled bool) {
+	s.trayCache.mu.Lock()
+	defer s.trayCache.mu.Unlock()
+	want := !enabled
+	if !s.trayCache.mExitTouched || s.trayCache.mExitDisabled != want {
+		setMenuItemEnabled(s.mExitNode, enabled)
+		s.trayCache.mExitDisabled = want
+		s.trayCache.mExitTouched = true
+	}
 }
 
 func (s *serviceClient) onTrayReady() {
@@ -1118,9 +1297,30 @@ func protoConfigToConfig(cfg *proto.GetConfigResponse) *profilemanager.Config {
 func (s *serviceClient) applyUpdateStateLocked(us *proto.UpdateState) {
 	s.isUpdateIconActive = us.GetAvailable()
 	v := decideUpdateMenu(runtime.GOOS, us)
-	applyUpdateMenuItem(s.mUpdateStatus, v.statusShown, v.statusTitle, v.statusTooltip)
-	applyUpdateMenuItem(s.mInstallUpdate, v.installShown, v.installTitle, v.installTooltip)
-	applyUpdateMenuItem(s.mDownloadUpdate, v.downloadShown, v.downloadTitle, v.downloadTooltip)
+	s.applyUpdateMenuItemCached("status", s.mUpdateStatus, v.statusShown, v.statusTitle, v.statusTooltip)
+	s.applyUpdateMenuItemCached("install", s.mInstallUpdate, v.installShown, v.installTitle, v.installTooltip)
+	s.applyUpdateMenuItemCached("download", s.mDownloadUpdate, v.downloadShown, v.downloadTitle, v.downloadTooltip)
+}
+
+// applyUpdateMenuItemCached delegates to applyUpdateMenuItem only when
+// the desired (shown/title/tooltip) tuple differs from the last value
+// pushed to that item. Stops the About-submenu update group from
+// flickering on every 2s poll tick (3 items × Hide/Show + SetTitle +
+// SetTooltip per tick = a lot of repaint noise on GTK/X11).
+func (s *serviceClient) applyUpdateMenuItemCached(key string, item *systray.MenuItem, show bool, title, tooltip string) {
+	s.trayCache.mu.Lock()
+	defer s.trayCache.mu.Unlock()
+
+	if s.trayCache.updateItems == nil {
+		s.trayCache.updateItems = make(map[string]updateItemState, 3)
+	}
+	last, seen := s.trayCache.updateItems[key]
+	want := updateItemState{shown: show, title: title, tooltip: tooltip}
+	if seen && last == want {
+		return
+	}
+	applyUpdateMenuItem(item, show, title, tooltip)
+	s.trayCache.updateItems[key] = want
 }
 
 // updateMenuVerdict is the per-platform decision about how the

--- a/client/ui/client_ui.go
+++ b/client/ui/client_ui.go
@@ -448,17 +448,11 @@ func (s *serviceClient) updateIcon() {
 	s.setNewIcons()
 	s.updateIndicationLock.Lock()
 	if s.connected {
-		if s.isUpdateIconActive {
-			systray.SetTemplateIcon(iconUpdateConnectedMacOS, s.icUpdateConnected)
-		} else {
-			systray.SetTemplateIcon(iconConnectedMacOS, s.icConnected)
-		}
+		key, b, m := s.connectedIcon()
+		s.setTemplateIconCached(key, m, b)
 	} else {
-		if s.isUpdateIconActive {
-			systray.SetTemplateIcon(iconUpdateDisconnectedMacOS, s.icUpdateDisconnected)
-		} else {
-			systray.SetTemplateIcon(iconDisconnectedMacOS, s.icDisconnected)
-		}
+		key, b, m := s.disconnectedIcon()
+		s.setTemplateIconCached(key, m, b)
 	}
 	s.updateIndicationLock.Unlock()
 }
@@ -687,10 +681,10 @@ func (s *serviceClient) handleSSOLogin(loginResp *proto.LoginResponse, conn prot
 }
 
 func (s *serviceClient) menuUpClick() error {
-	systray.SetTemplateIcon(iconConnectingMacOS, s.icConnecting)
+	s.setTemplateIconCached("connecting", iconConnectingMacOS, s.icConnecting)
 	conn, err := s.getSrvClient(defaultFailTimeout)
 	if err != nil {
-		systray.SetTemplateIcon(iconErrorMacOS, s.icError)
+		s.setTemplateIconCached("error", iconErrorMacOS, s.icError)
 		log.Errorf("get client: %v", err)
 		return err
 	}
@@ -721,7 +715,7 @@ func (s *serviceClient) menuUpClick() error {
 }
 
 func (s *serviceClient) menuDownClick() error {
-	systray.SetTemplateIcon(iconConnectingMacOS, s.icConnecting)
+	s.setTemplateIconCached("connecting", iconConnectingMacOS, s.icConnecting)
 	conn, err := s.getSrvClient(defaultFailTimeout)
 	if err != nil {
 		log.Errorf("get client: %v", err)
@@ -902,6 +896,8 @@ func (s *serviceClient) applyTray(d desiredTrayState) {
 
 	first := !s.trayCache.initialized
 
+	// Icon is inlined here (instead of delegating to
+	// setTemplateIconCached) so we don't double-lock the cache mutex.
 	if first || s.trayCache.iconKey != d.iconKey {
 		systray.SetTemplateIcon(d.iconMacOSBytes, d.iconBytes)
 		s.trayCache.iconKey = d.iconKey
@@ -952,6 +948,28 @@ func setMenuItemEnabled(item *systray.MenuItem, enabled bool) {
 	}
 }
 
+// setTemplateIconCached is the single point of entry for changing the
+// tray icon. Updates trayCache.iconKey so the next applyTray() sees
+// the truth — otherwise direct systray.SetTemplateIcon calls outside
+// applyTray (e.g. menuUpClick's connecting/error icons, updateIcon
+// on theme change) leave the cache stale, and the next periodic
+// applyTray for the SAME logical state would skip the SetTemplateIcon
+// and leave the wrong icon stuck on the tray. Safe to call from any
+// goroutine.
+func (s *serviceClient) setTemplateIconCached(key string, macOSBytes, bytes []byte) {
+	s.trayCache.mu.Lock()
+	defer s.trayCache.mu.Unlock()
+	if s.trayCache.initialized && s.trayCache.iconKey == key {
+		return
+	}
+	systray.SetTemplateIcon(macOSBytes, bytes)
+	s.trayCache.iconKey = key
+	// NOTE: we do NOT flip initialized=true here. applyTray's other
+	// fields (tooltip, statusTitle, etc.) still need their first-apply
+	// pass; setting initialized=true now would make those zero-valued
+	// fields look "already applied" and skip them.
+}
+
 // setExitNodeEnabledCached toggles mExitNode via the shared trayCache
 // so the goroutine spawned by updateExitNodes (re-fired every 2s
 // during a connected session) only pushes Enable/Disable when the
@@ -970,7 +988,10 @@ func (s *serviceClient) setExitNodeEnabledCached(enabled bool) {
 }
 
 func (s *serviceClient) onTrayReady() {
-	systray.SetTemplateIcon(iconDisconnectedMacOS, s.icDisconnected)
+	// Initial icon — route through the cache so the very first
+	// updateStatus tick (which will desire "disconnected") doesn't
+	// re-fire the setter unnecessarily.
+	s.setTemplateIconCached("disconnected", iconDisconnectedMacOS, s.icDisconnected)
 	systray.SetTooltip("Openzro")
 
 	// setup systray menu items

--- a/client/ui/client_ui.go
+++ b/client/ui/client_ui.go
@@ -681,10 +681,10 @@ func (s *serviceClient) handleSSOLogin(loginResp *proto.LoginResponse, conn prot
 }
 
 func (s *serviceClient) menuUpClick() error {
-	s.setTemplateIconCached("connecting", iconConnectingMacOS, s.icConnecting)
+	s.setTemplateIconCached(s.connectingIconKey(), iconConnectingMacOS, s.icConnecting)
 	conn, err := s.getSrvClient(defaultFailTimeout)
 	if err != nil {
-		s.setTemplateIconCached("error", iconErrorMacOS, s.icError)
+		s.setTemplateIconCached(s.errorIconKey(), iconErrorMacOS, s.icError)
 		log.Errorf("get client: %v", err)
 		return err
 	}
@@ -715,7 +715,7 @@ func (s *serviceClient) menuUpClick() error {
 }
 
 func (s *serviceClient) menuDownClick() error {
-	s.setTemplateIconCached("connecting", iconConnectingMacOS, s.icConnecting)
+	s.setTemplateIconCached(s.connectingIconKey(), iconConnectingMacOS, s.icConnecting)
 	conn, err := s.getSrvClient(defaultFailTimeout)
 	if err != nil {
 		log.Errorf("get client: %v", err)
@@ -852,7 +852,7 @@ func (s *serviceClient) setConnectingStatus() {
 	s.connected = false
 	exitDisabled := true
 	s.applyTray(desiredTrayState{
-		iconKey:        "connecting",
+		iconKey:        s.connectingIconKey(),
 		iconBytes:      s.icConnecting,
 		iconMacOSBytes: iconConnectingMacOS,
 		tooltip:        "Openzro (Connecting)",
@@ -869,21 +869,54 @@ func (s *serviceClient) setConnectingStatus() {
 
 // connectedIcon returns the cache key + byte slices for the connected
 // icon, branching on whether an update is currently available.
+// The theme variant is folded into the key so a light↔dark theme
+// switch (which mutates s.icConnected / s.icUpdateConnected via
+// setNewIcons without changing the logical state) invalidates the
+// cache and gets the fresh bitmap pushed to the tray.
 func (s *serviceClient) connectedIcon() (string, []byte, []byte) {
+	suffix := s.themeKeySuffix()
 	if s.isUpdateIconActive {
-		return "connected-update", s.icUpdateConnected, iconUpdateConnectedMacOS
+		return "connected-update" + suffix, s.icUpdateConnected, iconUpdateConnectedMacOS
 	}
-	return "connected", s.icConnected, iconConnectedMacOS
+	return "connected" + suffix, s.icConnected, iconConnectedMacOS
 }
 
 // disconnectedIcon returns the cache key + byte slices for the
 // disconnected icon, branching on whether an update is currently
-// available.
+// available. Theme variant is folded in — see connectedIcon.
 func (s *serviceClient) disconnectedIcon() (string, []byte, []byte) {
+	suffix := s.themeKeySuffix()
 	if s.isUpdateIconActive {
-		return "disconnected-update", s.icUpdateDisconnected, iconUpdateDisconnectedMacOS
+		return "disconnected-update" + suffix, s.icUpdateDisconnected, iconUpdateDisconnectedMacOS
 	}
-	return "disconnected", s.icDisconnected, iconDisconnectedMacOS
+	return "disconnected" + suffix, s.icDisconnected, iconDisconnectedMacOS
+}
+
+// connectingIconKey returns the cache key for the connecting icon
+// (used by menuUpClick / menuDownClick / setConnectingStatus). The
+// connecting bitmap also flips by theme, so the suffix is required.
+func (s *serviceClient) connectingIconKey() string {
+	return "connecting" + s.themeKeySuffix()
+}
+
+// errorIconKey returns the cache key for the error icon (used by
+// menuUpClick on getSrvClient failure). Also theme-variant aware.
+func (s *serviceClient) errorIconKey() string {
+	return "error" + s.themeKeySuffix()
+}
+
+// themeKeySuffix returns ":dark" or ":light" so cache keys for
+// theme-variant icons reflect which bitmap was loaded into the
+// s.ic… fields by setNewIcons. Without this, a theme switch would
+// repaint s.icConnected etc. but leave the cache key unchanged, and
+// the next setTemplateIconCached call would skip the systray
+// repaint — leaving the old theme's bitmap visible until the state
+// itself changes.
+func (s *serviceClient) themeKeySuffix() string {
+	if s.app.Settings().ThemeVariant() == theme.VariantDark {
+		return ":dark"
+	}
+	return ":light"
 }
 
 // applyTray pushes `desired` to the systray, skipping any setter
@@ -989,9 +1022,13 @@ func (s *serviceClient) setExitNodeEnabledCached(enabled bool) {
 
 func (s *serviceClient) onTrayReady() {
 	// Initial icon — route through the cache so the very first
-	// updateStatus tick (which will desire "disconnected") doesn't
-	// re-fire the setter unnecessarily.
-	s.setTemplateIconCached("disconnected", iconDisconnectedMacOS, s.icDisconnected)
+	// updateStatus tick (which will desire the disconnected icon)
+	// doesn't re-fire the setter unnecessarily. The key encodes the
+	// current theme variant so a subsequent theme switch
+	// invalidates the cache. isUpdateIconActive is false at boot,
+	// so disconnectedIcon() yields the non-update variant.
+	key, b, m := s.disconnectedIcon()
+	s.setTemplateIconCached(key, m, b)
 	systray.SetTooltip("Openzro")
 
 	// setup systray menu items

--- a/client/ui/network.go
+++ b/client/ui/network.go
@@ -353,11 +353,11 @@ func (s *serviceClient) updateExitNodes() {
 
 	s.recreateExitNodeMenu(exitNodes)
 
-	if len(s.mExitNodeItems) > 0 {
-		s.mExitNode.Enable()
-	} else {
-		s.mExitNode.Disable()
-	}
+	// Route through the tray-state cache so we don't re-fire
+	// Enable/Disable on every 2s tick (each call generates a repaint
+	// on GTK/X11 that reads as flicker — loses the user's hover/
+	// selection mid-menu).
+	s.setExitNodeEnabledCached(len(s.mExitNodeItems) > 0)
 }
 
 func (s *serviceClient) recreateExitNodeMenu(exitNodes []*proto.Network) {


### PR DESCRIPTION
## Summary

The systray menu lost the user's hover/selection on every tick on
Linux/GTK because \`updateStatus\` + \`setConnectingStatus\` +
\`setDisconnectedStatus\` + \`applyUpdateStateLocked\` +
\`updateExitNodes\` unconditionally re-fired every property setter on
each 2-second poll, regardless of whether the value changed. Each call
generates a repaint at the panel level (KDE Plasma in particular),
shifting the highlight away from whatever menu item the user was about
to click.

This PR adds a \`trayStateCache\` on \`serviceClient\` — a small
mutex-guarded record of the last value pushed to each setter — and
routes every per-tick property push through it. The setter only fires
when the desired value differs from the cached one. On a stable
connected session the cache hits 100% and the systray becomes
visually still.

## Cache coverage

Everything \`updateStatus\` (and the helpers it dispatches) would
otherwise re-push every 2s:

- \`systray.SetTemplateIcon\` — connected / connecting / disconnected,
  each branching on \`isUpdateIconActive\`
- \`systray.SetTooltip\`
- \`s.mStatus.SetTitle\` + \`s.mStatus.SetIcon\`
- \`s.mUp / s.mDown / s.mNetworks / s.mExitNode\` enable/disable
- \`applyUpdateMenuItem\` on the three About-submenu update rows
  (status / install / download), cached per-row

## Design notes

- \`initialized bool\` on the cache forces the very first apply to
  fire every setter regardless of whether the desired value matches
  the zero value — avoids the "first Enable() never fires because
  !want==false" trap.
- \`mExitNode\` has its own \`mExitTouched\` flag because it's also
  driven from \`updateExitNodes\` (outside the
  connected/connecting/disconnected switch) and may be set first
  from either path.
- The cache mutex is independent of \`serviceClient.updateIndicationLock\`
  because \`setDisconnectedStatus\` is called both inside the lock
  (normal tick path) and outside it (the RPC-failed branch at the
  top of \`updateStatus\`). A dedicated short-held mutex keeps the
  cache safe from both call sites without risk of deadlock with
  the broader indication lock.
- \`desiredTrayState\` uses \`*bool\` for \`mExitDisabled\` so the
  Connected branch can opt out of touching it (mExit is driven by
  the asynchronous \`updateExitNodes\` goroutine instead).

Behavior preserved verbatim. Only difference vs main: silently
skipped setter calls when the value didn't change. State transitions
still apply normally on the first tick that observes them.

## Test plan

- [x] \`go build ./client/ui/...\` clean
- [x] Local smoke on KDE Plasma Wayland — hover/selection no longer
      dies mid-menu; transitions still render correctly
      (Connect → Connecting → Connected → Disconnect)
- [x] Update menu items still hide/show when the daemon flips the
      update directive

## License posture

BSD-3 (client tree). No license-sensitive code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)