### PR TITLE
fix(mgmt/mfa): default ConnectorID="local" when JWT lacks federated_claims

### DIFF
--- a/management/server/auth/jwt/extractor.go
+++ b/management/server/auth/jwt/extractor.go
@@ -136,12 +136,22 @@ func (c *ClaimsExtractor) ToUserAuth(token *jwt.Token) (nbcontext.UserAuth, erro
 	// (issue #31) to distinguish "local" (Dex staticPasswords, no
 	// IdP-side MFA, openZro TOTP is the primary second factor) from
 	// federated providers (TOTP is an optional redundancy layer on
-	// top of the IdP's own MFA). Absent on PATs / non-Dex IdPs that
-	// don't emit the claim — Empty string is the natural default and
-	// the gate's resolveMFAEnforcement treats anything-other-than-
-	// "local" as the federated branch.
+	// top of the IdP's own MFA).
+	//
+	// Dex emits federated_claims for *external* connectors (google,
+	// github, oidc, oauth, etc.) but NOT for the bundled staticPasswords
+	// connector — and even when it does, the claim only ships on the
+	// id_token, not the access_token the dashboard sends as Bearer.
+	// Without a fallback, every staticPasswords login would arrive
+	// here with ConnectorID="" and resolveMFAEnforcement would route
+	// it to the federated branch, silently bypassing MFAEnforceLocal.
+	// Default to "local" when the claim is absent so the gate honours
+	// the operator's local-enforcement toggle. PATs are screened by
+	// IsPAT upstream and never reach resolveMFAEnforcement, so this
+	// default has no impact on them.
+	userAuth.ConnectorID = "local"
 	if fc, ok := claims["federated_claims"].(map[string]any); ok {
-		if cid, ok := fc["connector_id"].(string); ok {
+		if cid, ok := fc["connector_id"].(string); ok && cid != "" {
 			userAuth.ConnectorID = cid
 		}
 	}

--- a/management/server/auth/jwt/extractor_test.go
+++ b/management/server/auth/jwt/extractor_test.go
@@ -1,0 +1,84 @@
+package jwt
+
+import (
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// Regression: Dex's staticPasswords connector does not emit
+// federated_claims on the access_token the dashboard sends as Bearer.
+// Before the fix, ConnectorID arrived empty and resolveMFAEnforcement
+// routed staticPasswords logins to the federated branch, silently
+// bypassing MFAEnforceLocal (issue #31). The extractor now defaults
+// ConnectorID to "local" when the claim is absent so the gate honours
+// the operator's local-enforcement toggle.
+func TestClaimsExtractor_ConnectorID(t *testing.T) {
+	tests := []struct {
+		name   string
+		claims jwt.MapClaims
+		want   string
+	}{
+		{
+			name: "federated_claims absent defaults to local",
+			claims: jwt.MapClaims{
+				"sub": "user-1",
+			},
+			want: "local",
+		},
+		{
+			name: "federated_claims present without connector_id defaults to local",
+			claims: jwt.MapClaims{
+				"sub":              "user-1",
+				"federated_claims": map[string]any{"user_id": "x"},
+			},
+			want: "local",
+		},
+		{
+			name: "federated_claims connector_id empty string defaults to local",
+			claims: jwt.MapClaims{
+				"sub":              "user-1",
+				"federated_claims": map[string]any{"connector_id": ""},
+			},
+			want: "local",
+		},
+		{
+			name: "federated_claims connector_id local is honoured",
+			claims: jwt.MapClaims{
+				"sub":              "user-1",
+				"federated_claims": map[string]any{"connector_id": "local"},
+			},
+			want: "local",
+		},
+		{
+			name: "federated_claims connector_id google is honoured",
+			claims: jwt.MapClaims{
+				"sub":              "user-1",
+				"federated_claims": map[string]any{"connector_id": "google"},
+			},
+			want: "google",
+		},
+		{
+			name: "federated_claims connector_id github is honoured",
+			claims: jwt.MapClaims{
+				"sub":              "user-1",
+				"federated_claims": map[string]any{"connector_id": "github"},
+			},
+			want: "github",
+		},
+	}
+
+	extractor := NewClaimsExtractor()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			token := &jwt.Token{Claims: tc.claims}
+			userAuth, err := extractor.ToUserAuth(token)
+			if err != nil {
+				t.Fatalf("ToUserAuth: %v", err)
+			}
+			if userAuth.ConnectorID != tc.want {
+				t.Fatalf("ConnectorID: got %q want %q", userAuth.ConnectorID, tc.want)
+			}
+		})
+	}
+}

