### PR TITLE
fix(dashboard/oidc): break the /auth?code=… post-logout login loop

### DIFF
--- a/dashboard/src/auth/OIDCError.tsx
+++ b/dashboard/src/auth/OIDCError.tsx
@@ -32,6 +32,26 @@ export const OIDCError = () => {
     }
   }, [accessDenied, title]);
 
+  // Scrub the stale ?code= / ?state= that the failed token exchange
+  // left in the address bar. Without this the Logout button below
+  // (and the OidcSecure auto-retry from SecureProvider) re-enters
+  // /auth?code=..., axa-fr re-attempts the same dead code, this same
+  // error renders, and the user is stuck in a loop that only a manual
+  // URL edit breaks. We keep `error` / `error_description` because
+  // the rendering below reads them.
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const url = new URL(window.location.href);
+    if (!url.searchParams.has("code") && !url.searchParams.has("state")) {
+      return;
+    }
+    url.searchParams.delete("code");
+    url.searchParams.delete("state");
+    url.searchParams.delete("session_state");
+    url.searchParams.delete("iss");
+    window.history.replaceState(null, "", url.pathname + url.search);
+  }, []);
+
   return (
     <div
       className={

--- a/dashboard/src/auth/OIDCError.tsx
+++ b/dashboard/src/auth/OIDCError.tsx
@@ -18,7 +18,7 @@ export const OIDCError = () => {
   const invalidRequest = errorParam === "invalid_request";
   const [title, setTitle] = useState(params.get("error_description"));
   const errorDescription = params.get("error_description");
-  const { logout, login } = useOidc();
+  const { logout } = useOidc();
 
   useEffect(() => {
     if (accessDenied) {
@@ -32,24 +32,57 @@ export const OIDCError = () => {
     }
   }, [accessDenied, title]);
 
-  // Scrub the stale ?code= / ?state= that the failed token exchange
-  // left in the address bar. Without this the Logout button below
-  // (and the OidcSecure auto-retry from SecureProvider) re-enters
-  // /auth?code=..., axa-fr re-attempts the same dead code, this same
-  // error renders, and the user is stuck in a loop that only a manual
-  // URL edit breaks. We keep `error` / `error_description` because
-  // the rendering below reads them.
+  // Scrub the stale code/state the failed token exchange left in the
+  // address bar. Without this the Logout button below (and the
+  // OidcSecure auto-retry from SecureProvider) re-enters the
+  // callback route, axa-fr re-attempts the same dead code, this
+  // same error renders, and the user is stuck in a loop that only
+  // a manual URL edit breaks. `error` / `error_description` stay
+  // because the rendering below reads them.
+  //
+  // Two URL shapes to handle:
+  //   - search-string callbacks   /auth?code=…&state=…
+  //   - hash-string callbacks     /#callback?code=…&state=…
+  //                               (the loadConfig fallback when the
+  //                                deployment didn't set
+  //                                AUTH_REDIRECT_URI). The OIDC
+  //                                library parses params inside the
+  //                                hash too, so leaving them in
+  //                                place keeps the loop alive on
+  //                                hash-style deployments.
   useEffect(() => {
     if (typeof window === "undefined") return;
+    const stale = ["code", "state", "session_state", "iss"];
+    let dirty = false;
+
     const url = new URL(window.location.href);
-    if (!url.searchParams.has("code") && !url.searchParams.has("state")) {
-      return;
+    for (const key of stale) {
+      if (url.searchParams.has(key)) {
+        url.searchParams.delete(key);
+        dirty = true;
+      }
     }
-    url.searchParams.delete("code");
-    url.searchParams.delete("state");
-    url.searchParams.delete("session_state");
-    url.searchParams.delete("iss");
-    window.history.replaceState(null, "", url.pathname + url.search);
+
+    let hash = url.hash;
+    if (hash.startsWith("#")) {
+      const qIdx = hash.indexOf("?");
+      if (qIdx !== -1) {
+        const hashPath = hash.slice(0, qIdx);
+        const hashParams = new URLSearchParams(hash.slice(qIdx + 1));
+        for (const key of stale) {
+          if (hashParams.has(key)) {
+            hashParams.delete(key);
+            dirty = true;
+          }
+        }
+        const remaining = hashParams.toString();
+        hash = remaining ? `${hashPath}?${remaining}` : hashPath;
+      }
+    }
+
+    if (!dirty) return;
+    const rebuilt = url.pathname + url.search + hash;
+    window.history.replaceState(null, "", rebuilt);
   }, []);
 
   return (

--- a/dashboard/src/auth/SecureProvider.tsx
+++ b/dashboard/src/auth/SecureProvider.tsx
@@ -6,27 +6,46 @@ import { useEffect } from "react";
 type Props = {
   children: React.ReactNode;
 };
+
+// safeCallbackPath collapses the OIDC callback routes (/auth,
+// /silent-auth) down to "/" so the post-login redirect never points
+// back at the route that just consumed the authorization code. Left
+// untreated, a failed token exchange (expired code, state mismatch
+// from a previous tab, etc.) lands the user on /auth?code=...&state=...,
+// SecureProvider then calls login(currentPath) → Dex → redirect_uri
+// /auth?code=...&state=... → React re-mounts on the SAME path → loop.
+// Any non-callback path passes through unchanged so a user who hit
+// /peers, got bounced to login, and authed successfully still lands
+// back on /peers.
+const safeCallbackPath = (path: string | null): string => {
+  if (!path) return "/";
+  if (path === "/auth" || path.startsWith("/auth/")) return "/";
+  if (path === "/silent-auth" || path.startsWith("/silent-auth/")) return "/";
+  return path;
+};
+
 export const SecureProvider = ({ children }: Props) => {
   const { isAuthenticated, login } = useOidc();
   const currentPath = usePathname();
+  const callbackPath = safeCallbackPath(currentPath);
 
   useEffect(() => {
     let timeout: NodeJS.Timeout | undefined = undefined;
     if (!isAuthenticated) {
       timeout = setTimeout(async () => {
         if (!isAuthenticated) {
-          await login(currentPath);
+          await login(callbackPath);
         }
       }, 1500);
     }
     return () => {
       clearTimeout(timeout);
     };
-  }, [currentPath, isAuthenticated, login]);
+  }, [callbackPath, isAuthenticated, login]);
 
   return (
     <>
-      <OidcSecure callbackPath={currentPath}>{children}</OidcSecure>
+      <OidcSecure callbackPath={callbackPath}>{children}</OidcSecure>
     </>
   );
 };

--- a/dashboard/src/auth/SecureProvider.tsx
+++ b/dashboard/src/auth/SecureProvider.tsx
@@ -1,33 +1,77 @@
 import { OidcSecure, useOidc } from "@axa-fr/react-oidc";
+import loadConfig from "@utils/config";
 import { usePathname } from "next/navigation";
 import * as React from "react";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 
 type Props = {
   children: React.ReactNode;
 };
 
-// safeCallbackPath collapses the OIDC callback routes (/auth,
-// /silent-auth) down to "/" so the post-login redirect never points
-// back at the route that just consumed the authorization code. Left
-// untreated, a failed token exchange (expired code, state mismatch
-// from a previous tab, etc.) lands the user on /auth?code=...&state=...,
-// SecureProvider then calls login(currentPath) → Dex → redirect_uri
-// /auth?code=...&state=... → React re-mounts on the SAME path → loop.
-// Any non-callback path passes through unchanged so a user who hit
-// /peers, got bounced to login, and authed successfully still lands
-// back on /peers.
-const safeCallbackPath = (path: string | null): string => {
+const config = loadConfig();
+
+// callbackPathBase strips any query/hash and a leading "/#" so a
+// configured redirect like "/#callback" or "/auth?foo=bar" still
+// matches the bare "/auth" route comparisons we get from
+// usePathname(). Returns null when the input cannot be normalised
+// (empty / non-path), so callers can decide whether to keep the
+// original.
+const callbackPathBase = (raw: string | undefined): string | null => {
+  if (!raw) return null;
+  let s = raw.startsWith("/#") ? raw.slice(2) : raw;
+  if (!s.startsWith("/")) s = "/" + s;
+  const stop = Math.min(
+    ...["?", "#"]
+      .map((c) => s.indexOf(c))
+      .filter((i) => i !== -1)
+      .concat(s.length),
+  );
+  const base = s.slice(0, stop);
+  return base === "/" || base === "" ? null : base;
+};
+
+// blockedCallbackPaths returns the set of routes (no query, no hash)
+// that we MUST NOT use as the post-login destination: the OIDC
+// callback itself and the silent-renew callback. Derived from
+// config.redirectURI / config.silentRedirectURI so deployments that
+// customise these (e.g. `/nb-auth`, the Zitadel quickstart, or the
+// legacy hash-style `/#callback`) get the same loop-prevention as
+// the default `/auth`.
+const blockedCallbackPaths = (): Set<string> => {
+  const set = new Set<string>();
+  for (const candidate of [config.redirectURI, config.silentRedirectURI]) {
+    const base = callbackPathBase(candidate);
+    if (base) set.add(base);
+  }
+  return set;
+};
+
+// safeCallbackPath collapses any callback route down to "/" so the
+// post-login redirect never points back at the route that just
+// consumed the authorization code. Left untreated, a failed token
+// exchange (expired Dex code, state mismatch from a previous tab,
+// etc.) lands the user on /<callback>?code=…&state=…, SecureProvider
+// then calls login(currentPath) → Dex → redirect_uri /<callback> →
+// React re-mounts on the SAME path → loop. Non-callback paths pass
+// through so a user who hit /peers, got bounced to login, and authed
+// successfully still lands back on /peers.
+const safeCallbackPath = (
+  path: string | null,
+  blocked: Set<string>,
+): string => {
   if (!path) return "/";
-  if (path === "/auth" || path.startsWith("/auth/")) return "/";
-  if (path === "/silent-auth" || path.startsWith("/silent-auth/")) return "/";
+  if (blocked.has(path)) return "/";
+  for (const base of blocked) {
+    if (path === base || path.startsWith(base + "/")) return "/";
+  }
   return path;
 };
 
 export const SecureProvider = ({ children }: Props) => {
   const { isAuthenticated, login } = useOidc();
   const currentPath = usePathname();
-  const callbackPath = safeCallbackPath(currentPath);
+  const blocked = useMemo(blockedCallbackPaths, []);
+  const callbackPath = safeCallbackPath(currentPath, blocked);
 
   useEffect(() => {
     let timeout: NodeJS.Timeout | undefined = undefined;


### PR DESCRIPTION
## Symptom

After logout-then-relogin, or any time the Dex authorization code fails to exchange (expired code, sessionStorage state mismatch from a previous tab/attempt), the dashboard parks the user on the **"Oops, something went wrong / Error: Unauthenticated"** panel with no escape. Clicking the Logout button on that screen takes the user through Dex and right back to \`/auth?code=…&state=…\`; the OIDC lib retries the same dead code, the same error renders, and the only way out is editing the address bar by hand.

## Root cause — two compounding bugs

### 1. \`callbackPath={currentPath}\` aims the post-login redirect at the callback itself

[\`SecureProvider.tsx\`](dashboard/src/auth/SecureProvider.tsx) passed \`callbackPath={currentPath}\` to \`<OidcSecure>\`. On the error screen \`currentPath\` is \`/auth\` — the OIDC \`redirect_uri\` itself. A successful re-auth would then route back to \`/auth\`, immediately try to exchange the next code, and walk into whatever failure mode tripped before. Even a clean retry loops through the callback route.

Fix: collapse \`/auth\` / \`/silent-auth\` (and any sub-paths) down to \`/\` via \`safeCallbackPath\`. Any other route passes through so a user who hit \`/peers\`, got bounced to login, and authed cleanly still ends up back on \`/peers\`.

### 2. \`OIDCError\` left the stale OIDC params in the address bar

Even with the callbackPath collapsed, the Logout button + the 1.5 s \`OidcSecure\` retry inside \`SecureProvider\` re-rendered the route with \`?code=…&state=…\` still attached, so the next navigation kept feeding axa-fr the same rotten code.

Fix: on mount, [\`OIDCError.tsx\`](dashboard/src/auth/OIDCError.tsx) scrubs \`code\`, \`state\`, \`session_state\`, and \`iss\` from \`window.location\` via \`history.replaceState\`. \`error\` / \`error_description\` stay because the panel reads them.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [ ] Manual smoke (lab):
  - log in, log out, log in again immediately → should land on the dashboard, not \`/auth\` with an error
  - leave the tab idle past the Dex session lifetime, click around to force re-auth → expected to hit the panel **once** then Logout cleanly (no loop)
  - hit \`/peers\` while logged out → Dex login → expected to land on \`/peers\` after auth (not \`/\`), confirming the safeCallbackPath passthrough still works for non-callback routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)