### PR TITLE
fix(mgmt/mfa): extract ConnectorID from the Dex `sub` protobuf

### DIFF
--- a/management/server/auth/jwt/extractor.go
+++ b/management/server/auth/jwt/extractor.go
@@ -156,7 +156,7 @@ func (c *ClaimsExtractor) ToUserAuth(token *jwt.Token) (nbcontext.UserAuth, erro
 	//   3. Empty string. Non-Dex IdPs (Auth0, Keycloak, …) emit
 	//      UUID-style subs that don't parse as a Dex protobuf;
 	//      resolveMFAEnforcement then treats the absence as the
-	//      federated branch — same legacy behaviour, no regression
+	//      federated branch — same legacy behavior, no regression
 	//      for those deployments.
 	if fc, ok := claims["federated_claims"].(map[string]any); ok {
 		if cid, ok := fc["connector_id"].(string); ok {

--- a/management/server/auth/jwt/extractor.go
+++ b/management/server/auth/jwt/extractor.go
@@ -1,12 +1,14 @@
 package jwt
 
 import (
+	"encoding/base64"
 	"errors"
 	"net/url"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 	log "github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/encoding/protowire"
 
 	nbcontext "github.com/openzro/openzro/management/server/context"
 )
@@ -131,22 +133,85 @@ func (c *ClaimsExtractor) ToUserAuth(token *jwt.Token) (nbcontext.UserAuth, erro
 		}
 	}
 
-	// federated_claims.connector_id is the Dex-emitted identifier for
-	// the connector that authenticated this JWT. Used by the MFA gate
-	// (issue #31) to distinguish "local" (Dex staticPasswords, no
-	// IdP-side MFA, openZro TOTP is the primary second factor) from
-	// federated providers (TOTP is an optional redundancy layer on
-	// top of the IdP's own MFA). Absent on PATs / non-Dex IdPs that
-	// don't emit the claim — Empty string is the natural default and
-	// the gate's resolveMFAEnforcement treats anything-other-than-
-	// "local" as the federated branch.
+	// ConnectorID is the identifier of the connector that authenticated
+	// this JWT. Used by the MFA gate (issue #31) to distinguish "local"
+	// (Dex staticPasswords, no IdP-side MFA, openZro TOTP is the
+	// primary second factor) from federated providers (TOTP is an
+	// optional redundancy layer on top of the IdP's own MFA).
+	//
+	// Resolution order:
+	//   1. `federated_claims.connector_id` if present. Standard OIDC
+	//      extension some IdPs emit; kept first so the gate stays
+	//      forward-compatible if Dex (or a future IdP) ever starts
+	//      shipping the claim on access tokens. Today Dex only
+	//      populates federated_claims on id_token and the dashboard
+	//      sends access_token as Bearer, so this branch is effectively
+	//      unused in production.
+	//   2. The `sub` claim parsed as a Dex internal-id protobuf —
+	//      see parseDexSubConnector. Dex encodes the connector id
+	//      directly inside `sub` on every token it issues, so this
+	//      catches both staticPasswords (conn_id="local") and any
+	//      federated connector (conn_id="google", "github", ...)
+	//      without depending on federated_claims.
+	//   3. Empty string. Non-Dex IdPs (Auth0, Keycloak, …) emit
+	//      UUID-style subs that don't parse as a Dex protobuf;
+	//      resolveMFAEnforcement then treats the absence as the
+	//      federated branch — same legacy behaviour, no regression
+	//      for those deployments.
 	if fc, ok := claims["federated_claims"].(map[string]any); ok {
 		if cid, ok := fc["connector_id"].(string); ok {
 			userAuth.ConnectorID = cid
 		}
 	}
+	if userAuth.ConnectorID == "" {
+		userAuth.ConnectorID = parseDexSubConnector(userID)
+	}
 
 	return userAuth, nil
+}
+
+// parseDexSubConnector decodes Dex's internal-id protobuf out of the
+// JWT `sub` claim and returns the embedded connector id, or empty
+// string if `sub` is not in that shape.
+//
+// Dex builds every issued token's sub by base64url-encoding a
+// protobuf message with two LEN-typed string fields:
+//
+//	field 1 = user_id   (the connector-local subject)
+//	field 2 = conn_id   (the configured connector identifier)
+//
+// See Dex `internal/server/handlers.go:formatSubject` and the
+// `internalIDProto` schema. The format has been stable since Dex
+// 2.x and is shared across staticPasswords + every federated
+// connector (oauth, oidc, google, github, …).
+//
+// Non-Dex IdPs (Auth0, Keycloak, …) emit UUID-style subs that
+// won't parse as a protobuf with field 2 = string; the consumer
+// gets "" back and falls through to the legacy code path.
+func parseDexSubConnector(sub string) string {
+	if sub == "" {
+		return ""
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(sub)
+	if err != nil {
+		return ""
+	}
+	for len(raw) > 0 {
+		num, typ, n := protowire.ConsumeTag(raw)
+		if n < 0 || typ != protowire.BytesType {
+			return ""
+		}
+		raw = raw[n:]
+		val, n := protowire.ConsumeBytes(raw)
+		if n < 0 {
+			return ""
+		}
+		raw = raw[n:]
+		if num == 2 {
+			return string(val)
+		}
+	}
+	return ""
 }
 
 func (c *ClaimsExtractor) ToGroups(token *jwt.Token, claimName string) []string {

--- a/management/server/auth/jwt/extractor_test.go
+++ b/management/server/auth/jwt/extractor_test.go
@@ -1,0 +1,121 @@
+package jwt
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+// dexSub builds a Dex-shaped sub claim (base64url-encoded protobuf
+// of {field1=userID, field2=connID}) the same way
+// `internal/server/handlers.go:formatSubject` does on the Dex side.
+// Used to feed the extractor realistic fixtures for the protobuf
+// fallback path.
+func dexSub(t *testing.T, userID, connID string) string {
+	t.Helper()
+	var buf []byte
+	buf = protowire.AppendTag(buf, 1, protowire.BytesType)
+	buf = protowire.AppendString(buf, userID)
+	buf = protowire.AppendTag(buf, 2, protowire.BytesType)
+	buf = protowire.AppendString(buf, connID)
+	return base64.RawURLEncoding.EncodeToString(buf)
+}
+
+// Regression: the MFA gate (issue #31) routes on userAuth.ConnectorID.
+// Dex's bundled staticPasswords connector does not emit
+// federated_claims on the access token the dashboard sends as Bearer,
+// so the extractor falls back to parsing the connector id out of
+// Dex's `sub` protobuf — covering staticPasswords + every federated
+// connector without depending on federated_claims.
+func TestClaimsExtractor_ConnectorID(t *testing.T) {
+	tests := []struct {
+		name   string
+		claims jwt.MapClaims
+		want   string
+	}{
+		{
+			name: "federated_claims connector_id wins over sub fallback",
+			claims: jwt.MapClaims{
+				"sub":              dexSub(t, "user-1", "google"),
+				"federated_claims": map[string]any{"connector_id": "github"},
+			},
+			want: "github",
+		},
+		{
+			name: "Dex staticPasswords sub yields local",
+			claims: jwt.MapClaims{
+				"sub": dexSub(t, "openzro-bootstrap-admin", "local"),
+			},
+			want: "local",
+		},
+		{
+			name: "Dex google sub yields google",
+			claims: jwt.MapClaims{
+				"sub": dexSub(t, "ChVhbm5hQGV4YW1wbGUuY29tEgZnb29nbGU", "google"),
+			},
+			want: "google",
+		},
+		{
+			name: "non-Dex UUID sub stays empty",
+			claims: jwt.MapClaims{
+				"sub": "5f6c1c0a-3d4e-4d5b-9c8a-2f1a3b4c5d6e",
+			},
+			want: "",
+		},
+		{
+			name: "federated_claims present without connector_id falls back",
+			claims: jwt.MapClaims{
+				"sub":              dexSub(t, "user-1", "local"),
+				"federated_claims": map[string]any{"user_id": "x"},
+			},
+			want: "local",
+		},
+		{
+			name: "federated_claims with empty connector_id keeps it empty",
+			claims: jwt.MapClaims{
+				"sub":              "non-dex-uuid",
+				"federated_claims": map[string]any{"connector_id": ""},
+			},
+			want: "",
+		},
+	}
+
+	extractor := NewClaimsExtractor()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			token := &jwt.Token{Claims: tc.claims}
+			userAuth, err := extractor.ToUserAuth(token)
+			if err != nil {
+				t.Fatalf("ToUserAuth: %v", err)
+			}
+			if userAuth.ConnectorID != tc.want {
+				t.Fatalf("ConnectorID: got %q want %q", userAuth.ConnectorID, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseDexSubConnector(t *testing.T) {
+	tests := []struct {
+		name string
+		sub  string
+		want string
+	}{
+		{"empty", "", ""},
+		{"non-base64", "not-base64-!!!", ""},
+		{"non-protobuf UUID", base64.RawURLEncoding.EncodeToString([]byte("5f6c1c0a-3d4e-4d5b")), ""},
+		{"Dex local", dexSub(t, "u1", "local"), "local"},
+		{"Dex google", dexSub(t, "u2", "google"), "google"},
+		{"Dex empty connector", dexSub(t, "u3", ""), ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseDexSubConnector(tc.sub)
+			if got != tc.want {
+				t.Fatalf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/management/server/context/auth.go
+++ b/management/server/context/auth.go
@@ -45,15 +45,16 @@ type UserAuth struct {
 	// Indicates whether this user has authenticated with a Personal Access Token
 	IsPAT bool
 
-	// ConnectorID is the Dex connector that authenticated this JWT,
-	// extracted from `federated_claims.connector_id`. Dex's bundled
-	// staticPasswords connector emits the literal value "local";
-	// federated providers (Okta, Google Workspace, Microsoft Entra,
-	// Authentik, Keycloak, etc.) emit their configured connector id.
-	// Used by the MFA gate (issue #31) to apply MFAEnforceLocal vs.
-	// MFAEnforceFederated. Empty when the JWT didn't carry
-	// federated_claims (PAT auth, legacy tokens, non-Dex IdPs that
-	// don't emit the claim).
+	// ConnectorID is the identifier of the connector that
+	// authenticated this JWT. Resolved by the JWT extractor with
+	// `federated_claims.connector_id` first and Dex's `sub` protobuf
+	// as fallback so Dex deployments populate this even though
+	// federated_claims only ships on the id_token. Used by the MFA
+	// gate (issue #31) to apply MFAEnforceLocal vs.
+	// MFAEnforceFederated. Empty for PATs, service users, and
+	// non-Dex IdPs (Auth0, Keycloak, …) whose subs aren't Dex
+	// protobufs — resolveMFAEnforcement treats those as the
+	// federated branch.
 	ConnectorID string
 }
 


### PR DESCRIPTION
## Summary

Replaces #122 with a correct approach: instead of defaulting an empty `ConnectorID` to `"local"` (which classified federated providers as local — see #122 review), parse the connector id directly out of Dex's `sub` protobuf, which carries it on every JWT regardless of token type or connector kind.

New resolution order in [extractor.go](management/server/auth/jwt/extractor.go):

1. `federated_claims.connector_id` if present (forward-compat).
2. Dex internal-id protobuf parsed out of `sub` (`{user_id, conn_id}`).
3. Empty string — non-Dex IdPs (Auth0, Keycloak, …) emit UUID-style subs that don't parse; they fall through to the legacy federated-branch behaviour unchanged.

Closes the gap for self-hosted Dex deployments without regressing any other IdP.

## Why

The MFA gate (issue #31) routes on `userAuth.ConnectorID == "local"` to apply `MFAEnforceLocal`. The original extractor only looked at `federated_claims.connector_id`, but Dex populates `federated_claims` on the **id_token** only. The dashboard sends the access_token as Bearer (`tokenSource` defaults to `accessToken` in [`dashboard/src/utils/config.ts`](dashboard/src/utils/config.ts)), so every connector — local AND federated — arrived at the gate with `ConnectorID=""`. Operators who wanted `MFAEnforceLocal` had to also enable `MFAEnforceFederated`, defeating the per-connector model.

PR #122's first attempt — defaulting `""` to `"local"` — was wrong: it classified federated providers as local because **they also arrive without `federated_claims` on the access_token**.

Lab evidence (decoded id_token of the bootstrap admin in `openzro-test`, with the SW exposing it via the `tokenSource=idToken` experiment):

```
sub: "ChdvcGVuenJvLWJvb3RzdHJhcC1hZG1pbhIFbG9jYWw"  (base64url)
   = 0x0A 0x17 "openzro-bootstrap-admin"  0x12 0x05 "local"
                ↑ field 1 (user_id)        ↑ field 2 (conn_id) = "local"
```

The format has been stable since Dex 2.x (see `internal/server/handlers.go:formatSubject` and the `internalIDProto` schema) and is shared across staticPasswords and every federated connector.

## What this does NOT change

- No change to how `resolveMFAEnforcement` maps `(connector_id, settings)` → enforcement decision; only the *source* of `connector_id` is wider now.
- No change to PAT / service-user paths — they short-circuit the gate via `IsPAT` / `IsServiceUser` upstream and never consult `ConnectorID`.
- `google.golang.org/protobuf` is already a transitive dependency; the parse uses `protowire` directly without adding any new module.

## Test plan

- [x] `go test ./management/server/auth/jwt/... -count=1 -v` — 12 cases green (6 for the extractor, 6 for `parseDexSubConnector` directly), covering federated_claims wins, Dex local, Dex federated (google), Dex empty connector, non-Dex UUID sub, non-base64 sub, empty sub.
- [x] `go test ./management/server/ -count=1 -run "MFA|Connector"` — green
- [x] `go build ./...` — clean
- [x] `go vet ./management/server/auth/jwt/...` — clean
- [ ] Manual smoke (lab): with `MFAEnforceLocal=true` and `MFAEnforceFederated=false`, a fresh admin login through Dex staticPasswords triggers the OTP challenge (currently passes through because `ConnectorID=""`).
- [ ] CI green

## Follow-up

Once green, close the empirical workaround on the lab (no dashboard env-var change is needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)