### PR TITLE
fix(release): keep pkg.openzro.io publish on platform build failure

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -993,7 +993,22 @@ jobs:
     # Only on tag push — nothing to publish for snapshot builds, and
     # we want the GitHub Release to exist (with the .deb / .rpm
     # assets attached) before we try to download from it.
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    #
+    # `!cancelled()` decouples *ordering* from *failure propagation*.
+    # The jobs in `needs:` still gate WHEN this runs (so the assets are
+    # uploaded first), but a failure in a non-critical platform builder
+    # must NOT skip the Linux repo publish. Concretely: release_pkg's
+    # macOS notarization can 403 on a pending Apple agreement, and that
+    # used to skip publish_packages entirely, silently leaving
+    # pkg.openzro.io's apt/yum/pacman repos stale (see #135). Only the
+    # core `release` job (the CLI .deb/.rpm producer) is a hard gate;
+    # publish-packages.sh already WARNs + skips any missing per-platform
+    # asset (and now surfaces it as a run-level ::warning::).
+    if: >-
+      !cancelled()
+      && github.event_name == 'push'
+      && startsWith(github.ref, 'refs/tags/v')
+      && needs.release.result == 'success'
     # Wait for every job that uploads an asset publish-packages.sh
     # republishes under a stable URL:
     #   release            → CLI .deb/.rpm/.pkg.tar.zst → apt/yum/pacman

--- a/scripts/publish-packages.sh
+++ b/scripts/publish-packages.sh
@@ -382,6 +382,8 @@ if [ -f "$WORK/downloads/openzro_${VER_NOV}_windows_amd64.msi" ]; then
     echo "Staged windows/openzro.msi → $VERSION"
 else
     echo "WARN: windows MSI for $VERSION missing — skipping stable URL."
+    [ -n "${GITHUB_ACTIONS:-}" ] && \
+        echo "::warning title=Missing release asset::windows MSI for $VERSION not found — /windows/openzro.msi kept at its previous version"
 fi
 
 if [ -f "$WORK/downloads/openzro_${VER_NOV}_darwin_universal.pkg" ]; then
@@ -390,12 +392,18 @@ if [ -f "$WORK/downloads/openzro_${VER_NOV}_darwin_universal.pkg" ]; then
     echo "Staged macos/openzro.pkg → $VERSION"
 else
     echo "WARN: macOS PKG for $VERSION missing — skipping stable URL."
+    [ -n "${GITHUB_ACTIONS:-}" ] && \
+        echo "::warning title=Missing release asset::macOS PKG for $VERSION not found — /macos/openzro.pkg kept at its previous version"
 fi
 
 if [ -f "$WORK/downloads/openzro-ui_${VER_NOV}_darwin_universal.tar.gz" ]; then
     cp "$WORK/downloads/openzro-ui_${VER_NOV}_darwin_universal.tar.gz" \
         "$WORK/repo/macos/openzro-ui.tar.gz"
     echo "Staged macos/openzro-ui.tar.gz → $VERSION"
+else
+    echo "WARN: macOS UI tarball for $VERSION missing — skipping stable URL."
+    [ -n "${GITHUB_ACTIONS:-}" ] && \
+        echo "::warning title=Missing release asset::macOS UI tarball for $VERSION not found — /macos/openzro-ui.tar.gz kept at its previous version"
 fi
 
 # Also drop a tiny latest.json so the dashboard can show


### PR DESCRIPTION
## Describe your changes

Fixes the cascade from #135: a failure in one platform builder used to
**silently skip** the entire `pkg.openzro.io` repo publish.

`publish_packages` kept `release_pkg` (and the other platform builders) in
`needs:` for ordering, but without `if: always()` GitHub also **skips** the
job whenever any `needs` dependency *fails*. In `v0.53.1-alpha.85` the macOS
PKG job 403'd at notarization (a pending Apple Developer agreement — signing
itself was fine), which skipped `publish_packages` entirely and left the
apt/yum/dnf/zypper/pacman repos on the previous tag, even though every Linux
`.deb`/`.rpm` asset had uploaded successfully.

### Changes

- **`.github/workflows/release-binaries.yml`** — decouple *ordering* from
  *failure propagation*. Keep the builders in `needs:` (so publish still runs
  last), but gate with `!cancelled()` and require only the core `release` job
  (the Linux `.deb`/`.rpm` producer):

  ```yaml
  if: >-
    !cancelled()
    && github.event_name == 'push'
    && startsWith(github.ref, 'refs/tags/v')
    && needs.release.result == 'success'
  ```

  A failed non-critical platform build (macOS PKG, Windows MSI, macOS UI
  tarball) now leaves that one stable URL at its previous version while the
  Linux repos still refresh — `publish-packages.sh` already WARNs + skips a
  missing asset.

- **`scripts/publish-packages.sh`** — surface a missing per-platform asset as
  a run-level `::warning::` annotation (not just a buried `echo WARN`), so a
  partial publish is visible in the Actions UI. Also warn on a missing macOS
  UI tarball, which was previously silent. Guarded by `${GITHUB_ACTIONS:-}` so
  local runs are unaffected (verified safe under `set -euo pipefail`).

### Behaviour

| Scenario | Before | After |
|---|---|---|
| `release_pkg` (macOS) fails | publish_packages **skipped** → Linux repos stale | publish runs; Linux repos refresh; `/macos/openzro.pkg` kept at prev version + `::warning::` |
| `release` (Linux) fails | skipped | still skipped (hard gate) |
| Run cancelled | skipped | still skipped (`!cancelled()`) |

## Issue ticket number and link

Closes #135 — https://github.com/openzro/openzro/issues/135

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [ ] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
- [x] All commits in this PR are signed off with `git commit -s` (DCO)

> No automated test: this is a GitHub Actions `if:` gate + a shell warning
> path, neither covered by an existing harness. YAML/`bash -n` validated; the
> `set -euo pipefail` safety of the guarded `::warning::` was verified
> empirically. The gate is exercised by the next release run.
