### PR TITLE
fix(relay/cluster): bump HELLO budget to 10s for slow macOS CI loopback

### DIFF
--- a/relay/server/cluster/forwarder_test.go
+++ b/relay/server/cluster/forwarder_test.go
@@ -3,8 +3,6 @@ package cluster
 import (
 	"context"
 	"errors"
-	"os"
-	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -109,23 +107,6 @@ func startForwarderPair(t *testing.T, ownsA, ownsB []messages.PeerID) (
 	string, string,
 ) {
 	t.Helper()
-
-	// Every cross-pod forwarder test goes through here, which Dials a
-	// bidirectional inter-pod TCP HELLO handshake on loopback. The
-	// accept side bounds the HELLO read by the production const
-	// helloTimeout (3s, transport.go) — not overridable from a test.
-	// The macOS CI runner is contended enough that a loopback HELLO
-	// read intermittently exceeds 3s, the connection is dropped, the
-	// peer never registers, and the test fails with "peer not
-	// connected anywhere" / read HELLO i/o timeout. This is a
-	// non-hermetic timing dependency on a slow shared runner, not a
-	// forwarder bug — the logic is OS-agnostic and fully covered on
-	// Linux CI + locally. Skip on darwin CI only (mirrors the
-	// TestServiceLifecycle FreeBSD-CI precedent); proper hardening of
-	// the handshake budget is tracked separately.
-	if runtime.GOOS == "darwin" && os.Getenv("CI") == "true" {
-		t.Skip("non-hermetic on macOS CI: contended runner exceeds the 3s loopback HELLO budget — covered on Linux")
-	}
 
 	dispA := newFakeDispatcher(ownsA...)
 	dispB := newFakeDispatcher(ownsB...)

--- a/relay/server/cluster/transport.go
+++ b/relay/server/cluster/transport.go
@@ -115,9 +115,18 @@ func (s *Stream) readLoop(handler FrameHandler) {
 
 // helloTimeout caps how long an accepted connection has to send
 // its HELLO frame before we drop it. Real intra-cluster handshakes
-// finish in microseconds; 3 s leaves plenty of room for slow CNI
-// startup without enabling a long-tail DoS via half-open conns.
-const helloTimeout = 3 * time.Second
+// finish in microseconds, but contended macOS CI runners have been
+// observed taking >3 s on loopback (issue #116). 10 s holds enough
+// headroom for the slowest hosts we've measured without enabling a
+// long-tail DoS via half-open conns — the relay's connection caps
+// and rate limits enforce the actual anti-abuse budget; this value
+// only governs how long ONE half-open conn is allowed to dangle.
+//
+// Declared as `var` (not `const`) so transport_test.go can shrink
+// it locally to keep TestTransport_AcceptedConnWithoutHelloTimesOut
+// fast — restored by t.Cleanup, no shared-state leakage between
+// tests in the package.
+var helloTimeout = 10 * time.Second
 
 // classifyHelloReject maps a DecodeHello failure to a metric label.
 // Pattern-matching on the error text keeps the cluster package

--- a/relay/server/cluster/transport_test.go
+++ b/relay/server/cluster/transport_test.go
@@ -187,6 +187,14 @@ func TestTransport_AcceptedConnWithoutHelloIsDropped(t *testing.T) {
 func TestTransport_AcceptedConnWithoutHelloTimesOut(t *testing.T) {
 	// A dialer that opens the conn and never sends anything must
 	// be reaped by the helloTimeout, not held forever.
+	//
+	// Shrink the production budget locally so the test waits ~400ms
+	// instead of ~10s; the path under test (deadline fires → conn
+	// dropped → no stream registered) is value-independent.
+	orig := helloTimeout
+	helloTimeout = 200 * time.Millisecond
+	t.Cleanup(func() { helloTimeout = orig })
+
 	srvHandler := newCaptureHandler()
 	srv, addr := startTransport(t, srvHandler)
 


### PR DESCRIPTION
Closes #116.

## Summary

- Bump [`helloTimeout`](relay/server/cluster/transport.go) from `const 3 * time.Second` to `var 10 * time.Second`.
- Switch it from `const` to `var` so [`TestTransport_AcceptedConnWithoutHelloTimesOut`](relay/server/cluster/transport_test.go) can shrink it to 200ms locally (restored by `t.Cleanup`) — the test still runs in < 1s instead of dragging the suite by 10s.
- Drop the `runtime.GOOS == "darwin" && CI` skip from [`forwarder_test.go:startForwarderPair`](relay/server/cluster/forwarder_test.go) — the macOS coverage comes back now that the deadline is no longer the bottleneck.

## Why

Real intra-cluster HELLO handshakes finish in microseconds, but the macOS GitHub-Actions runner is contended enough that loopback occasionally takes > 3 s, producing `read HELLO: i/o timeout` flakes across `TestLocator_*` and the forwarder pair tests. The forwarder side had already been worked around with a Darwin-CI skip ("proper hardening of the handshake budget is tracked separately"); the locator side had nothing and kept rerunning until lucky. Both pointed at the same root cause — production hard-coded a budget too narrow for the slowest hosts we run on.

10s makes no material difference to anti-DoS posture: the relay's per-IP connection caps and rate limits enforce the actual abuse budget; `helloTimeout` only governs how long ONE half-open conn is allowed to dangle.

## Test plan

- [x] `go test ./relay/server/cluster/ -count=1 -run "TestLocator|TestForwarder|TestTransport"` — green locally (2.3s total)
- [x] `go build ./...` — clean
- [ ] CI green — including the macOS lane that previously skipped/flaked

🤖 Generated with [Claude Code](https://claude.com/claude-code)