### PR TITLE
fix(management/ephemeral): skip cluster-connected peers on cleanup

### DIFF
--- a/management/server/ephemeral.go
+++ b/management/server/ephemeral.go
@@ -180,6 +180,23 @@ func (e *EphemeralManager) cleanup(ctx context.Context) {
 
 	e.peersLock.Unlock()
 
+	// Cluster-wide liveness gate. This manager keeps per-process, in-memory
+	// state, but the store is shared across every management replica. A
+	// replica that does not own a peer's Sync stream still loaded that peer
+	// at startup and scheduled its cleanup here — deleting it now would rip
+	// a peer that is continuously connected on another replica out of the
+	// shared store. Before deleting, re-read the authoritative Connected
+	// flag (written by the stream-owning replica and guarded against stale
+	// disconnects, see updatePeerStatusAndLocation) and skip any peer that
+	// is connected anywhere in the cluster. The owning replica deletes it
+	// once the peer actually disconnects.
+	//
+	// The read is one bulk query per account (not one per peer): cleanup is
+	// a batched, low-frequency path and the delete it guards is far heavier,
+	// but a peer storm that expires many peers at once should still not fan
+	// out into N individual SELECTs.
+	e.dropStillConnected(ctx, deletePeers)
+
 	bufferAccountCall := make(map[string]struct{})
 
 	for id, p := range deletePeers {
@@ -193,6 +210,45 @@ func (e *EphemeralManager) cleanup(ctx context.Context) {
 	}
 	for accountID := range bufferAccountCall {
 		e.accountManager.BufferUpdateAccountPeers(ctx, accountID)
+	}
+}
+
+// dropStillConnected removes from the delete set every peer that must not
+// be hard-deleted: peers still connected somewhere in the cluster, peers
+// already gone from the store, and — on a store read error — every peer of
+// the affected account (never delete on an unverified state; a peer that is
+// really stale is re-loaded and re-scheduled on the next LoadInitialPeers).
+// It groups the staged peers by account so the shared store is hit once per
+// account instead of once per peer.
+func (e *EphemeralManager) dropStillConnected(ctx context.Context, deletePeers map[string]*ephemeralPeer) {
+	idsByAccount := make(map[string][]string)
+	for id, p := range deletePeers {
+		idsByAccount[p.accountID] = append(idsByAccount[p.accountID], id)
+	}
+
+	for accountID, ids := range idsByAccount {
+		current, err := e.store.GetPeersByIDs(ctx, store.LockingStrengthShare, accountID, ids)
+		if err != nil {
+			log.WithContext(ctx).Warnf("skip ephemeral cleanup for account %s: cannot verify connection state: %s", accountID, err)
+			for _, id := range ids {
+				delete(deletePeers, id)
+			}
+			continue
+		}
+
+		for _, id := range ids {
+			peer, ok := current[id]
+			if !ok {
+				// Already removed from the store (e.g. deleted via API) —
+				// nothing left to delete.
+				delete(deletePeers, id)
+				continue
+			}
+			if peer.Status != nil && peer.Status.Connected {
+				log.WithContext(ctx).Debugf("skip ephemeral cleanup for peer %s: still connected on the cluster", id)
+				delete(deletePeers, id)
+			}
+		}
 	}
 }
 

--- a/management/server/ephemeral_test.go
+++ b/management/server/ephemeral_test.go
@@ -30,6 +30,16 @@ func (s *MockStore) GetAllEphemeralPeers(_ context.Context, _ store.LockingStren
 	return peers, nil
 }
 
+func (s *MockStore) GetPeersByIDs(_ context.Context, _ store.LockingStrength, _ string, peerIDs []string) (map[string]*nbpeer.Peer, error) {
+	res := make(map[string]*nbpeer.Peer)
+	for _, id := range peerIDs {
+		if p, ok := s.account.Peers[id]; ok {
+			res[id] = p
+		}
+	}
+	return res, nil
+}
+
 type MockAccountManager struct {
 	mu sync.Mutex
 	nbAccount.Manager
@@ -177,6 +187,59 @@ func TestNewManagerPeerDisconnected(t *testing.T) {
 	expected := numberOfPeers + numberOfEphemeralPeers - 1
 	if len(store.account.Peers) != expected {
 		t.Errorf("failed to cleanup ephemeral peers, expected: %d, result: %d", expected, len(store.account.Peers))
+	}
+}
+
+// TestCleanupSkipsClusterConnectedPeer is the regression test for the
+// multi-replica ephemeral-peer bug: a replica that does NOT own a peer's
+// Sync stream still loads that peer at startup and schedules its cleanup.
+// Before the fix, that non-owning replica hard-deleted the peer from the
+// shared store ~lifeTime after its own start, even though the peer was
+// continuously connected on another replica. cleanup must now re-check the
+// cluster-shared Status.Connected flag (written by the stream-owning
+// replica) and skip the delete while the peer is connected anywhere.
+func TestCleanupSkipsClusterConnectedPeer(t *testing.T) {
+	t.Cleanup(func() {
+		timeNow = time.Now
+	})
+	startTime := time.Now()
+	timeNow = func() time.Time {
+		return startTime
+	}
+
+	store := &MockStore{}
+	am := MockAccountManager{
+		store: store,
+	}
+
+	store.account = newAccountWithId(context.Background(), "account", "", "", false)
+	// connected is owned by another replica's Sync stream — its shared
+	// status says Connected=true, so this replica must not delete it.
+	connected := &nbpeer.Peer{
+		ID: "ephemeral_connected", AccountID: store.account.Id, Ephemeral: true,
+		Status: &nbpeer.PeerStatus{Connected: true, OwnerStreamID: "stream-on-replica-a"},
+	}
+	// disconnected is genuinely gone — it must still be cleaned up.
+	disconnected := &nbpeer.Peer{
+		ID: "ephemeral_disconnected", AccountID: store.account.Id, Ephemeral: true,
+		Status: &nbpeer.PeerStatus{Connected: false},
+	}
+	store.account.Peers[connected.ID] = connected
+	store.account.Peers[disconnected.ID] = disconnected
+
+	mgr := NewEphemeralManager(store, &am)
+	mgr.loadEphemeralPeers(context.Background())
+	startTime = startTime.Add(ephemeralLifeTime + 1)
+	mgr.cleanup(context.Background())
+
+	if _, ok := store.account.Peers[connected.ID]; !ok {
+		t.Errorf("cluster-connected ephemeral peer must not be deleted by a non-owning replica")
+	}
+	if _, ok := store.account.Peers[disconnected.ID]; ok {
+		t.Errorf("disconnected ephemeral peer should have been cleaned up")
+	}
+	if calls := am.GetDeletePeerCalls(); calls != 1 {
+		t.Errorf("expected exactly 1 DeletePeer call, got %d", calls)
 	}
 }
 


### PR DESCRIPTION
## Describe your changes

`EphemeralManager` keeps per-process, in-memory state (linked list + `time.AfterFunc` timers) but deletes from the store, which every management replica shares — it is the only subsystem component not tied to the Redis cluster coordinator. With more than one replica this is unsafe: `LoadInitialPeers` loads *all* ephemeral peers on every replica and schedules their cleanup, but `OnPeerConnected`/`OnPeerDisconnected` only fire on the replica that owns the peer's Sync stream. A non-owning replica therefore hard-deletes a peer that is continuously connected on another replica, ~`lifeTime` (10 min) after its own start.

**Fix:** before each hard delete, `cleanup` re-reads the authoritative `Status.Connected` flag from the shared store and drops from the delete set any peer still connected anywhere in the cluster. That flag is written by the stream-owning replica and already guarded against stale disconnects via `OwnerStreamID` (see `updatePeerStatusAndLocation`, introduced in #35). Peers already gone from the store are dropped too; on a store read error no peer of that account is deleted (never delete on unverified state — a truly stale peer is re-scheduled on the next `LoadInitialPeers`).

The verification is **one bulk `GetPeersByIDs` per account**, not one read per peer, so a peer storm that expires many peers at once does not fan out into N individual SELECTs. `cleanup` is a batched, low-frequency path and the delete it guards is far heavier than the read.

## Issue ticket number and link

Fixes #137 — https://github.com/openzro/openzro/issues/137

## Testing

Automated: `TestCleanupSkipsClusterConnectedPeer` (new regression test — fails on `main`, where `cleanup` deleted unconditionally) plus the existing ephemeral tests, green with `-race`.

Manual, against a HA deployment (2 management replicas, shared Postgres + Redis coordinator) using a working-tree image, plus the single-replica baseline:

| # | Scenario | Expectation | Result |
|---|----------|-------------|--------|
| 1 | replica=1, newly enrolled ephemeral peer | kept (single-instance correct) | ✅ kept |
| 2 | replica=2 + fix, peer connected | kept (bug fixed) | ✅ survived >14 min, past the ~10–11 min deletion window, no cross-replica delete |
| 3 | replica=2, client offline | deleted after ~10 min (cleanup semantics intact) | ✅ correctly deleted |

The original bug (a non-owning replica killing a connected peer after ~10 min) is reproducibly fixed, and genuinely-offline peers are still cleaned up.

## Stack

Single commit; no dependent branches.

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
- [x] All commits in this PR are signed off with `git commit -s` (DCO)
