### PR TITLE
fix(relay/cluster): skip the 2-pod loopback tests on macOS CI

### DIFF
--- a/relay/server/cluster/darwin_skip_test.go
+++ b/relay/server/cluster/darwin_skip_test.go
@@ -1,0 +1,28 @@
+package cluster
+
+import (
+	"os"
+	"runtime"
+	"testing"
+)
+
+// skipOnDarwinCI bails out of any test that brings up a 2-pod
+// cluster on loopback. The macOS GitHub-Actions runners are shared
+// hosts whose loopback latency can spike past whatever HELLO budget
+// we set: alpha.84 was tagged with helloTimeout at 10 s (3× the
+// original 3 s — see issue #116 / PR #128), and the runners still
+// drift past that under load, leaving `i/o timeout: read HELLO`
+// across TestLocator_* and TestForwarder_*.
+//
+// Coverage is identical on the Linux + FreeBSD + Windows lanes, so
+// skipping macOS-only here costs us nothing — the logic is OS-
+// agnostic. Local macOS runs of `go test ./relay/server/cluster/...`
+// still execute these tests; only CI is gated. Re-enable in a
+// future commit if/when we move the relay cluster tests to a
+// docker-backed runner with deterministic loopback latency.
+func skipOnDarwinCI(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "darwin" && os.Getenv("CI") == "true" {
+		t.Skip("non-hermetic on macOS CI: shared runner exceeds the loopback HELLO budget — covered on Linux / FreeBSD / Windows")
+	}
+}

--- a/relay/server/cluster/forwarder_test.go
+++ b/relay/server/cluster/forwarder_test.go
@@ -107,6 +107,7 @@ func startForwarderPair(t *testing.T, ownsA, ownsB []messages.PeerID) (
 	string, string,
 ) {
 	t.Helper()
+	skipOnDarwinCI(t)
 
 	dispA := newFakeDispatcher(ownsA...)
 	dispB := newFakeDispatcher(ownsB...)

--- a/relay/server/cluster/locator_test.go
+++ b/relay/server/cluster/locator_test.go
@@ -60,6 +60,7 @@ func newPeerID(seed byte) messages.PeerID {
 // other so they form a 2-pod cluster for the test.
 func startPair(t *testing.T, ownsA, ownsB []messages.PeerID) (*PeerLocator, *PeerLocator, string, string) {
 	t.Helper()
+	skipOnDarwinCI(t)
 
 	ownerA := newFakeOwner(ownsA...)
 	ownerB := newFakeOwner(ownsB...)


### PR DESCRIPTION
## Why

alpha.84's post-merge Darwin lane re-tripped the same \`i/o timeout: read HELLO\` flake the locator/forwarder tests have carried since the multi-pod relay landed. The history:

- Original budget: \`helloTimeout = 3 * time.Second\`. \`startForwarderPair\` skipped on macOS CI as a workaround; locator tests just re-ran.
- [PR #128](https://github.com/openzro/openzro/pull/128) bumped the budget to **10 s** and removed the macOS-CI skip from the forwarder tests, on the assumption that the wider budget would cover macOS too.
- alpha.84 main run [27632611942](https://github.com/openzro/openzro/actions/runs/27632611942) failed again with the same error — under load the GitHub-Actions macOS runners still drift past 10 s on loopback.

Bumping the budget further is a race we keep losing.

## Fix

Stop fighting and restore the skip. The logic under test is OS-agnostic; the Linux, FreeBSD, and Windows lanes exercise the same code paths, so coverage doesn't change — only the non-hermetic CI noise goes away. Local \`go test ./relay/server/cluster/...\` on a developer macOS still runs everything (the gate keys on \`CI=true\`, mirroring the FreeBSD-CI precedent for \`TestServiceLifecycle\`).

Implementation: a single \`skipOnDarwinCI\` helper in a new \`darwin_skip_test.go\`, called from \`startPair\` (locator) and \`startForwarderPair\` (forwarder). The next 2-pod loopback test that gets the same treatment is a one-liner.

## Test plan

- [x] \`go test ./relay/server/cluster/ -count=1 -run "TestLocator|TestForwarder"\` — clean locally (Linux)
- [ ] CI: Linux / FreeBSD / Windows lanes still run the full suite; Darwin lane skips the 2-pod startup helpers and finishes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)