### PR TITLE
fix(dashboard/mfa): single-flight the 403 redirect to /mfa/{enroll,challenge}

### DIFF
--- a/dashboard/src/utils/api.tsx
+++ b/dashboard/src/utils/api.tsx
@@ -36,6 +36,11 @@ type RequestOptions = {
 
 export type Params = Record<string, string | number | boolean>;
 
+// Module-scoped lock so parallel 403s from a single login (users,
+// groups, peers, settings, …) can only trigger ONE MFA navigation —
+// see the comment at the assign() call site in apiRequest.
+let mfaRedirectInFlight = false;
+
 async function apiRequest<T>(
   oidcFetch: (input: RequestInfo, init?: RequestInit) => Promise<Response>,
   method: Method,
@@ -70,6 +75,17 @@ async function apiRequest<T>(
       // dropped (the caller's .catch will fire) — after the user
       // completes MFA, the dashboard reloads naturally and the next
       // request rides the X-MFA-Token header.
+      //
+      // A fresh login fires several useFetchApi calls in parallel
+      // (users, groups, peers, settings, …); each lands a 403 with
+      // an enroll/challenge token, and without the in-flight guard
+      // every response would race window.location.assign, causing
+      // visible flicker as the browser starts then cancels
+      // navigations. The module-level flag clamps to a single
+      // assign per page lifecycle; the full reload that follows
+      // resets it naturally. The pathname check covers the case
+      // where a 403 arrives while the user is already on the
+      // destination page (e.g. polling on /mfa/challenge itself).
       if (res.status === 403 && body?.token) {
         if (body.mfa_required || body.mfa_enrollment_required) {
           setMfaRedirectToken(body.token);
@@ -77,7 +93,20 @@ async function apiRequest<T>(
             const dest = body.mfa_enrollment_required
               ? "/mfa/enroll"
               : "/mfa/challenge";
-            window.location.assign(dest);
+            const onDest = window.location.pathname === dest;
+            if (!mfaRedirectInFlight && !onDest) {
+              mfaRedirectInFlight = true;
+              // Mask the current page synchronously so parallel 403s
+              // that resolve between this assign() and the browser
+              // actually starting the navigation cannot drive
+              // visible re-renders (every other SWR fetch on the
+              // page also lands a 403 right now). Cleared naturally
+              // by the full page load that follows.
+              if (document.body) {
+                document.body.style.visibility = "hidden";
+              }
+              window.location.assign(dest);
+            }
           }
           return Promise.reject({
             code: 403,


### PR DESCRIPTION
## Summary

- Module-level `mfaRedirectInFlight` flag so parallel 403s from a single login only schedule **one** `window.location.assign` per page lifecycle.
- Skip the assign when the pathname already matches the destination (e.g. a 403 polled while the user is already on `/mfa/challenge`).
- Set `document.body.style.visibility = "hidden"` synchronously the moment the assign fires so the gap between schedule and navigation-start cannot show flicker from sibling SWR rejections resolving in the same tick.

## Why

A fresh login fires several `useFetchApi` calls in parallel — users, groups, peers, settings, peer-count, … . When the MFA gate is on, every one of them lands a 403 with `mfa_required` or `mfa_enrollment_required`, and each one independently called `window.location.assign(dest)`. The browser starts then cancels navigations as more 403s arrive, and the page keeps re-rendering in between because SWR fires setState on the failing keys — the user sees several visible flashes before the destination page finally takes over.

Lab-confirmed: with this patch, login as a restricted user with `MFAEnforceLocal=true` and no enrolled TOTP transitions from `/peers` → `/mfa/enroll` (or `/mfa/challenge` when already enrolled) **without intermediate flicker**.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] Manual smoke (lab): fresh login as a restricted user → single navigation to the MFA interstitial, no flicker
- [x] Manual smoke: same user already enrolled but `mfa_session_token` cleared → single navigation to `/mfa/challenge`, no flicker
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)