### PR TITLE
feat(dashboard/oidc): trust extra IdP domains via AUTH_EXTRA_OIDC_DOMAINS

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -92,6 +92,7 @@ takes the following environment variables:
 | `AUTH_SUPPORTED_SCOPES` | Space-separated scope list. Default: `openid profile email offline_access api`. |
 | `AUTH_REDIRECT_URI` | Public dashboard URL + `/auth`. |
 | `AUTH_SILENT_REDIRECT_URI` | Public dashboard URL + `/silent-auth`. |
+| `AUTH_EXTRA_OIDC_DOMAINS` | Optional, comma-separated. Extra IdP origins/prefixes the service worker trusts for token interception, in addition to `AUTH_AUTHORITY`. Needed when the IdP serves authorize/token/userinfo from a different path or host than the discovery authority. Microsoft Entra ID: `https://login.microsoftonline.com/<tenant-id>,https://graph.microsoft.com`. |
 | `USE_AUTH0` | `"true"` only when your issuer is literally Auth0 (forces the Auth0-specific token shape). `"false"` otherwise. |
 | `OPENZRO_MGMT_API_ENDPOINT` | REST URL for the Management service, e.g. `https://api.openzro.example.com`. |
 | `OPENZRO_MGMT_GRPC_API_ENDPOINT` | gRPC URL for the Management service, e.g. `https://api.openzro.example.com:443`. |

--- a/dashboard/docker/init_react_envs.sh
+++ b/dashboard/docker/init_react_envs.sh
@@ -53,6 +53,12 @@ export AUTH_REDIRECT_URI=${AUTH_REDIRECT_URI}
 export AUTH_SILENT_REDIRECT_URI=${AUTH_SILENT_REDIRECT_URI}
 export USE_AUTH0=${USE_AUTH0:-true}
 export AUTH_SUPPORTED_SCOPES=${AUTH_SUPPORTED_SCOPES:-openid profile email api offline_access email_verified}
+# Optional comma-separated extra IdP origins/prefixes the service worker
+# trusts for token interception, on top of AUTH_AUTHORITY. Needed when
+# the IdP serves authorize/token/userinfo from a different path or host
+# than the discovery authority (e.g. Microsoft Entra ID). Consumed by
+# OidcTrustedDomains.js.tmpl. Empty by default → no behaviour change.
+export AUTH_EXTRA_OIDC_DOMAINS=${AUTH_EXTRA_OIDC_DOMAINS}
 
 export OPENZRO_MGMT_API_ENDPOINT=$(echo $OPENZRO_MGMT_API_ENDPOINT | sed -E 's/(:80|:443)$//')
 export OPENZRO_MGMT_GRPC_API_ENDPOINT=${OPENZRO_MGMT_GRPC_API_ENDPOINT}
@@ -66,7 +72,7 @@ echo "Openzro latest version: ${OPENZRO_LATEST_VERSION}"
 # placeholders were dropped along with the third-party tracker
 # scripts — see dashboard/src/contexts/AnalyticsProvider.tsx for the
 # rationale.
-ENV_STR="\$\$USE_AUTH0 \$\$AUTH_AUDIENCE \$\$AUTH_AUTHORITY \$\$AUTH_CLIENT_ID \$\$AUTH_CLIENT_SECRET \$\$AUTH_SUPPORTED_SCOPES \$\$OPENZRO_MGMT_API_ENDPOINT \$\$OPENZRO_MGMT_GRPC_API_ENDPOINT \$\$AUTH_REDIRECT_URI \$\$AUTH_SILENT_REDIRECT_URI \$\$OPENZRO_TOKEN_SOURCE \$\$OPENZRO_DRAG_QUERY_PARAMS"
+ENV_STR="\$\$USE_AUTH0 \$\$AUTH_AUDIENCE \$\$AUTH_AUTHORITY \$\$AUTH_CLIENT_ID \$\$AUTH_CLIENT_SECRET \$\$AUTH_SUPPORTED_SCOPES \$\$AUTH_EXTRA_OIDC_DOMAINS \$\$OPENZRO_MGMT_API_ENDPOINT \$\$OPENZRO_MGMT_GRPC_API_ENDPOINT \$\$AUTH_REDIRECT_URI \$\$AUTH_SILENT_REDIRECT_URI \$\$OPENZRO_TOKEN_SOURCE \$\$OPENZRO_DRAG_QUERY_PARAMS"
 
 OIDC_TRUSTED_DOMAINS="/usr/share/nginx/html/OidcTrustedDomains.js"
 envsubst "$ENV_STR" < "$OIDC_TRUSTED_DOMAINS".tmpl > "$OIDC_TRUSTED_DOMAINS"

--- a/dashboard/public/OidcTrustedDomains.js.tmpl
+++ b/dashboard/public/OidcTrustedDomains.js.tmpl
@@ -54,6 +54,29 @@ const _hostBoundary = "(?:$|/)";
 // injected on the way out.
 const _idpRegex = new RegExp("^" + _esc(_idpAuthority) + _hostBoundary);
 
