### PR TITLE
fix(dashboard/mfa): clear X-MFA-Token sessionStorage on logout

### DIFF
--- a/dashboard/src/auth/SessionLost.tsx
+++ b/dashboard/src/auth/SessionLost.tsx
@@ -2,6 +2,7 @@ import { useOidc } from "@axa-fr/react-oidc";
 import Button from "@components/Button";
 import Paragraph from "@components/Paragraph";
 import loadConfig from "@utils/config";
+import { clearMfaSessionToken } from "@utils/mfaSession";
 import { LogIn } from "lucide-react";
 import * as React from "react";
 import { useEffect, useRef } from "react";
@@ -23,6 +24,11 @@ export const SessionLost = () => {
   useEffect(() => {
     if (triggered.current) return;
     triggered.current = true;
+    // Clear the stale X-MFA-Token so the re-login flow forces a
+    // fresh TOTP challenge — without this the token in sessionStorage
+    // would silently re-elevate the next session (see logout() in
+    // UsersProvider.tsx for the full rationale).
+    clearMfaSessionToken();
     // Empty post-logout target = the dashboard origin. After Dex
     // logs the user out, the dashboard root re-arms the OIDC flow
     // and pushes them through the login form again.

--- a/dashboard/src/contexts/UsersProvider.tsx
+++ b/dashboard/src/contexts/UsersProvider.tsx
@@ -2,6 +2,7 @@ import { useOidc } from "@axa-fr/react-oidc";
 import FullScreenLoading from "@components/ui/FullScreenLoading";
 import useFetchApi from "@utils/api";
 import loadConfig from "@utils/config";
+import { clearMfaSessionToken } from "@utils/mfaSession";
 import React, { useMemo } from "react";
 import { useApplicationContext } from "@/contexts/ApplicationProvider";
 import PermissionsProvider from "@/contexts/PermissionsProvider";
@@ -90,6 +91,17 @@ export const useLoggedInUser = () => {
   const isOwnerOrAdmin = isOwner || isAdmin;
 
   const logout = async () => {
+    // Clear the X-MFA-Token from sessionStorage BEFORE the OIDC
+    // logout redirect. If we leave the stale token in place, a
+    // subsequent login in the same tab would silently re-elevate the
+    // session: the new JWT's hash equals the previous hash often
+    // enough (Dex sometimes short-circuits issuance within its token
+    // lifetime), so MFASessionValid validates an mfa_session_token
+    // bound to a session the operator already left. Bypassing the
+    // re-challenge defeats the per-session model from issue #31.
+    // Always-clear is safe — at worst the operator pays one extra
+    // TOTP entry next login, which is the intended behavior anyway.
+    clearMfaSessionToken();
     return oidcLogout("/", { client_id: config.clientId }).then(() => {
       setGlobalApiParams?.({});
     });


### PR DESCRIPTION
## Summary

The dashboard's logout path
(\`UsersProvider.useLoggedInUser.logout\`) and the OIDC session-lost
fallback (\`auth/SessionLost\`) both went straight to \`oidcLogout()\`
without clearing the \`openzro.mfa_session_token\` sessionStorage key
set by \`setMfaSessionToken\` on enrollment / challenge.

When the operator hit logout + login in the same browser tab,
sessionStorage survived (it only clears on tab close). The next
session would send the stale \`X-MFA-Token\` alongside the fresh JWT
Authorization. If Dex happened to short-circuit and reissue a JWT
whose hash matched the previous session's \`jwtSessionID\` (the
post-enrollment short window where it can return a still-valid
existing id_token), \`MFASessionValid\` validated the orphan token
and the gate returned **Pass** — silently re-elevating a session the
operator had explicitly left, defeating the per-session verification
model from issue #31.

## Symptom in the lab

After enabling \`mfa_enforce_local\` and enrolling the local
\`admin@app.openzro.io\` user, the operator clicked logout from the
sidebar dropdown and immediately logged in again. The dashboard
landed on \`/peers\` without prompting for the TOTP code. The
management gate logged no challenge — the orphan
\`mfa_session_token\` had already silently passed the check.

## Fix

Call \`clearMfaSessionToken()\` in both paths **before** the OIDC
logout redirect. Always-clear is safe: at worst the operator pays
one extra TOTP entry on next login, which is the intended behavior
under per-session enforcement.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean
- [ ] Manual smoke: enroll → logout → login → confirm \`/mfa/challenge\`
      fires
- [ ] Same flow with tab close in between — must continue to fire
      challenge (closing the tab already clears sessionStorage so
      behavior is unchanged here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)