### PR TITLE
fix(dashboard): restore Profile Settings entry for restricted users

### DIFF
--- a/dashboard/src/app/(v2-dashboard)/team/user/page.tsx
+++ b/dashboard/src/app/(v2-dashboard)/team/user/page.tsx
@@ -51,26 +51,43 @@ export default function UserPage() {
   const queryParameter = useSearchParams();
   const userId = queryParameter.get("id");
   const { permission } = usePermissions();
+  const { loggedInUser, isOwnerOrAdmin } = useLoggedInUser();
   const isServiceUser = queryParameter.get("service_user") === "true";
+
+  // Self-profile view doesn't need `users.read`. Restricted accounts
+  // hit this page from the sidebar "Profile Settings" entry so they
+  // can enrol MFA, manage their own PATs, etc. /users would 403 for
+  // them, so rely on loggedInUser (sourced from /users/current, which
+  // has no permission gate) and gate the list fetch on canListUsers
+  // to suppress the request altogether for restricted users.
+  const isSelf = !!loggedInUser && loggedInUser.id === userId;
+  const canListUsers = permission.users.read;
   const { data: users, isLoading } = useFetchApi<User[]>(
     `/users?service_user=${isServiceUser}`,
+    false,
+    true,
+    canListUsers,
   );
-  const { isOwnerOrAdmin } = useLoggedInUser();
 
   const user = useMemo(() => {
+    if (isSelf) return loggedInUser;
     return users?.find((u) => u.id === userId);
-  }, [users, userId]);
+  }, [users, userId, isSelf, loggedInUser]);
 
   useRedirect("/team/users", false, !userId);
 
   const userGroups = useGroupIdsToGroups(user?.auto_groups);
 
-  if (!permission.users.read) {
+  if (!canListUsers && !isSelf) {
     return (
       <div className="space-y-6 p-8">
         <RestrictedAccess page={"User Information"} />
       </div>
     );
+  }
+
+  if (isSelf && user) {
+    return <UserOverview user={user} initialGroups={[]} />;
   }
 
   if (!isOwnerOrAdmin && user && !isLoading) {

--- a/dashboard/src/app/(v2-dashboard)/team/user/page.tsx
+++ b/dashboard/src/app/(v2-dashboard)/team/user/page.tsx
@@ -86,7 +86,12 @@ export default function UserPage() {
     );
   }
 
-  if (isSelf && user) {
+  // Restricted self-viewers don't have users.read so userGroups never
+  // resolves — fall back to []. Admin/owner self-viewers still need
+  // the resolved userGroups (UserOverview renders the editable
+  // Auto-assigned Groups card for them; an empty initialGroups +
+  // Save would clear auto_groups on the server).
+  if (isSelf && !isOwnerOrAdmin && user) {
     return <UserOverview user={user} initialGroups={[]} />;
   }
 

--- a/dashboard/src/layouts/V2DashboardLayout.tsx
+++ b/dashboard/src/layouts/V2DashboardLayout.tsx
@@ -780,7 +780,6 @@ function UserFooter({ collapsed = false }: { collapsed?: boolean }) {
   const router = useRouter();
   const { loggedInUser, logout } = useLoggedInUser();
   const { user } = useApplicationContext();
-  const { isRestricted } = usePermissions();
 
   const display = loggedInUser?.name || loggedInUser?.email || "—";
   const role = loggedInUser?.role || "user";
@@ -806,7 +805,6 @@ function UserFooter({ collapsed = false }: { collapsed?: boolean }) {
         <UserMenuContent
           loggedInUser={loggedInUser}
           user={user}
-          isRestricted={isRestricted}
           onClose={() => setOpen(false)}
           logout={logout}
           router={router}
@@ -862,7 +860,6 @@ function UserFooter({ collapsed = false }: { collapsed?: boolean }) {
         <UserMenuContent
           loggedInUser={loggedInUser}
           user={user}
-          isRestricted={isRestricted}
           onClose={() => setOpen(false)}
           logout={logout}
           router={router}
@@ -876,14 +873,12 @@ function UserFooter({ collapsed = false }: { collapsed?: boolean }) {
 function UserMenuContent({
   loggedInUser,
   user,
-  isRestricted,
   onClose,
   logout,
   router,
 }: {
   loggedInUser: ReturnType<typeof useLoggedInUser>["loggedInUser"];
   user: ReturnType<typeof useApplicationContext>["user"];
-  isRestricted: boolean;
   onClose: () => void;
   logout: () => Promise<void>;
   router: ReturnType<typeof useRouter>;
@@ -907,7 +902,7 @@ function UserMenuContent({
         </div>
       </DropdownMenuLabel>
       <DropdownMenuSeparator />
-      {!isRestricted && loggedInUser && (
+      {loggedInUser && (
         <DropdownMenuItem
           onClick={() => {
             onClose();


### PR DESCRIPTION
## Summary

- Drop the `!isRestricted` predicate hiding the **Profile Settings** dropdown item, so any logged-in user can reach their own profile.
- Bypass `permission.users.read` on [team/user/page.tsx](dashboard/src/app/(v2-dashboard)/team/user/page.tsx) when the requested `userId == loggedInUser.id`. Skip the `/users` list fetch for restricted self-viewers (it would 403) and resolve `user` from `loggedInUser` (sourced from `/users/current`, which has no permission gate).
- Remove the now-unused `isRestricted` prop from `UserMenuContent`.

## Why

Restricted users (peer-only accounts) had the Profile Settings entry hidden because `/team/user` returns Restricted Access without `users.read`. The side effect was that restricted accounts had no UI surface for:

- **Voluntary MFA enrolment** (before the admin flips the enforcement toggle — the forced-enrolment redirect handles enrolment *after*, but a user that wants TOTP today had no entry point).
- **Regenerating backup codes** after exhausting them.
- **Creating / listing their own PATs** when `permission.pats.read`.

UserOverview already gates editable sections on `isOwnerOrAdmin` / `permission.users.update` and the Cancel/Save header on `!isUser`, so the read-only render for restricted self-viewers degrades cleanly — they see their nameplate + a disabled role selector + the **MFASection** and their PATs section.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on both files — clean
- [ ] Manual smoke (lab): log in as a peer-only user → "Profile Settings" appears in the avatar menu → clicking it opens `/team/user?id=<self>` with avatar + name + disabled role + **MFASection enrollable** + PATs section (if `permission.pats.read`); admin flow unchanged.
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)