### PR TITLE
fix(brand/css): undo `text-deacmetion` typo that re-enabled link underlines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ If you create reusable components, name them with the `Oz` prefix
 </a>
 ```
 ```css
-.oz-lockup { display: inline-flex; align-items: center; gap: 10px; text-deacmetion: none; }
+.oz-lockup { display: inline-flex; align-items: center; gap: 10px; text-decoration: none; }
 .oz-lockup .oz-wordmark { font-size: 20px; }
 ```
 

--- a/dashboard/src/app/globals.css
+++ b/dashboard/src/app/globals.css
@@ -229,7 +229,7 @@
   display: inline-flex;
   align-items: center;
   gap: 10px;
-  text-deacmetion: none;
+  text-decoration: none;
 }
 .oz-lockup .oz-wordmark { font-size: 20px; }
 

--- a/dashboard/src/components/CopyToClipboardText.tsx
+++ b/dashboard/src/components/CopyToClipboardText.tsx
@@ -23,7 +23,7 @@ export default function CopyToClipboardText({
   return (
     <div
       className={cn(
-        "flex gap-2 items-center group cursor-pointer transition-all hover:underline underline-offset-4 deacmetion-dashed deacmetion-nb-gray-600",
+        "flex gap-2 items-center group cursor-pointer transition-all hover:underline underline-offset-4 decoration-dashed decoration-nb-gray-600",
         !copied && "hover:opacity-90",
         className,
       )}

--- a/dashboard/src/components/v2/OzEmptyState.tsx
+++ b/dashboard/src/components/v2/OzEmptyState.tsx
@@ -109,7 +109,7 @@ export default function OzEmptyState({
   );
 }
 
-// Dotted radial grid behind the mesh. Pure deacmetion — sits absolutely
+// Dotted radial grid behind the mesh. Pure decoration — sits absolutely
 // inside the card and fades out toward the edges via a radial mask so
 // it never reaches the card border.
 function DottedGridBackdrop() {

--- a/deploy/dev-idp/web/themes/openzro/styles.css
+++ b/deploy/dev-idp/web/themes/openzro/styles.css
@@ -38,13 +38,13 @@ body.oz-body {
   overflow-x: hidden;
   min-height: 100vh;
 }
-a { color: inherit; text-deacmetion: none; }
+a { color: inherit; text-decoration: none; }
 button { font: inherit; cursor: pointer; border: 0; background: transparent; color: inherit; }
 
 /* Backdrop scene — three radial-gradient orbs + a 64×64 grid masked
  * to a centered ellipse. Fixed positioning so it tiles the viewport
  * regardless of card height. Pointer-events disabled because it's
- * pure deacmetion. */
+ * pure decoration. */
 .scene {
   position: fixed;
   inset: 0;

--- a/infrastructure_files/web/themes/openzro/styles.css
+++ b/infrastructure_files/web/themes/openzro/styles.css
@@ -150,7 +150,7 @@ body.theme-body::before {
  */
 .theme-form-row > a {
   display: block;
-  text-deacmetion: none;
+  text-decoration: none;
 }
 
 .theme-btn-provider {
@@ -369,11 +369,11 @@ body.theme-body::before {
 
 .theme-link-back a {
   color: var(--oz-primary);
-  text-deacmetion: none;
+  text-decoration: none;
 }
 .theme-link-back a:hover {
   color: var(--oz-primary-hover);
-  text-deacmetion: underline;
+  text-decoration: underline;
 }
 
 .theme-remember-me {


### PR DESCRIPTION
The Dex login page (and a couple of dashboard surfaces) started showing the user-agent default underline on anchor-styled buttons after a recent rebuild. Single typo on six lines:

\`text-deacmetion\` → \`text-decoration\`. Browser silently ignores the unknown property and the default \`text-decoration: underline\` on \`<a>\` stays.

Affected files:

- [\`deploy/dev-idp/web/themes/openzro/styles.css\`](deploy/dev-idp/web/themes/openzro/styles.css) — the **visible bug** (Dex login)
- [\`infrastructure_files/web/themes/openzro/styles.css\`](infrastructure_files/web/themes/openzro/styles.css) — bare-metal Dex theme (mirror)
- [\`CLAUDE.md\`](CLAUDE.md) — the original snippet copy; every paste after that picked up the typo
- [\`dashboard/src/app/globals.css\`](dashboard/src/app/globals.css) — \`.oz-lockup\` anchor reset
- [\`dashboard/src/components/CopyToClipboardText.tsx\`](dashboard/src/components/CopyToClipboardText.tsx) — \`deacmetion-dashed\` / \`deacmetion-nb-gray-600\` Tailwind classes (both silently ignored)
- [\`dashboard/src/components/v2/OzEmptyState.tsx\`](dashboard/src/components/v2/OzEmptyState.tsx) — comment

## Rollout

To restore the Dex theme on a deployed cluster, the next \`ghcr.io/openzro/dex:\` tag has to ship — the theme is baked into the image via \`docker/Dockerfile.dex\`. Lab can pull \`pr-css-typo\` for a smoke before merge if helpful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)