--- a/management/server/context/auth.go
+++ b/management/server/context/auth.go
@@ -46,14 +46,15 @@ type UserAuth struct {
 	IsPAT bool
 
 	// ConnectorID is the Dex connector that authenticated this JWT,
-	// extracted from `federated_claims.connector_id`. Dex's bundled
-	// staticPasswords connector emits the literal value "local";
-	// federated providers (Okta, Google Workspace, Microsoft Entra,
-	// Authentik, Keycloak, etc.) emit their configured connector id.
-	// Used by the MFA gate (issue #31) to apply MFAEnforceLocal vs.
-	// MFAEnforceFederated. Empty when the JWT didn't carry
-	// federated_claims (PAT auth, legacy tokens, non-Dex IdPs that
-	// don't emit the claim).
+	// extracted from `federated_claims.connector_id`. Federated
+	// providers (Okta, Google Workspace, Microsoft Entra, Authentik,
+	// Keycloak, etc.) emit their configured connector id. Dex's
+	// bundled staticPasswords connector does NOT emit federated_claims
+	// on access tokens, so the extractor defaults to "local" when the
+	// claim is absent — the gate (issue #31) therefore routes
+	// staticPasswords logins to MFAEnforceLocal and external providers
+	// to MFAEnforceFederated. PATs short-circuit the gate via IsPAT
+	// before this value is consulted.
 	ConnectorID string
 }
 

--- a/management/server/mfa.go
+++ b/management/server/mfa.go
@@ -431,7 +431,10 @@ func (am *DefaultAccountManager) MFAGateForRequest(
 // resolveMFAEnforcement maps (connector_id, settings) to a yes/no
 // enforcement decision. connector_id == "local" follows the
 // MFAEnforceLocal toggle; anything else (federated providers)
-// follows MFAEnforceFederated.
+// follows MFAEnforceFederated. The extractor defaults connector_id
+// to "local" when the JWT carries no federated_claims, so absence
+// of the claim is treated as a staticPasswords login (see
+// extractor.go for the rationale).
 func (am *DefaultAccountManager) resolveMFAEnforcement(connectorID string, settings *types.Settings) bool {
 	if settings == nil {
 		return false


### PR DESCRIPTION
## Summary

- Default `userAuth.ConnectorID` to `"local"` in the JWT extractor when the token carries no `federated_claims` (or carries the map without a `connector_id`).
- Update the surrounding comments in [extractor.go](management/server/auth/jwt/extractor.go), [context/auth.go](management/server/context/auth.go), and [mfa.go](management/server/mfa.go) to describe the new contract.
- Add `extractor_test.go` with six regression cases covering: claim absent, claim present without `connector_id`, empty `connector_id`, and explicit external connectors (`local`, `google`, `github`).

## Why

`MFAEnforceLocal` (issue #31) is supposed to apply only to staticPasswords logins, identified by `federated_claims.connector_id == "local"`. In practice Dex emits `federated_claims` only for *external* connectors, and even then only on the `id_token` — never on the `access_token` the dashboard sends as Bearer. Every staticPasswords login therefore arrived at the gate with `ConnectorID=""` and `resolveMFAEnforcement` routed it to the federated branch (`MFAEnforceFederated`). With only the local toggle enabled, the gate returned `Pass` and the operator's policy was silently bypassed — to force MFA on a staticPasswords account, operators had to enable BOTH toggles, which also enforced MFA on every federated provider that already had IdP-side MFA.

Treating the absence of `federated_claims` as a staticPasswords login matches the only source the claim ever comes from (Dex external connectors) and restores the intended semantics. PATs short-circuit the gate via `IsPAT` upstream, so the default has no impact on non-interactive auth.

## Repro

1. Deploy `MFAEnforceLocal=true`, `MFAEnforceFederated=false`.
2. Log into the dashboard as a Dex staticPasswords (`local`) user.
3. Expected: redirected to MFA enrollment / challenge.
4. Actual (before this fix): no challenge — request passes straight through.

Manually verified in the lab on a 2-replica deployment: with only the local toggle on, the admin login now correctly redirects to the OTP challenge.

## Test plan

- [x] `go test ./management/server/auth/jwt/...` — 6/6 regression cases green
- [x] `go test ./management/server/mfa/...` — package still green (no behavioural change)
- [x] Manual smoke on the lab: image built from this branch, mgmt rolled, OTP prompt confirmed on staticPasswords login with `MFAEnforceFederated=false`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)