### PR TITLE
fix(dashboard): hide sidebar Overview from restricted users

### DIFF
--- a/dashboard/src/layouts/V2DashboardLayout.tsx
+++ b/dashboard/src/layouts/V2DashboardLayout.tsx
@@ -527,8 +527,9 @@ function buildSidebarSections(
   // so the sidebar reflects exactly what each landing route will let
   // the operator see. Items with no page-level gate (Overview, Peers,
   // Control Center, Documentation) follow the upstream Navigation.tsx
-  // convention: Peers is hidden for restricted users (peer-only
-  // accounts), the rest stay visible.
+  // convention: Peers and Overview are hidden for restricted users
+  // (peer-only accounts whose only interactive surface is the
+  // PeersBlockedView landing), the rest stay visible.
   const raw: { id: string; label: string; items: sidebarItemSpec[] }[] = [
     {
       id: "workspace",
@@ -540,7 +541,7 @@ function buildSidebarSections(
           icon: NAV_ICONS.home,
           active: matches("/overview"),
           onClick: () => go("/overview"),
-          visible: true,
+          visible: !isRestricted,
         },
         {
           id: "peers",


### PR DESCRIPTION
## Summary

- Gate the sidebar **Overview** item on `!isRestricted` (was `true`), so peer-only accounts no longer see a top-level navigation entry that lands on a 404 — the only navigable section they had left.
- Refresh the surrounding comment so the "Items with no page-level gate" rule names both Peers and Overview as hidden for restricted users.

## Why

Restricted users (peer-only) already had Peers, Networks, Network Routes, and DNS hidden because each of those page-level gates returns the restricted view; only Overview was hardcoded `visible: true`. `/overview` returns 404 today (ADR-0016 explicitly accepts that until the Overview screen ships), so the entry exposed restricted users to an actively broken landing inside their only navigable section.

The fix mirrors the convention already used by the Peers item one line below in [V2DashboardLayout.tsx](dashboard/src/layouts/V2DashboardLayout.tsx).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [ ] Manual smoke (lab): log in as a peer-only user → sidebar shows only Documentation + the Account section the role allows (no Overview, no Peers, no Networks/Routes/DNS); log in as admin → Overview still listed.
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)