### PR TITLE
fix(management/ephemeral): retry cleanup in-process on store read error

### DIFF
--- a/management/server/ephemeral.go
+++ b/management/server/ephemeral.go
@@ -195,7 +195,16 @@ func (e *EphemeralManager) cleanup(ctx context.Context) {
 	// a batched, low-frequency path and the delete it guards is far heavier,
 	// but a peer storm that expires many peers at once should still not fan
 	// out into N individual SELECTs.
-	e.dropStillConnected(ctx, deletePeers)
+	//
+	// Peers whose state could not be verified (a transient store error) are
+	// returned rather than deleted, and re-tracked below so a running
+	// instance retries them — the expired peers were already popped off the
+	// in-memory list above, and LoadInitialPeers only runs once at startup,
+	// so without this they would be orphaned until the process restarts.
+	requeue := e.dropStillConnected(ctx, deletePeers)
+	if len(requeue) > 0 {
+		e.rescheduleAfterError(ctx, requeue)
+	}
 
 	bufferAccountCall := make(map[string]struct{})
 
@@ -214,23 +223,29 @@ func (e *EphemeralManager) cleanup(ctx context.Context) {
 }
 
 // dropStillConnected removes from the delete set every peer that must not
-// be hard-deleted: peers still connected somewhere in the cluster, peers
-// already gone from the store, and — on a store read error — every peer of
-// the affected account (never delete on an unverified state; a peer that is
-// really stale is re-loaded and re-scheduled on the next LoadInitialPeers).
+// be hard-deleted and returns the peers that need to be re-tracked in
+// process. Three cases are dropped from the set: peers still connected
+// somewhere in the cluster and peers already gone from the store (both
+// drop-and-forget — the owning replica handles the connected one, the gone
+// one needs nothing), and — on a store read error — every peer of the
+// affected account (never delete on an unverified state). Only the last
+// case is returned: those peers could not be verified, so a running
+// instance must retry them rather than forget them until a restart.
 // It groups the staged peers by account so the shared store is hit once per
 // account instead of once per peer.
-func (e *EphemeralManager) dropStillConnected(ctx context.Context, deletePeers map[string]*ephemeralPeer) {
+func (e *EphemeralManager) dropStillConnected(ctx context.Context, deletePeers map[string]*ephemeralPeer) []*ephemeralPeer {
 	idsByAccount := make(map[string][]string)
 	for id, p := range deletePeers {
 		idsByAccount[p.accountID] = append(idsByAccount[p.accountID], id)
 	}
 
+	var requeue []*ephemeralPeer
 	for accountID, ids := range idsByAccount {
 		current, err := e.store.GetPeersByIDs(ctx, store.LockingStrengthShare, accountID, ids)
 		if err != nil {
-			log.WithContext(ctx).Warnf("skip ephemeral cleanup for account %s: cannot verify connection state: %s", accountID, err)
+			log.WithContext(ctx).Warnf("defer ephemeral cleanup for account %s: cannot verify connection state: %s", accountID, err)
 			for _, id := range ids {
+				requeue = append(requeue, deletePeers[id])
 				delete(deletePeers, id)
 			}
 			continue
@@ -249,6 +264,32 @@ func (e *EphemeralManager) dropStillConnected(ctx context.Context, deletePeers m
 				delete(deletePeers, id)
 			}
 		}
+	}
+	return requeue
+}
+
+// rescheduleAfterError re-tracks peers whose connection state could not be
+// verified during cleanup (a transient store error) and re-arms the cleanup
+// timer if it is idle, so a running instance retries them after another
+// lifeTime rather than forgetting them until the next restart. A fresh
+// deadline is used deliberately: the retry is a backstop for a transient
+// store blip, not a tight spin.
+func (e *EphemeralManager) rescheduleAfterError(ctx context.Context, peers []*ephemeralPeer) {
+	e.peersLock.Lock()
+	defer e.peersLock.Unlock()
+
+	for _, p := range peers {
+		e.addPeer(p.accountID, p.id, e.newDeadLine())
+	}
+
+	if e.timer == nil && e.headPeer != nil {
+		delay := e.headPeer.deadline.Sub(timeNow()) + e.cleanupWindow
+		if delay < 0 {
+			delay = 0
+		}
+		e.timer = time.AfterFunc(delay, func() {
+			e.cleanup(ctx)
+		})
 	}
 }
 

--- a/management/server/ephemeral_test.go
+++ b/management/server/ephemeral_test.go
@@ -18,6 +18,9 @@ import (
 type MockStore struct {
 	store.Store
 	account *types.Account
+	// failGetPeersByIDs makes the next N GetPeersByIDs calls return an
+	// error, simulating a transient store outage during cleanup.
+	failGetPeersByIDs int
 }
 
 func (s *MockStore) GetAllEphemeralPeers(_ context.Context, _ store.LockingStrength) ([]*nbpeer.Peer, error) {
@@ -31,6 +34,10 @@ func (s *MockStore) GetAllEphemeralPeers(_ context.Context, _ store.LockingStren
 }
 
 func (s *MockStore) GetPeersByIDs(_ context.Context, _ store.LockingStrength, _ string, peerIDs []string) (map[string]*nbpeer.Peer, error) {
+	if s.failGetPeersByIDs > 0 {
+		s.failGetPeersByIDs--
+		return nil, fmt.Errorf("simulated store outage")
+	}
 	res := make(map[string]*nbpeer.Peer)
 	for _, id := range peerIDs {
 		if p, ok := s.account.Peers[id]; ok {
@@ -240,6 +247,69 @@ func TestCleanupSkipsClusterConnectedPeer(t *testing.T) {
 	}
 	if calls := am.GetDeletePeerCalls(); calls != 1 {
 		t.Errorf("expected exactly 1 DeletePeer call, got %d", calls)
+	}
+}
+
+// TestCleanupRequeuesPeersOnStoreError is the regression test for the
+// follow-up to #137: cleanup pops expired peers off the in-memory list
+// before it verifies their connection state, and LoadInitialPeers runs only
+// once at startup. So if the store read fails, the peers must be re-tracked
+// in process — otherwise a transient DB blip during cleanup would orphan a
+// batch of ephemeral peers until the next restart. The first cleanup hits a
+// simulated store outage (nothing deleted, peer re-tracked); a later cleanup
+// with the store healthy then deletes it, proving the retry happened without
+// a restart.
+func TestCleanupRequeuesPeersOnStoreError(t *testing.T) {
+	t.Cleanup(func() {
+		timeNow = time.Now
+	})
+	startTime := time.Now()
+	timeNow = func() time.Time {
+		return startTime
+	}
+
+	store := &MockStore{}
+	am := MockAccountManager{
+		store: store,
+	}
+
+	store.account = newAccountWithId(context.Background(), "account", "", "", false)
+	peer := &nbpeer.Peer{
+		ID: "ephemeral_offline", AccountID: store.account.Id, Ephemeral: true,
+		Status: &nbpeer.PeerStatus{Connected: false},
+	}
+	store.account.Peers[peer.ID] = peer
+
+	mgr := NewEphemeralManager(store, &am)
+	t.Cleanup(mgr.Stop)
+	mgr.loadEphemeralPeers(context.Background())
+
+	// First cleanup: the store read fails, so nothing is deleted and the
+	// peer must be re-tracked in process for a later retry.
+	store.failGetPeersByIDs = 1
+	startTime = startTime.Add(ephemeralLifeTime + 1)
+	mgr.cleanup(context.Background())
+
+	if _, ok := store.account.Peers[peer.ID]; !ok {
+		t.Fatalf("peer must not be deleted when its state could not be verified")
+	}
+	if calls := am.GetDeletePeerCalls(); calls != 0 {
+		t.Fatalf("expected 0 DeletePeer calls on store error, got %d", calls)
+	}
+	if !mgr.isPeerOnList(peer.ID) {
+		t.Fatalf("peer must be re-tracked in process after a store error, not forgotten until restart")
+	}
+
+	// Second cleanup with the store healthy: the re-tracked peer is now
+	// verified (offline) and cleaned up — no process restart needed.
+	startTime = startTime.Add(ephemeralLifeTime + ephemeralLifeTime)
+	mgr.cleanup(context.Background())
+
+	if _, ok := store.account.Peers[peer.ID]; ok {
+		t.Errorf("re-tracked offline peer should have been cleaned up on retry")
+	}
+	if calls := am.GetDeletePeerCalls(); calls != 1 {
+		t.Errorf("expected exactly 1 DeletePeer call after retry, got %d", calls)
 	}
 }
 


### PR DESCRIPTION
## Describe your changes

Follow-up to #138 (issue #137), addressing @klinux's non-blocking review note on the store-error branch of `dropStillConnected`.

`cleanup` pops expired ephemeral peers off the in-memory linked list *before* `dropStillConnected` verifies their connection state, and `LoadInitialPeers` runs only **once at startup** (`management/cmd/management.go`) — it is not periodic. So on a transient store read error the affected peers were dropped from the delete set (correctly never deleted) but also lost from in-process tracking, i.e. orphaned until the next process restart. On a single-replica deployment a brief DB blip during cleanup could strand a batch of ephemeral peers.

**Fix:** `dropStillConnected` now returns the peers whose state it could not verify; `cleanup` re-tracks them via the new `rescheduleAfterError`, which re-adds them with a fresh deadline and re-arms the cleanup timer if idle, so a running instance retries after another `lifeTime` instead of relying on a restart. The connected and already-gone cases still drop-and-forget (the stream-owning replica handles the connected one; the gone one needs nothing).

Also corrects the misleading "re-scheduled on the next `LoadInitialPeers`" comment that motivated the review note.

## Issue ticket number and link

Follow-up to #138 / #137 (both merged/closed). Review context: https://github.com/openzro/openzro/pull/138#issuecomment

## Testing

New regression test `TestCleanupRequeuesPeersOnStoreError`: the first `cleanup` hits a simulated store outage — nothing is deleted and the peer is re-tracked in process; a later `cleanup` with the store healthy then deletes it, proving the retry happens without a restart. Fails without this change (the peer is forgotten, never retried). The existing ephemeral tests stay green with `-race`.

## Stack

Single commit; no dependent branches.

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
- [x] All commits in this PR are signed off with `git commit -s` (DCO)
