### PR TITLE
fix(dashboard/mfa): add lateral padding to enrollment modal stages

### DIFF
--- a/dashboard/src/modules/mfa/MFAEnrollmentModal.tsx
+++ b/dashboard/src/modules/mfa/MFAEnrollmentModal.tsx
@@ -6,8 +6,6 @@ import { setMfaSessionToken } from "@utils/mfaSession";
 import { Copy, ShieldCheck } from "lucide-react";
 import { QRCodeSVG } from "qrcode.react";
 import React, { useEffect, useState } from "react";
-import OzButton from "@/components/v2/OzButton";
-import OzInput from "@/components/v2/OzInput";
 import {
   Modal,
   ModalContent,
@@ -15,6 +13,8 @@ import {
   ModalFooter,
   ModalTitle,
 } from "@/components/modal/Modal";
+import OzButton from "@/components/v2/OzButton";
+import OzInput from "@/components/v2/OzInput";
 
 // MFAEnrollmentModal walks the user through voluntary TOTP enrollment
 // in three stages: QR-scan → 6-digit verify → backup-codes display.
@@ -135,38 +135,46 @@ export default function MFAEnrollmentModal({
       <ModalContent maxWidthClass="max-w-[480px]">
         {stage === "qr" && (
           <>
-            <ModalTitle>Set up two-factor authentication</ModalTitle>
-            <ModalDescription>
-              Scan the QR code with your authenticator app (Google
-              Authenticator, Authy, 1Password, Bitwarden). The app
-              generates a fresh 6-digit code every 30 seconds.
-            </ModalDescription>
-            <div className="mt-4 flex flex-col items-center gap-4">
-              {otpauthURL ? (
-                <div className="rounded-lg bg-white p-4">
-                  <QRCodeSVG value={otpauthURL} size={192} level="M" />
-                </div>
-              ) : (
-                <div className="h-[224px] w-[224px] animate-pulse rounded-lg bg-oz2-bg-sunken" />
-              )}
-              {secret && (
-                <details className="w-full text-[12px] text-oz2-text-muted">
-                  <summary className="cursor-pointer select-none">
-                    Can&apos;t scan? Enter this code manually.
-                  </summary>
-                  <div className="mt-2 flex items-center gap-2 rounded-md bg-oz2-bg-sunken p-3 font-mono text-[13px] text-oz2-text">
-                    <span className="flex-1 break-all">{secret}</span>
-                    <button
-                      type="button"
-                      className="rounded-md p-1 hover:bg-oz2-bg-soft"
-                      onClick={() => navigator.clipboard.writeText(secret)}
-                      title="Copy secret"
-                    >
-                      <Copy size={14} />
-                    </button>
+            {/* px-8 mirrors ModalFooter's horizontal padding so the
+                title, description, and QR block don't sit flush
+                against the modal's borders. ModalContent itself
+                intentionally has no horizontal padding so every
+                modal can pick its own — see DnsZoneModal /
+                NameserverModal for the same convention. */}
+            <div className="px-8">
+              <ModalTitle>Set up two-factor authentication</ModalTitle>
+              <ModalDescription className="mt-2">
+                Scan the QR code with your authenticator app (Google
+                Authenticator, Authy, 1Password, Bitwarden). The app
+                generates a fresh 6-digit code every 30 seconds.
+              </ModalDescription>
+              <div className="mt-4 flex flex-col items-center gap-4">
+                {otpauthURL ? (
+                  <div className="rounded-lg bg-white p-4">
+                    <QRCodeSVG value={otpauthURL} size={192} level="M" />
                   </div>
-                </details>
-              )}
+                ) : (
+                  <div className="h-[224px] w-[224px] animate-pulse rounded-lg bg-oz2-bg-sunken" />
+                )}
+                {secret && (
+                  <details className="w-full text-[12px] text-oz2-text-muted">
+                    <summary className="cursor-pointer select-none">
+                      Can&apos;t scan? Enter this code manually.
+                    </summary>
+                    <div className="mt-2 flex items-center gap-2 rounded-md bg-oz2-bg-sunken p-3 font-mono text-[13px] text-oz2-text">
+                      <span className="flex-1 break-all">{secret}</span>
+                      <button
+                        type="button"
+                        className="rounded-md p-1 hover:bg-oz2-bg-soft"
+                        onClick={() => navigator.clipboard.writeText(secret)}
+                        title="Copy secret"
+                      >
+                        <Copy size={14} />
+                      </button>
+                    </div>
+                  </details>
+                )}
+              </div>
             </div>
             <ModalFooter>
               <OzButton variant="ghost" type="button" onClick={onClose}>
@@ -186,25 +194,27 @@ export default function MFAEnrollmentModal({
 
         {stage === "verify" && (
           <>
-            <ModalTitle>Verify your authenticator</ModalTitle>
-            <ModalDescription>
-              Enter the 6-digit code from your authenticator app to
-              confirm enrollment.
-            </ModalDescription>
-            <div className="mt-4">
-              <OzInput
-                value={code}
-                onChange={(e) =>
-                  setCode(e.target.value.replace(/[^0-9]/g, "").slice(0, 6))
-                }
-                placeholder="123456"
-                inputMode="numeric"
-                pattern="[0-9]{6}"
-                maxLength={6}
-                error={codeError}
-                autoFocus
-                data-cy="mfa-verify-code"
-              />
+            <div className="px-8">
+              <ModalTitle>Verify your authenticator</ModalTitle>
+              <ModalDescription className="mt-2">
+                Enter the 6-digit code from your authenticator app to
+                confirm enrollment.
+              </ModalDescription>
+              <div className="mt-4">
+                <OzInput
+                  value={code}
+                  onChange={(e) =>
+                    setCode(e.target.value.replace(/[^0-9]/g, "").slice(0, 6))
+                  }
+                  placeholder="123456"
+                  inputMode="numeric"
+                  pattern="[0-9]{6}"
+                  maxLength={6}
+                  error={codeError}
+                  autoFocus
+                  data-cy="mfa-verify-code"
+                />
+              </div>
             </div>
             <ModalFooter>
               <OzButton
@@ -228,41 +238,43 @@ export default function MFAEnrollmentModal({
 
         {stage === "backup-codes" && (
           <>
-            <ModalTitle className="flex items-center gap-2">
-              <ShieldCheck size={18} className="text-emerald-500" />
-              Save your backup codes
-            </ModalTitle>
-            <ModalDescription>
-              Store these 10 single-use codes somewhere safe — a password
-              manager, a printout in a locked drawer. Each code works
-              once, in place of a TOTP code, if you lose access to your
-              authenticator app. <strong>You won&apos;t see them again.</strong>
-            </ModalDescription>
-            <div className="mt-4 grid grid-cols-2 gap-2 rounded-md bg-oz2-bg-sunken p-4 font-mono text-[13px]">
-              {backupCodes.map((c) => (
-                <div key={c} className="text-oz2-text">
-                  {c}
-                </div>
-              ))}
+            <div className="px-8">
+              <ModalTitle className="flex items-center gap-2">
+                <ShieldCheck size={18} className="text-emerald-500" />
+                Save your backup codes
+              </ModalTitle>
+              <ModalDescription className="mt-2">
+                Store these 10 single-use codes somewhere safe — a password
+                manager, a printout in a locked drawer. Each code works
+                once, in place of a TOTP code, if you lose access to your
+                authenticator app. <strong>You won&apos;t see them again.</strong>
+              </ModalDescription>
+              <div className="mt-4 grid grid-cols-2 gap-2 rounded-md bg-oz2-bg-sunken p-4 font-mono text-[13px]">
+                {backupCodes.map((c) => (
+                  <div key={c} className="text-oz2-text">
+                    {c}
+                  </div>
+                ))}
+              </div>
+              <button
+                type="button"
+                className="mt-2 inline-flex items-center gap-1 text-[12px] text-oz2-text-muted hover:text-oz2-text"
+                onClick={() =>
+                  navigator.clipboard.writeText(backupCodes.join("\n"))
+                }
+              >
+                <Copy size={12} /> Copy all
+              </button>
+              <label className="mt-4 flex items-start gap-2 text-[13px] text-oz2-text-muted">
+                <input
+                  type="checkbox"
+                  checked={savedConfirmed}
+                  onChange={(e) => setSavedConfirmed(e.target.checked)}
+                  className="mt-1"
+                />
+                <span>I&apos;ve saved these codes somewhere safe.</span>
+              </label>
             </div>
-            <button
-              type="button"
-              className="mt-2 inline-flex items-center gap-1 text-[12px] text-oz2-text-muted hover:text-oz2-text"
-              onClick={() =>
-                navigator.clipboard.writeText(backupCodes.join("\n"))
-              }
-            >
-              <Copy size={12} /> Copy all
-            </button>
-            <label className="mt-4 flex items-start gap-2 text-[13px] text-oz2-text-muted">
-              <input
-                type="checkbox"
-                checked={savedConfirmed}
-                onChange={(e) => setSavedConfirmed(e.target.checked)}
-                className="mt-1"
-              />
-              <span>I&apos;ve saved these codes somewhere safe.</span>
-            </label>
             <ModalFooter>
               <OzButton
                 variant="primary"

--- a/dashboard/src/modules/mfa/MFAEnrollmentModal.tsx
+++ b/dashboard/src/modules/mfa/MFAEnrollmentModal.tsx
@@ -141,7 +141,7 @@ export default function MFAEnrollmentModal({
                 intentionally has no horizontal padding so every
                 modal can pick its own — see DnsZoneModal /
                 NameserverModal for the same convention. */}
-            <div className="px-8">
+            <div className="px-8 pb-6">
               <ModalTitle>Set up two-factor authentication</ModalTitle>
               <ModalDescription className="mt-2">
                 Scan the QR code with your authenticator app (Google
@@ -194,7 +194,7 @@ export default function MFAEnrollmentModal({
 
         {stage === "verify" && (
           <>
-            <div className="px-8">
+            <div className="px-8 pb-6">
               <ModalTitle>Verify your authenticator</ModalTitle>
               <ModalDescription className="mt-2">
                 Enter the 6-digit code from your authenticator app to
@@ -238,7 +238,7 @@ export default function MFAEnrollmentModal({
 
         {stage === "backup-codes" && (
           <>
-            <div className="px-8">
+            <div className="px-8 pb-6">
               <ModalTitle className="flex items-center gap-2">
                 <ShieldCheck size={18} className="text-emerald-500" />
                 Save your backup codes


### PR DESCRIPTION
## Summary

\`ModalContent\` only carries \`py-6\`; horizontal padding is
intentionally the modal's responsibility (so each surface can pick
its own inset). \`MFAEnrollmentModal\` wasn't passing any — title,
description, QR code, verify input, and backup-codes grid all sat
flush against the left/right borders, with only \`ModalFooter\`'s
\`px-8\` looking correctly inset.

Wrap each stage's title/description/body in a single
\`<div className=\"px-8\">\` so the content lines up with the footer
exactly, matching what \`DnsZoneModal\` / \`NameserverModal\` already
do. Also bumps the descriptions to \`mt-2\` for breathing room under
the title (they had no top margin before).

No behavior change — purely visual padding fix. Three stages
covered: QR scan, code verify, backup-codes display.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [ ] Manual: open Profile → Security → enrollment modal walks through
      all 3 stages with consistent padding on all 4 sides

🤖 Generated with [Claude Code](https://claude.com/claude-code)