+// Extra IdP origins/prefixes to trust for token interception, beyond
+// AUTH_AUTHORITY. Some IdPs serve authorize / token / userinfo from
+// paths or hosts that are NOT under the discovery authority, so
+// `_idpRegex` alone never intercepts them. Microsoft Entra ID is the
+// canonical case: authority is
+// `https://login.microsoftonline.com/<tenant>/v2.0`, but authorize /
+// token / logout live under `.../oauth2/v2.0/` (a sibling path, not a
+// child of the authority) and userinfo on a different host entirely,
+// `https://graph.microsoft.com`.
+//
+// AUTH_EXTRA_OIDC_DOMAINS is an optional comma-separated list of
+// origins or URL prefixes. Each entry is trailing-slash-normalized,
+// regex-escaped and host-boundary-anchored exactly like _idpAuthority,
+// so the same anti-subdomain hardening applies: an entry
+// "https://login.microsoftonline.com/<tenant>" matches that origin and
+// its sub-paths but NOT "https://login.microsoftonline.com.evil.test".
+// Empty / unset yields no extra domains (default behaviour unchanged).
+const _extraOidcRegexes = "$AUTH_EXTRA_OIDC_DOMAINS"
+  .split(",")
+  .map((s) => s.trim())
+  .filter((s) => s.length > 0)
+  .map((s) => new RegExp("^" + _esc(_stripTrailingSlash(s)) + _hostBoundary));
+
 // Mgmt API URLs that get the OIDC bearer injected. Negative lookahead
 // `(?!mfa/)` after `/api/` lets all paths through EXCEPT the MFA
 // token-bearer endpoints (/api/mfa/challenge, /api/mfa/enroll/start,
@@ -63,13 +86,13 @@ const _apiRegex = new RegExp("^" + _esc(_mgmtApiOrigin) + "/api/(?!mfa/)");
 
 const trustedDomains = {
   default: {
-    oidcDomains: [_idpRegex],
+    oidcDomains: [_idpRegex, ..._extraOidcRegexes],
     accessTokenDomains: [_apiRegex],
     showAccessToken: false,
     allowMultiTabLogin: false,
   },
   auth0: {
-    oidcDomains: [_idpRegex],
+    oidcDomains: [_idpRegex, ..._extraOidcRegexes],
     accessTokenDomains: [_apiRegex],
     showAccessToken: false,
     allowMultiTabLogin: false,

--- a/release_files/dashboard/openzro-dashboard.env.example
+++ b/release_files/dashboard/openzro-dashboard.env.example
@@ -23,6 +23,12 @@ USE_AUTH0=false
 # AUTH_REDIRECT_URI=/auth
 # AUTH_SILENT_REDIRECT_URI=/silent-auth
 
+# Optional, comma-separated extra IdP origins/prefixes the service
+# worker trusts for token interception, on top of AUTH_AUTHORITY. Set
+# this when your IdP serves authorize/token/userinfo from a different
+# path or host than the discovery authority. Microsoft Entra ID needs:
+# AUTH_EXTRA_OIDC_DOMAINS=https://login.microsoftonline.com/<tenant-id>,https://graph.microsoft.com
+
 # -----------------------------------------------------------------
 # Management server endpoints
 # -----------------------------------------------------------------


### PR DESCRIPTION
## Describe your changes

The dashboard service-worker trusted-domains list (`OidcTrustedDomains.js`) is
derived solely from `AUTH_AUTHORITY`. That assumes every IdP endpoint is a path
under the discovery authority, which does not hold for **Microsoft Entra ID**:
the authority is `https://login.microsoftonline.com/<tenant>/v2.0`, but
`authorize`/`token`/`logout` live under `.../oauth2/v2.0/` (a sibling path) and
`userinfo` on a different host, `https://graph.microsoft.com`. None of those
match `_idpRegex`, so the SW never intercepts the token response and Entra
sign-in cannot complete. See #133 for the full endpoint breakdown.

This adds an optional, comma-separated **`AUTH_EXTRA_OIDC_DOMAINS`** env var.
Each entry is trailing-slash-normalized, regex-escaped and host-boundary-anchored
exactly like `_idpAuthority`, so the existing anti-subdomain hardening (from #110
/ #84) is preserved — an entry for an origin does **not** match a look-alike
`...evil.test` host. Empty/unset yields no extra domains, so this is a **no-op**
for existing Dex / Auth0 / Keycloak deployments.

For Entra, operators set:
`AUTH_EXTRA_OIDC_DOMAINS=https://login.microsoftonline.com/<tenant-id>,https://graph.microsoft.com`

Changes:
- `dashboard/public/OidcTrustedDomains.js.tmpl` — build `_extraOidcRegexes` from
  the new var and append to `oidcDomains` in both `default` and `auth0` configs.
- `dashboard/docker/init_react_envs.sh` — export the var + add it to the
  `envsubst` allow-list.
- `dashboard/README.md` + `release_files/dashboard/openzro-dashboard.env.example`
  — document it.

Verified by rendering the template through the same GNU `gettext` `envsubst`
the container uses and checking the generated `oidcDomains` regexes against the
real Entra discovery endpoints: `authorize`, `token`, `jwks` and `userinfo` all
match with the var set, a look-alike `login.microsoftonline.com.evil.test` host
is rejected, and with the var unset only the discovery authority matches
(behaviour unchanged).

## Issue ticket number and link

Closes #133 — https://github.com/openzro/openzro/issues/133

## Stack

<!-- branch-stack -->

### Checklist
- [ ] Is it a bug fix
- [ ] Is a typo/documentation fix
- [x] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [x] Extended the README / documentation, if necessary
- [x] All commits in this PR are signed off with `git commit -s` (DCO)
