### PR TITLE
fix(management/test): widen Ephemeral cleanup window so batched test stops flaking

### DIFF
--- a/management/server/ephemeral_test.go
+++ b/management/server/ephemeral_test.go
@@ -181,10 +181,20 @@ func TestNewManagerPeerDisconnected(t *testing.T) {
 }
 
 func TestCleanupSchedulingBehaviorIsBatched(t *testing.T) {
+	// testCleanupWindow needs to be wide enough that the loop below
+	// stages every OnPeerDisconnected BEFORE the first cleanup timer
+	// fires. The original 100ms window left ~1s of margin, which a
+	// contended Linux CI runner could still eat (scheduler starves
+	// the test goroutine, peer-N lands AFTER cleanup #1 finishes,
+	// peer-N triggers a new timer → cleanup #2 → BufferUpdate==2).
+	// 1s window × 3s lifetime gives ~3s of headroom after the loop
+	// completes — more than enough for any GH-Actions Linux runner
+	// we measure. Test runtime grows ~3s; the alternative is the
+	// recurring flake observed on the v0.53.1-alpha.83 tag push.
 	const (
 		ephemeralPeers    = 10
-		testLifeTime      = 1 * time.Second
-		testCleanupWindow = 100 * time.Millisecond
+		testLifeTime      = 3 * time.Second
+		testCleanupWindow = 1 * time.Second
 	)
 	mockStore := &MockStore{}
 	mockAM := &MockAccountManager{


### PR DESCRIPTION
## Summary

Widen `testLifeTime` (1s → 3s) and `testCleanupWindow` (100ms → 1s) inside [`TestCleanupSchedulingBehaviorIsBatched`](management/server/ephemeral_test.go) so the loop that stages 10 `OnPeerDisconnected` calls always finishes before the first cleanup timer can fire.

## Why

The test failed on the **alpha.83 tag push** Linux postgres lane ([run 26489875600](https://github.com/openzro/openzro/actions/runs/26489875600)) with:

```
--- FAIL: TestCleanupSchedulingBehaviorIsBatched (1.22s)
  ephemeral_test.go:209:
    Error: Not equal: expected: 1  actual: 2
    Test:  TestCleanupSchedulingBehaviorIsBatched
    Messages: buffer update should be called once
```

The test stages 10 `OnPeerDisconnected` calls staggered by `testCleanupWindow/ephemeralPeers` (≈100ms total) and asserts the cleanup timer collects all 10 in a single pass. Under scheduler contention, the cleanup timer (≈1.1s after the first add) can fire while the last peer-Ns are still queued in the loop — those late additions then spawn a new timer, a **second** cleanup runs on them, and `BufferUpdateAccountPeers` is invoked twice for the same account. `wg.Wait()` still settles (all 10 peers eventually deleted) so the `Len == 0` assert passes, but the batching assert fails.

alpha.77's earlier fix (delete-then-`Done` in the `DeletePeer` mock) only addressed the `Len == 0` race; the call-count race survived and the larger lifetime + window simply closes the timing gap that exposes it.

## Cost

Test runtime grows ~3s per run (1.22s → ~4.1s). 5× consecutive local runs all pass at the new window.

## Test plan

- [x] `go test ./management/server -count=5 -run TestCleanupSchedulingBehaviorIsBatched -timeout=60s` — 5/5 green locally (20.6s total)
- [ ] CI green on the Linux postgres lane

🤖 Generated with [Claude Code](https://claude.com/claude-code)