### PR TITLE
feat(dns): opt-in DNS response selection for multi-resolver zones (ADR-0023)

### DIFF
--- a/client/internal/connect.go
+++ b/client/internal/connect.go
@@ -468,6 +468,7 @@ func createEngineConfig(key wgtypes.Key, config *profilemanager.Config, peerConf
 		RosenpassPermissive:  config.RosenpassPermissive,
 		ServerSSHAllowed:     util.ReturnBoolWithDefaultTrue(config.ServerSSHAllowed),
 		DNSRouteInterval:     config.DNSRouteInterval,
+		DNSSelectionPolicy:   config.DNSSelectionPolicy,
 
 		DisableClientRoutes: config.DisableClientRoutes,
 		DisableServerRoutes: config.DisableServerRoutes || config.BlockInbound,

--- a/client/internal/connect_test.go
+++ b/client/internal/connect_test.go
@@ -3,6 +3,13 @@ package internal
 import (
 	"net"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
+
+	"github.com/openzro/openzro/client/internal/profilemanager"
+	mgmProto "github.com/openzro/openzro/management/proto"
 )
 
 func Test_freePort(t *testing.T) {
@@ -66,6 +73,27 @@ func Test_freePort(t *testing.T) {
 		})
 
 	}
+}
+
+// TestCreateEngineConfig_CarriesDNSSelectionPolicy pins the seam between the
+// persisted client config and the engine: the DNS response-selection policy
+// (ADR-0023 D8) is opt-in through config.json only, so if this mapping is missing
+// the DNS server never learns about it and the whole opt-in is dead.
+func TestCreateEngineConfig_CarriesDNSSelectionPolicy(t *testing.T) {
+	key, err := wgtypes.GeneratePrivateKey()
+	require.NoError(t, err)
+
+	engineConfig, err := createEngineConfig(
+		key,
+		&profilemanager.Config{DNSSelectionPolicy: "prefer_private"},
+		&mgmProto.PeerConfig{Address: "100.64.0.1/16"},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, "prefer_private", engineConfig.DNSSelectionPolicy)
+
+	engineConfig, err = createEngineConfig(key, &profilemanager.Config{}, &mgmProto.PeerConfig{Address: "100.64.0.1/16"})
+	require.NoError(t, err)
+	assert.Empty(t, engineConfig.DNSSelectionPolicy, "an unconfigured policy stays empty")
 }
 
 // TestConnectClient_PersistState_NilSafe pins the openZro #5128

--- a/client/internal/debug/debug.go
+++ b/client/internal/debug/debug.go
@@ -451,6 +451,13 @@ func (g *BundleGenerator) addCommonConfigFields(configContent *strings.Builder) 
 
 	configContent.WriteString(fmt.Sprintf("DNSRouteInterval: %s\n", g.internalConfig.DNSRouteInterval))
 
+	// Written unconditionally, and as the configured string rather than the policy
+	// that was resolved from it: for a feature whose support question is "which
+	// answer won, and why", an absent line must not be ambiguous between "not
+	// configured" and "client too old to know the field", and an ignored typo has
+	// to stay visible.
+	configContent.WriteString(fmt.Sprintf("DNSSelectionPolicy: %s\n", g.internalConfig.DNSSelectionPolicy))
+
 	if g.internalConfig.ClientCertPath != "" {
 		configContent.WriteString(fmt.Sprintf("ClientCertPath: %s\n", g.internalConfig.ClientCertPath))
 	}

--- a/client/internal/dns/pool.go
+++ b/client/internal/dns/pool.go
@@ -244,10 +244,13 @@ func (p *resolverPool) serveSelected(
 func (p *resolverPool) gather(r *dns.Msg, members []*poolMember, logger *log.Entry) []selection.Candidate {
 	replies := make(chan selection.Candidate, len(members))
 	for _, m := range members {
+		// Each group gets its own copy of the request, taken here rather than
+		// inside the goroutine: they pack it concurrently, a shared message
+		// would be a data race, and copying before the worker starts means no
+		// worker ever reads r after ServeDNS has returned it.
+		req := r.Copy()
 		go func() {
-			// Each group gets its own copy of the request: they pack it
-			// concurrently, and a shared message would be a data race.
-			resp, err := m.resolver.queryUpstreams(logger, r.Copy())
+			resp, err := m.resolver.queryUpstreams(logger, req)
 			m.resolver.checkUpstreamFails(err)
 			replies <- selection.Candidate{Resp: resp, Source: m.resolver.source()}
 		}()

--- a/client/internal/dns/pool.go
+++ b/client/internal/dns/pool.go
@@ -1,0 +1,436 @@
+package dns
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/miekg/dns"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/openzro/openzro/client/internal/dns/selection"
+	"github.com/openzro/openzro/client/internal/dns/types"
+)
+
+const (
+	// selectionGrace bounds how much longer the pool waits for the remaining
+	// nameserver groups once the first one has replied. The clock starts with that
+	// first reply, so it caps the latency the pool ADDS, not the query as a whole
+	// (ADR-0023 D5).
+	selectionGrace = 500 * time.Millisecond
+
+	// ambiguityWarnInterval throttles the warning about nameserver groups that
+	// disagree on a name: a configuration smell for an operator to fix, not a
+	// per-query event (ADR-0023 D4).
+	ambiguityWarnInterval = 5 * time.Minute
+)
+
+// groupResolver is one nameserver group's resolver as the pool uses it: query it,
+// tell it how the query went, and manage its lifecycle. *upstreamResolver
+// satisfies this through the embedded upstreamResolverBase.
+type groupResolver interface {
+	queryUpstreams(logger *log.Entry, r *dns.Msg) (*dns.Msg, error)
+	checkUpstreamFails(err error)
+	ProbeAvailability()
+	Stop()
+	stopped() bool
+	source() string
+}
+
+// upstreamGroupHandler is one nameserver group's resolver as the server builds
+// it: a handler it can register on its own, plus the surface a pool needs.
+type upstreamGroupHandler interface {
+	handlerWithStop
+	groupResolver
+	setCallbacks(deactivate func(error), reactivate func())
+}
+
+// poolMember is one nameserver group inside a pool. enabled is false while the
+// group's health hooks have it deactivated; the pool then skips it.
+type poolMember struct {
+	resolver groupResolver
+	enabled  bool
+}
+
+// resolverPool serves one zone from every nameserver group configured for it.
+// Without a pool the highest-priority group answers and the others are never
+// asked, which is what makes a split-horizon zone return the public view of a
+// name that also has an internal one. The pool queries all groups at once and
+// hands their replies to a selection.Policy, which decides what the client gets.
+//
+// Locking, in order: hookMu → mu → the server lock. The members slice is fixed at
+// construction; only the enabled flags and the warning timestamp change, both
+// guarded by mu, and mu is never held while calling into a member or the server —
+// a member's health hook takes the server lock, so holding mu across it would
+// invert that order. hookMu is the outer lock a whole zone-level transition runs
+// under, membership change plus the zone hook that follows from it; nothing the
+// server calls while holding its own lock takes hookMu. See applyZoneState.
+type resolverPool struct {
+	domain string
+	policy selection.Policy
+	// grace and warnInterval carry the constants above; they are fields so tests
+	// can shorten them.
+	grace        time.Duration
+	warnInterval time.Duration
+
+	mu            sync.Mutex
+	members       []*poolMember
+	lastAmbiguity time.Time
+
+	hookMu sync.Mutex
+	zoneUp bool
+}
+
+func newResolverPool(domain string, policy selection.Policy, resolvers []groupResolver) *resolverPool {
+	members := make([]*poolMember, 0, len(resolvers))
+	for _, resolver := range resolvers {
+		members = append(members, &poolMember{resolver: resolver, enabled: true})
+	}
+
+	return &resolverPool{
+		domain:       domain,
+		policy:       policy,
+		grace:        selectionGrace,
+		warnInterval: ambiguityWarnInterval,
+		members:      members,
+		// The pool is registered for its zone as it is built.
+		zoneUp: true,
+	}
+}
+
+// String returns a string representation of the pool.
+func (p *resolverPool) String() string {
+	return fmt.Sprintf("pool for %s over %d nameserver groups", p.domain, len(p.members))
+}
+
+// ID returns the unique handler ID. It covers the zone and the pooled groups, so
+// re-applying an unchanged configuration re-registers the same handler, and is
+// distinct from the ID of any single group's resolver.
+func (p *resolverPool) ID() types.HandlerID {
+	sources := make([]string, 0, len(p.members))
+	for _, m := range p.members {
+		sources = append(sources, m.resolver.source())
+	}
+	slices.Sort(sources)
+
+	hash := sha256.New()
+	hash.Write([]byte(p.domain + ":"))
+	hash.Write([]byte(strings.Join(sources, "|")))
+	return types.HandlerID("upstream-pool-" + hex.EncodeToString(hash.Sum(nil)[:8]))
+}
+
+// MatchSubdomains reports that the pool serves the zone's subdomains too, as a
+// single upstream group does.
+func (p *resolverPool) MatchSubdomains() bool {
+	return true
+}
+
+// Stop stops every pooled group, deactivated ones included.
+func (p *resolverPool) Stop() {
+	log.Debugf("stopping %s", p)
+	for _, m := range p.members {
+		m.resolver.Stop()
+	}
+}
+
+// ProbeAvailability probes every pooled group, deactivated ones included, and
+// leaves it to each group what to make of the result. Note that probing never
+// brings a group back by itself: a deactivated group returns through its own
+// backoff loop (waitUntilResponse), which then calls the reactivate hook.
+func (p *resolverPool) ProbeAvailability() {
+	var wg sync.WaitGroup
+	for _, m := range p.members {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			m.resolver.ProbeAvailability()
+		}()
+	}
+	wg.Wait()
+}
+
+// ServeDNS answers one query for the pooled zone.
+func (p *resolverPool) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
+	logger := log.WithField("request_id", GenerateRequestID())
+
+	if len(r.Question) == 0 {
+		logger.Warnf("%s received a request without a question", p)
+		p.writeRcode(w, r, dns.RcodeFormatError, logger)
+		return
+	}
+
+	q := r.Question[0]
+	logger.Tracef("received pooled question: domain=%s type=%v class=%v", q.Name, q.Qtype, q.Qclass)
+
+	if r.Extra == nil {
+		r.MsgHdr.AuthenticatedData = true
+	}
+
+	enabled := p.enabledMembers()
+	members := runningMembers(enabled)
+	switch {
+	case len(enabled) > 0 && len(members) == 0:
+		// Stopped, not deactivated: a query that raced a reconfiguration. Say
+		// nothing and write nothing, as a stopped single resolver does.
+		logger.Tracef("%s has been stopped", p)
+	case len(members) == 0:
+		logger.Errorf("every nameserver group of %s is deactivated, question domain=%s", p, q.Name)
+		p.writeRcode(w, r, dns.RcodeServerFailure, logger)
+	case len(members) == 1 || !isAddressQuery(q.Qtype):
+		// Only address queries carry the signal a policy ranks on (ADR-0023 D5),
+		// so anything else is served by the highest-priority group alone —
+		// exactly as it is without a pool.
+		p.serveSingleGroup(w, r, members[0], logger)
+	default:
+		p.serveSelected(w, r, q, members, logger)
+	}
+}
+
+// serveSingleGroup forwards one group's reply, or SERVFAIL when it did not
+// answer: the behavior of a zone served by a single nameserver group.
+func (p *resolverPool) serveSingleGroup(w dns.ResponseWriter, r *dns.Msg, m *poolMember, logger *log.Entry) {
+	resp, err := m.resolver.queryUpstreams(logger, r)
+	m.resolver.checkUpstreamFails(err)
+
+	if resp == nil {
+		logger.Errorf("nameserver group %s of %s failed for question domain=%s: %v",
+			m.resolver.source(), p, r.Question[0].Name, err)
+		p.writeRcode(w, r, dns.RcodeServerFailure, logger)
+		return
+	}
+	p.write(w, resp, logger)
+}
+
+// serveSelected gathers every group's reply and writes the one the policy picks.
+func (p *resolverPool) serveSelected(
+	w dns.ResponseWriter,
+	r *dns.Msg,
+	q dns.Question,
+	members []*poolMember,
+	logger *log.Entry,
+) {
+	cands := p.gather(r, members, logger)
+
+	res, ok := p.policy.Select(q, cands)
+	if !ok {
+		logger.Errorf("no nameserver group of %s answered question domain=%s", p, q.Name)
+		p.writeRcode(w, r, dns.RcodeServerFailure, logger)
+		return
+	}
+
+	// Debug, not trace: when an operator asks why a name resolved to the public
+	// address although prefer_private is on, the source that won is the first thing
+	// to look at, and a policy can decline to prefer an answer for reasons the
+	// answer alone does not show (a mixed address set, an alias-only reply).
+	logger.Debugf("policy=%s selected the response from %s for question domain=%s",
+		p.policy.Name(), res.Source, q.Name)
+	if res.Ambiguous {
+		p.warnAmbiguous(q, res, cands, logger)
+	}
+	p.write(w, res.Resp, logger)
+}
+
+// gather queries every given group concurrently and collects the replies. It
+// returns once all of them have answered, or once the grace window that starts
+// with the first reply has elapsed — a straggler must not hold the answer back
+// (ADR-0023 D5). Groups still in flight are left behind; their result lands in the
+// buffered channel, so nothing blocks or leaks. There is deliberately no early
+// exit on an already-preferred reply: waiting out the window is what keeps the
+// choice independent of arrival order (ADR-0023 D4).
+func (p *resolverPool) gather(r *dns.Msg, members []*poolMember, logger *log.Entry) []selection.Candidate {
+	replies := make(chan selection.Candidate, len(members))
+	for _, m := range members {
+		go func() {
+			// Each group gets its own copy of the request: they pack it
+			// concurrently, and a shared message would be a data race.
+			resp, err := m.resolver.queryUpstreams(logger, r.Copy())
+			m.resolver.checkUpstreamFails(err)
+			replies <- selection.Candidate{Resp: resp, Source: m.resolver.source()}
+		}()
+	}
+
+	var timer *time.Timer
+	var grace <-chan time.Time
+	defer func() {
+		if timer != nil {
+			timer.Stop()
+		}
+	}()
+
+	cands := make([]selection.Candidate, 0, len(members))
+	for range members {
+		select {
+		case c := <-replies:
+			cands = append(cands, c)
+			// Armed by the first candidate a policy could actually rank, so a
+			// group that failed outright does not start the clock: cutting the
+			// window short after a fast failure would throw away the very answer
+			// the pool exists to fetch. The wait is then bounded by each group's
+			// own upstreamTimeout — see the ADR's implementation notes.
+			if timer == nil && selection.Responded(c.Resp) {
+				timer = time.NewTimer(p.grace)
+				grace = timer.C
+			}
+		case <-grace:
+			// Drain what is already in the channel before giving up. Go picks a
+			// ready case at random, so a reply that landed in the same instant
+			// the window elapsed would otherwise be kept or dropped by chance —
+			// exactly the arrival-order dependence D4 rules out.
+			cands = drainCandidates(replies, cands)
+			logger.Debugf("grace window of %s elapsed for question domain=%s with %d of %d replies",
+				p, r.Question[0].Name, len(cands), len(members))
+			return cands
+		}
+	}
+	return cands
+}
+
+// drainCandidates appends every candidate already buffered in replies, without waiting.
+func drainCandidates(replies <-chan selection.Candidate, cands []selection.Candidate) []selection.Candidate {
+	for {
+		select {
+		case c := <-replies:
+			cands = append(cands, c)
+		default:
+			return cands
+		}
+	}
+}
+
+// runningMembers returns the members that have not been stopped. It is applied outside
+// enabledMembers so that no member is called while p.mu is held.
+func runningMembers(members []*poolMember) []*poolMember {
+	active := make([]*poolMember, 0, len(members))
+	for _, m := range members {
+		if !m.resolver.stopped() {
+			active = append(active, m)
+		}
+	}
+	return active
+}
+
+// enabledMembers returns the groups the pool may query, in configuration order.
+func (p *resolverPool) enabledMembers() []*poolMember {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	active := make([]*poolMember, 0, len(p.members))
+	for _, m := range p.members {
+		if m.enabled {
+			active = append(active, m)
+		}
+	}
+	return active
+}
+
+// setMember adds a group to the fan-out or drops it, and reports whether that
+// changed anything. An out-of-range group is ignored.
+func (p *resolverPool) setMember(member int, enabled bool) (changed bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if member < 0 || member >= len(p.members) || p.members[member].enabled == enabled {
+		return false
+	}
+	p.members[member].enabled = enabled
+	return true
+}
+
+// serving reports whether the pool has a group left to ask.
+func (p *resolverPool) serving() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for _, m := range p.members {
+		if m.enabled {
+			return true
+		}
+	}
+	return false
+}
+
+// applyZoneState brings the zone-level registration in line with the membership:
+// a zone with no group left is deactivated, one that has a group again is
+// reactivated, and anything else is left alone.
+//
+// Callers hold hookMu, which is what makes this safe. Two groups can flip at the
+// same moment — one deactivates under its own lock while another reactivates from
+// its backoff goroutine — so edge-triggering off "was that the last one?" would let
+// the two zone hooks run in either order, leaving the zone deregistered with a
+// healthy group in the pool. Deciding from the membership converges whatever the
+// order, and reactivate can no longer precede deactivate, which its contract
+// forbids.
+func (p *resolverPool) applyZoneState(err error, deactivateZone func(error), reactivateZone func()) {
+	serving := p.serving()
+	if serving == p.zoneUp {
+		return
+	}
+
+	p.zoneUp = serving
+	if serving {
+		reactivateZone()
+		return
+	}
+	deactivateZone(err)
+}
+
+// warnAmbiguous logs, at most once per warnInterval, that the zone's nameserver
+// groups return different internal addresses for a name. The selection itself
+// stays deterministic; this is a configuration smell for the operator to fix.
+func (p *resolverPool) warnAmbiguous(
+	q dns.Question,
+	res selection.Result,
+	cands []selection.Candidate,
+	logger *log.Entry,
+) {
+	if !p.shouldWarn(time.Now()) {
+		return
+	}
+
+	answered := make([]string, 0, len(cands))
+	for _, c := range cands {
+		if c.Resp != nil {
+			answered = append(answered, c.Source)
+		}
+	}
+	logger.Warnf("nameserver groups of %s disagree on the internal address for domain=%s "+
+		"(answered: %s), serving the answer from %s. Check the zone's nameserver configuration.",
+		p, q.Name, strings.Join(answered, ", "), res.Source)
+}
+
+// shouldWarn reports whether an ambiguity warning may be emitted at now, and
+// records it when it may. Time is a parameter so the throttle stays testable.
+func (p *resolverPool) shouldWarn(now time.Time) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if !p.lastAmbiguity.IsZero() && now.Sub(p.lastAmbiguity) < p.warnInterval {
+		return false
+	}
+	p.lastAmbiguity = now
+	return true
+}
+
+// write sends resp to the client.
+func (p *resolverPool) write(w dns.ResponseWriter, resp *dns.Msg, logger *log.Entry) {
+	if err := w.WriteMsg(resp); err != nil {
+		logger.Errorf("failed to write DNS response for %s: %s", p, err)
+	}
+}
+
+// writeRcode answers r with a bare rcode.
+func (p *resolverPool) writeRcode(w dns.ResponseWriter, r *dns.Msg, rcode int, logger *log.Entry) {
+	m := new(dns.Msg)
+	m.SetRcode(r, rcode)
+	p.write(w, m, logger)
+}
+
+// isAddressQuery reports whether qtype asks for an address — the only kind of
+// answer a selection policy can rank (ADR-0023 D5).
+func isAddressQuery(qtype uint16) bool {
+	return qtype == dns.TypeA || qtype == dns.TypeAAAA
+}

--- a/client/internal/dns/pool_health_test.go
+++ b/client/internal/dns/pool_health_test.go
@@ -1,0 +1,405 @@
+package dns
+
+// This file covers the health side of pooling: how a member's deactivation and
+// return move the zone's registration, and how the server wires the two levels
+// together. The selection behavior itself is in pool_test.go.
+
+import (
+	"context"
+	"errors"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openzro/openzro/client/internal/dns/selection"
+	"github.com/openzro/openzro/client/internal/peer"
+	nbdns "github.com/openzro/openzro/dns"
+	"github.com/openzro/openzro/management/domain"
+)
+
+// TestResolverPool_MemberTransitions covers the membership bookkeeping the health
+// hooks drive.
+func TestResolverPool_MemberTransitions(t *testing.T) {
+	pool := newTestPool(t, "prefer_private",
+		&fakeGroup{src: "a-first", resp: aReply(privateAddr)},
+		&fakeGroup{src: "b-second", resp: aReply(publicAddr)},
+	)
+
+	assert.True(t, pool.setMember(0, false), "disabling a group changes the pool")
+	assert.False(t, pool.setMember(0, false), "disabling twice is a no-op")
+	assert.True(t, pool.serving(), "one group is left")
+
+	assert.True(t, pool.setMember(1, false), "the last group goes down")
+	assert.False(t, pool.serving(), "no group is left")
+
+	assert.True(t, pool.setMember(1, true), "a group comes back")
+	assert.True(t, pool.serving())
+	assert.False(t, pool.setMember(1, true), "enabling twice is a no-op")
+
+	assert.False(t, pool.setMember(-1, false), "an out-of-range member is ignored")
+	assert.False(t, pool.setMember(7, true), "an out-of-range member is ignored")
+}
+
+// TestResolverPool_ZoneStateFollowsMembership pins that the zone-level hooks are
+// driven by the membership, not by edges. Two groups can flip at the same moment
+// — one deactivating under its own lock while another reactivates from its
+// backoff goroutine — so reacting to "was that the last one?" would let the hooks
+// run in either order and leave the zone deregistered with a healthy group in the
+// pool. Deciding from the membership converges whatever the order.
+func TestResolverPool_ZoneStateFollowsMembership(t *testing.T) {
+	// Each case flips members in order and states the zone state and the number
+	// of zone hook calls that must follow.
+	type step struct {
+		member  int
+		enabled bool
+	}
+	cases := []struct {
+		name     string
+		steps    []step
+		wantUp   bool
+		wantDown int
+		wantBack int
+	}{
+		{
+			name:   "losing one of two groups keeps the zone served",
+			steps:  []step{{0, false}},
+			wantUp: true,
+		},
+		{
+			name:     "losing the last group deactivates the zone",
+			steps:    []step{{0, false}, {1, false}},
+			wantDown: 1,
+		},
+		{
+			name:     "the group that returns first brings the zone back",
+			steps:    []step{{0, false}, {1, false}, {0, true}},
+			wantUp:   true,
+			wantDown: 1,
+			wantBack: 1,
+		},
+		{
+			// The adversarial interleaving: the reactivation of the group that
+			// was already down is applied before the other group's failure.
+			name:     "a reactivation racing a failure leaves the zone served",
+			steps:    []step{{1, false}, {1, true}, {0, false}},
+			wantUp:   true,
+			wantDown: 0,
+			wantBack: 0,
+		},
+		{
+			name:     "repeated failures do not deactivate twice",
+			steps:    []step{{0, false}, {1, false}, {1, false}, {0, false}},
+			wantDown: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pool := newTestPool(t, "prefer_private",
+				&fakeGroup{src: "a-first", resp: aReply(privateAddr)},
+				&fakeGroup{src: "b-second", resp: aReply(publicAddr)},
+			)
+
+			var down, back int
+			deactivate := func(error) { down++ }
+			reactivate := func() { back++ }
+
+			for _, s := range tc.steps {
+				pool.setMember(s.member, s.enabled)
+				pool.applyZoneState(nil, deactivate, reactivate)
+			}
+
+			assert.Equal(t, tc.wantUp, pool.zoneUp, "zone state")
+			assert.Equal(t, tc.wantUp, pool.serving(), "zone state must match the membership")
+			assert.Equal(t, tc.wantDown, down, "zone deactivations")
+			assert.Equal(t, tc.wantBack, back, "zone reactivations")
+		})
+	}
+}
+
+// TestServer_PooledZoneHooksAreSerialized proves the hooks of two groups cannot
+// interleave: while one zone hook runs, the other group's transition has to wait.
+// Without that, both groups decide their transition first and the hooks then run
+// in an unspecified order — reactivate before deactivate leaves the zone
+// deregistered although a group is healthy, and violates the hook contract.
+func TestServer_PooledZoneHooksAreSerialized(t *testing.T) {
+	const zone = "eu.example.com"
+
+	server := poolServer(t, zone)
+	pool := registerPools(t, server, []*nbdns.NameServerGroup{
+		nsGroupFor("10.0.0.53", zone),
+		nsGroupFor("8.8.8.8", zone),
+	})[zone]
+
+	downA, _ := memberHooks(t, pool, 0)
+	downB, upB := memberHooks(t, pool, 1)
+
+	// B is already down, so A failing is what takes the zone with it.
+	downB(errors.New("timeout"))
+	require.True(t, zoneDisabled(t, server, zone) == false, "one group left: zone still served")
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	blocked := make(chan struct{})
+
+	// Hold the zone-level deactivation open, then have B return underneath it.
+	pool.hookMu.Lock()
+	go func() {
+		close(entered)
+		downA(errors.New("timeout"))
+	}()
+	<-entered
+
+	go func() {
+		upB()
+		close(blocked)
+	}()
+
+	select {
+	case <-blocked:
+		t.Fatal("a member transition ran while another was in progress")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	pool.hookMu.Unlock()
+	close(release)
+	<-blocked
+
+	// Whatever order the two got the lock in, the zone must match the membership.
+	assert.True(t, pool.serving(), "B is back, so the pool serves the zone")
+	assert.False(t, zoneDisabled(t, server, zone), "the zone must not stay disabled")
+	assert.True(t, zoneRegistered(server, zone, PriorityUpstream), "the handler must be registered")
+}
+
+// TestServer_PoolReplacesPerGroupHandlers asserts the merge point: with a
+// selection policy configured, a zone served by several nameserver groups gets a
+// single pooled handler instead of one handler per group at descending
+// priorities. Without a policy the pre-existing per-group handlers stay.
+func TestServer_PoolReplacesPerGroupHandlers(t *testing.T) {
+	nsGroups := []*nbdns.NameServerGroup{
+		{
+			Domains:     []string{"eu.example.com"},
+			NameServers: []nbdns.NameServer{{IP: netip.MustParseAddr("10.0.0.53"), NSType: nbdns.UDPNameServerType, Port: 53}},
+		},
+		{
+			Domains:     []string{"eu.example.com"},
+			NameServers: []nbdns.NameServer{{IP: netip.MustParseAddr("8.8.8.8"), NSType: nbdns.UDPNameServerType, Port: 53}},
+		},
+	}
+
+	newServer := func(policy selection.Policy) *DefaultServer {
+		return &DefaultServer{
+			ctx:             context.Background(),
+			wgInterface:     &mocWGIface{},
+			handlerChain:    NewHandlerChain(),
+			service:         &mockService{},
+			extraDomains:    make(map[domain.Domain]int),
+			selectionPolicy: policy,
+		}
+	}
+
+	t.Run("without a policy every group keeps its own handler", func(t *testing.T) {
+		updates, err := newServer(nil).buildUpstreamHandlerUpdate(nsGroups)
+		require.NoError(t, err)
+		require.Len(t, updates, 2)
+		assert.Equal(t, PriorityUpstream, updates[0].priority)
+		assert.Equal(t, PriorityUpstream-1, updates[1].priority)
+		for _, u := range updates {
+			_, isPool := u.handler.(*resolverPool)
+			assert.False(t, isPool, "expected a per-group handler, got a pool")
+			u.handler.Stop()
+		}
+	})
+
+	t.Run("with a policy the zone gets one pooled handler", func(t *testing.T) {
+		policy, ok := selection.Get("prefer_private")
+		require.True(t, ok)
+
+		updates, err := newServer(policy).buildUpstreamHandlerUpdate(nsGroups)
+		require.NoError(t, err)
+		require.Len(t, updates, 1)
+		assert.Equal(t, "eu.example.com", updates[0].domain)
+		assert.Equal(t, PriorityUpstream, updates[0].priority)
+
+		pool, isPool := updates[0].handler.(*resolverPool)
+		require.True(t, isPool, "expected a pooled handler, got %T", updates[0].handler)
+		assert.Len(t, pool.members, 2)
+		pool.Stop()
+	})
+}
+
+// nsGroupFor builds a nameserver group serving the given domains.
+func nsGroupFor(ip string, domains ...string) *nbdns.NameServerGroup {
+	return &nbdns.NameServerGroup{
+		Domains:     domains,
+		NameServers: []nbdns.NameServer{{IP: netip.MustParseAddr(ip), NSType: nbdns.UDPNameServerType, Port: 53}},
+	}
+}
+
+// hooks returns the health hooks installed on this resolver. It lives in the
+// test because only the test needs to read them back — production only ever
+// installs them (setCallbacks) and calls them from within the resolver.
+func (u *upstreamResolverBase) hooks() (deactivate func(error), reactivate func()) {
+	return u.deactivate, u.reactivate
+}
+
+// hookedResolver is what the server installs the health hooks on. Every
+// platform's resolver satisfies it through the embedded upstreamResolverBase, so
+// a test can drive exactly the pair the resolver itself would call.
+type hookedResolver interface {
+	hooks() (deactivate func(error), reactivate func())
+}
+
+// poolServer builds a server that pools multi-group zones, with just enough
+// state for the health hooks to run: a host config listing the zones and a
+// status recorder for the per-group state.
+func poolServer(t *testing.T, zones ...string) *DefaultServer {
+	t.Helper()
+
+	policy, ok := selection.Get("prefer_private")
+	require.True(t, ok)
+
+	domains := make([]DomainConfig, 0, len(zones))
+	for _, zone := range zones {
+		domains = append(domains, DomainConfig{Domain: zone})
+	}
+
+	return &DefaultServer{
+		ctx:             context.Background(),
+		wgInterface:     &mocWGIface{},
+		handlerChain:    NewHandlerChain(),
+		service:         &mockService{},
+		hostManager:     &noopHostConfigurator{},
+		extraDomains:    make(map[domain.Domain]int),
+		statusRecorder:  peer.NewRecorder("test"),
+		currentConfig:   HostDNSConfig{Domains: domains},
+		selectionPolicy: policy,
+	}
+}
+
+// registerPools registers every pooled handler the way updateMux does, and
+// returns them by zone.
+func registerPools(t *testing.T, s *DefaultServer, groups []*nbdns.NameServerGroup) map[string]*resolverPool {
+	t.Helper()
+
+	updates, err := s.buildUpstreamHandlerUpdate(groups)
+	require.NoError(t, err)
+
+	pools := make(map[string]*resolverPool, len(updates))
+	for _, u := range updates {
+		pool, isPool := u.handler.(*resolverPool)
+		require.Truef(t, isPool, "zone %s did not get a pooled handler, got %T", u.domain, u.handler)
+		s.registerHandler([]string{u.domain}, pool, u.priority)
+		pools[u.domain] = pool
+		t.Cleanup(pool.Stop)
+	}
+	return pools
+}
+
+// memberHooks returns the health hooks the server installed on a pooled member.
+func memberHooks(t *testing.T, pool *resolverPool, member int) (func(error), func()) {
+	t.Helper()
+
+	hooked, ok := pool.members[member].resolver.(hookedResolver)
+	require.Truef(t, ok, "member %d is a %T, which carries no health hooks", member, pool.members[member].resolver)
+
+	deactivate, reactivate := hooked.hooks()
+	require.NotNil(t, deactivate, "member %d has no deactivate hook", member)
+	require.NotNil(t, reactivate, "member %d has no reactivate hook", member)
+	return deactivate, reactivate
+}
+
+// zoneDisabled reports whether the host config has the zone marked disabled.
+func zoneDisabled(t *testing.T, s *DefaultServer, zone string) bool {
+	t.Helper()
+
+	for _, d := range s.currentConfig.Domains {
+		if d.Domain == zone {
+			return d.Disabled
+		}
+	}
+	t.Fatalf("zone %s is not in the host config", zone)
+	return false
+}
+
+// zoneRegistered reports whether a handler for the zone sits in the chain.
+func zoneRegistered(s *DefaultServer, zone string, priority int) bool {
+	s.handlerChain.mu.RLock()
+	defer s.handlerChain.mu.RUnlock()
+
+	for _, h := range s.handlerChain.handlers {
+		if h.OrigPattern == dns.Fqdn(zone) && h.Priority == priority {
+			return true
+		}
+	}
+	return false
+}
+
+// TestServer_PooledZoneRecoversWhateverGroupReturnsFirst pins the zone-level
+// health contract: the last group going down deactivates the zone, and ANY group
+// coming back brings it up again — not just the one that happened to be last.
+// The hooks share one removeIndex per pool, so this holds whichever group wins
+// the race back.
+func TestServer_PooledZoneRecoversWhateverGroupReturnsFirst(t *testing.T) {
+	const zone = "eu.example.com"
+
+	server := poolServer(t, zone)
+	pools := registerPools(t, server, []*nbdns.NameServerGroup{
+		nsGroupFor("10.0.0.53", zone),
+		nsGroupFor("8.8.8.8", zone),
+	})
+	pool := pools[zone]
+	require.Len(t, pool.members, 2)
+
+	downFirst, upFirst := memberHooks(t, pool, 0)
+	downLast, _ := memberHooks(t, pool, 1)
+	timeout := errors.New("timeout")
+
+	downFirst(timeout)
+	assert.False(t, zoneDisabled(t, server, zone), "one group left: the zone stays served")
+	assert.True(t, zoneRegistered(server, zone, PriorityUpstream), "the handler stays registered")
+
+	downLast(timeout)
+	require.True(t, zoneDisabled(t, server, zone), "the last group down must deactivate the zone")
+	require.False(t, zoneRegistered(server, zone, PriorityUpstream), "the handler must be deregistered")
+
+	// The group that comes back first is NOT the one that took the zone down.
+	upFirst()
+	assert.False(t, zoneDisabled(t, server, zone), "any group returning must bring the zone back")
+	assert.True(t, zoneRegistered(server, zone, PriorityUpstream), "the handler must be registered again")
+}
+
+// TestServer_PooledZoneDeactivationLeavesOtherZonesAlone pins the scope of the
+// zone-level hooks. A group may serve several domains, each pooled separately
+// with its own health; one zone losing all of its groups must not deregister
+// another zone that still has a healthy group.
+func TestServer_PooledZoneDeactivationLeavesOtherZonesAlone(t *testing.T) {
+	const (
+		failing = "eu.example.com"
+		healthy = "us.example.com"
+	)
+
+	server := poolServer(t, failing, healthy)
+	// The middle group serves both zones, so it is pooled in both.
+	pools := registerPools(t, server, []*nbdns.NameServerGroup{
+		nsGroupFor("10.0.0.53", failing),
+		nsGroupFor("10.0.0.54", failing, healthy),
+		nsGroupFor("8.8.8.8", healthy),
+	})
+	require.Len(t, pools, 2)
+
+	timeout := errors.New("timeout")
+	for member := range pools[failing].members {
+		down, _ := memberHooks(t, pools[failing], member)
+		down(timeout)
+	}
+
+	require.True(t, zoneDisabled(t, server, failing), "the failing zone lost every group")
+	assert.False(t, zoneDisabled(t, server, healthy), "the other zone still has a healthy group")
+	assert.True(t, zoneRegistered(server, healthy, PriorityUpstream),
+		"the other zone's handler must stay registered")
+}

--- a/client/internal/dns/pool_test.go
+++ b/client/internal/dns/pool_test.go
@@ -1,0 +1,521 @@
+package dns
+
+import (
+	"errors"
+	"net"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openzro/openzro/client/internal/dns/selection"
+	"github.com/openzro/openzro/client/internal/dns/test"
+)
+
+const (
+	poolZone    = "eu.example.com."
+	publicAddr  = "203.0.113.10"
+	privateAddr = "10.1.2.3"
+	meshAddr    = "100.64.0.7"
+)
+
+// testGrace keeps the pool's grace window short enough to keep tests fast while
+// staying well above the scheduling jitter of a loaded CI runner.
+const testGrace = 300 * time.Millisecond
+
+// fakeGroup is a groupResolver that replies from a canned message after an
+// optional delay, without touching the network.
+type fakeGroup struct {
+	src   string
+	resp  *dns.Msg
+	err   error
+	delay time.Duration
+
+	queried atomic.Int32
+	checked atomic.Int32
+	probed  atomic.Int32
+	stops   atomic.Int32
+
+	mu       sync.Mutex
+	seen     []*dns.Msg
+	reported []error
+}
+
+// reportedErrors returns the errors handed to checkUpstreamFails.
+func (f *fakeGroup) reportedErrors() []error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return slices.Clone(f.reported)
+}
+
+func (f *fakeGroup) queryUpstreams(_ *log.Entry, r *dns.Msg) (*dns.Msg, error) {
+	f.queried.Add(1)
+	f.mu.Lock()
+	f.seen = append(f.seen, r)
+	f.mu.Unlock()
+
+	if f.delay > 0 {
+		time.Sleep(f.delay)
+	}
+	if f.resp == nil {
+		return nil, f.err
+	}
+
+	resp := f.resp.Copy()
+	resp.Id = r.Id
+	return resp, nil
+}
+
+func (f *fakeGroup) checkUpstreamFails(err error) {
+	f.checked.Add(1)
+	f.mu.Lock()
+	f.reported = append(f.reported, err)
+	f.mu.Unlock()
+}
+func (f *fakeGroup) ProbeAvailability() { f.probed.Add(1) }
+func (f *fakeGroup) Stop()              { f.stops.Add(1) }
+func (f *fakeGroup) stopped() bool      { return f.stops.Load() > 0 }
+func (f *fakeGroup) source() string     { return f.src }
+
+func (f *fakeGroup) requests() []*dns.Msg {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return slices.Clone(f.seen)
+}
+
+// aReply builds an upstream reply carrying the given addresses as A records.
+func aReply(addrs ...string) *dns.Msg {
+	m := rcodeReply(dns.RcodeSuccess)
+	for _, addr := range addrs {
+		m.Answer = append(m.Answer, &dns.A{
+			Hdr: dns.RR_Header{Name: poolZone, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
+			A:   net.ParseIP(addr),
+		})
+	}
+	return m
+}
+
+// rcodeReply builds an answerless upstream reply with the given rcode.
+func rcodeReply(rcode int) *dns.Msg {
+	return &dns.Msg{
+		MsgHdr:   dns.MsgHdr{Response: true, Rcode: rcode},
+		Question: []dns.Question{{Name: poolZone, Qtype: dns.TypeA, Qclass: dns.ClassINET}},
+	}
+}
+
+func newTestPool(t *testing.T, policy string, groups ...*fakeGroup) *resolverPool {
+	t.Helper()
+
+	p, ok := selection.Get(policy)
+	require.True(t, ok, "unknown policy %q", policy)
+
+	resolvers := make([]groupResolver, 0, len(groups))
+	for _, g := range groups {
+		resolvers = append(resolvers, g)
+	}
+
+	pool := newResolverPool(poolZone, p, resolvers)
+	pool.grace = testGrace
+	return pool
+}
+
+// serveQuery runs one query through the pool and returns the written response.
+func serveQuery(t *testing.T, pool *resolverPool, qtype uint16) *dns.Msg {
+	t.Helper()
+
+	var got *dns.Msg
+	w := &test.MockResponseWriter{WriteMsgFunc: func(m *dns.Msg) error {
+		got = m
+		return nil
+	}}
+	pool.ServeDNS(w, new(dns.Msg).SetQuestion(poolZone, qtype))
+	require.NotNil(t, got, "pool wrote no response")
+	return got
+}
+
+// answerAddrs returns the addresses carried by m, for comparison in assertions.
+func answerAddrs(m *dns.Msg) []string {
+	var addrs []string
+	for _, rr := range m.Answer {
+		switch v := rr.(type) {
+		case *dns.A:
+			addrs = append(addrs, v.A.String())
+		case *dns.AAAA:
+			addrs = append(addrs, v.AAAA.String())
+		}
+	}
+	return addrs
+}
+
+func TestResolverPool_ServeDNS(t *testing.T) {
+	tests := []struct {
+		name        string
+		policy      string
+		qtype       uint16
+		groups      []*fakeGroup
+		disable     []int
+		wantAddrs   []string
+		wantRcode   int
+		wantQueried []int32
+	}{
+		{
+			name:   "prefer_private returns the internal answer over the public one",
+			policy: "prefer_private",
+			qtype:  dns.TypeA,
+			groups: []*fakeGroup{
+				{src: "a-public", resp: aReply(publicAddr)},
+				{src: "b-internal", resp: aReply(privateAddr), delay: 20 * time.Millisecond},
+			},
+			wantAddrs:   []string{privateAddr},
+			wantRcode:   dns.RcodeSuccess,
+			wantQueried: []int32{1, 1},
+		},
+		{
+			name:   "prefer_private returns the internal answer regardless of reply order",
+			policy: "prefer_private",
+			qtype:  dns.TypeA,
+			groups: []*fakeGroup{
+				{src: "a-internal", resp: aReply(privateAddr)},
+				{src: "b-public", resp: aReply(publicAddr), delay: 20 * time.Millisecond},
+			},
+			wantAddrs:   []string{privateAddr},
+			wantRcode:   dns.RcodeSuccess,
+			wantQueried: []int32{1, 1},
+		},
+		{
+			name:   "a CGNAT mesh address counts as internal",
+			policy: "prefer_private",
+			qtype:  dns.TypeA,
+			groups: []*fakeGroup{
+				{src: "a-public", resp: aReply(publicAddr)},
+				{src: "b-mesh", resp: aReply(meshAddr)},
+			},
+			wantAddrs:   []string{meshAddr},
+			wantRcode:   dns.RcodeSuccess,
+			wantQueried: []int32{1, 1},
+		},
+		{
+			name:   "two internal answers resolve deterministically by source",
+			policy: "prefer_private",
+			qtype:  dns.TypeA,
+			groups: []*fakeGroup{
+				{src: "b-second", resp: aReply(privateAddr), delay: 20 * time.Millisecond},
+				{src: "a-first", resp: aReply("10.9.9.9")},
+			},
+			wantAddrs:   []string{"10.9.9.9"},
+			wantRcode:   dns.RcodeSuccess,
+			wantQueried: []int32{1, 1},
+		},
+		{
+			name:   "the public answer is kept when no group has an internal one",
+			policy: "prefer_private",
+			qtype:  dns.TypeA,
+			groups: []*fakeGroup{
+				{src: "b-second", resp: aReply("198.51.100.7"), delay: 20 * time.Millisecond},
+				{src: "a-first", resp: aReply(publicAddr)},
+			},
+			wantAddrs:   []string{publicAddr},
+			wantRcode:   dns.RcodeSuccess,
+			wantQueried: []int32{1, 1},
+		},
+		{
+			name:   "an upstream error reply is forwarded rather than synthesized",
+			policy: "prefer_private",
+			qtype:  dns.TypeA,
+			groups: []*fakeGroup{
+				{src: "a-first", resp: rcodeReply(dns.RcodeServerFailure)},
+				{src: "b-second", resp: rcodeReply(dns.RcodeRefused)},
+			},
+			wantRcode:   dns.RcodeServerFailure,
+			wantQueried: []int32{1, 1},
+		},
+		{
+			name:   "no reply from any group yields SERVFAIL",
+			policy: "prefer_private",
+			qtype:  dns.TypeA,
+			groups: []*fakeGroup{
+				{src: "a-first", err: errors.New("timeout")},
+				{src: "b-second", err: errors.New("timeout")},
+			},
+			wantRcode:   dns.RcodeServerFailure,
+			wantQueried: []int32{1, 1},
+		},
+		{
+			name:   "a non-address query is served by the first group alone",
+			policy: "prefer_private",
+			qtype:  dns.TypeMX,
+			groups: []*fakeGroup{
+				{src: "a-first", resp: rcodeReply(dns.RcodeSuccess)},
+				{src: "b-second", resp: rcodeReply(dns.RcodeRefused)},
+			},
+			wantRcode:   dns.RcodeSuccess,
+			wantQueried: []int32{1, 0},
+		},
+		{
+			name:   "a deactivated group is not queried",
+			policy: "prefer_private",
+			qtype:  dns.TypeA,
+			groups: []*fakeGroup{
+				{src: "a-internal", resp: aReply(privateAddr)},
+				{src: "b-public", resp: aReply(publicAddr)},
+			},
+			disable:     []int{0},
+			wantAddrs:   []string{publicAddr},
+			wantRcode:   dns.RcodeSuccess,
+			wantQueried: []int32{0, 1},
+		},
+		{
+			name:   "SERVFAIL is returned when every group is deactivated",
+			policy: "prefer_private",
+			qtype:  dns.TypeA,
+			groups: []*fakeGroup{
+				{src: "a-internal", resp: aReply(privateAddr)},
+				{src: "b-public", resp: aReply(publicAddr)},
+			},
+			disable:     []int{0, 1},
+			wantRcode:   dns.RcodeServerFailure,
+			wantQueried: []int32{0, 0},
+		},
+		{
+			// Not reachable in production — a non-ranking policy is never pooled
+			// (selection.Ranking). Kept so the pool stays sane with any policy.
+			name:   "a non-ranking policy forwards the reply that arrives first",
+			policy: "first_success",
+			qtype:  dns.TypeA,
+			groups: []*fakeGroup{
+				{src: "a-first", resp: aReply(publicAddr)},
+				{src: "b-second", resp: aReply(privateAddr), delay: 50 * time.Millisecond},
+			},
+			wantAddrs:   []string{publicAddr},
+			wantRcode:   dns.RcodeSuccess,
+			wantQueried: []int32{1, 1},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pool := newTestPool(t, tc.policy, tc.groups...)
+			for _, i := range tc.disable {
+				pool.setMember(i, false)
+			}
+
+			got := serveQuery(t, pool, tc.qtype)
+
+			assert.Equal(t, dns.RcodeToString[tc.wantRcode], dns.RcodeToString[got.Rcode])
+			assert.Equal(t, tc.wantAddrs, answerAddrs(got))
+			for i, want := range tc.wantQueried {
+				assert.Equalf(t, want, tc.groups[i].queried.Load(),
+					"group %s query count", tc.groups[i].src)
+			}
+		})
+	}
+}
+
+// TestResolverPool_ReportsFailureToEveryGroup asserts the per-group health
+// bookkeeping still runs for each group the pool queried, so a group that stops
+// answering is still deactivated and probed back to life.
+func TestResolverPool_ReportsFailureToEveryGroup(t *testing.T) {
+	groups := []*fakeGroup{
+		{src: "a-first", err: errors.New("timeout")},
+		{src: "b-second", err: errors.New("timeout")},
+	}
+	pool := newTestPool(t, "prefer_private", groups...)
+
+	serveQuery(t, pool, dns.TypeA)
+
+	for _, g := range groups {
+		assert.Equal(t, int32(1), g.checked.Load(), "group %s health check", g.src)
+	}
+}
+
+// TestResolverPool_GraceWindowCapsTheWait asserts a straggling group cannot hold
+// the answer back for longer than the grace window: the clock starts with the
+// first reply, so the pool is never slower than a single group plus the window.
+func TestResolverPool_GraceWindowCapsTheWait(t *testing.T) {
+	fast := &fakeGroup{src: "a-public", resp: aReply(publicAddr)}
+	slow := &fakeGroup{src: "b-internal", resp: aReply(privateAddr), delay: 2 * time.Second}
+	pool := newTestPool(t, "prefer_private", fast, slow)
+	pool.grace = 50 * time.Millisecond
+
+	start := time.Now()
+	got := serveQuery(t, pool, dns.TypeA)
+	elapsed := time.Since(start)
+
+	assert.Equal(t, []string{publicAddr}, answerAddrs(got), "should not wait for the straggler")
+	assert.Less(t, elapsed, time.Second, "grace window did not cap the wait")
+}
+
+// TestResolverPool_ClonesTheRequestPerGroup guards against the groups sharing one
+// *dns.Msg: they pack it concurrently, which would be a data race.
+func TestResolverPool_ClonesTheRequestPerGroup(t *testing.T) {
+	first := &fakeGroup{src: "a-first", resp: aReply(publicAddr)}
+	second := &fakeGroup{src: "b-second", resp: aReply(privateAddr)}
+	pool := newTestPool(t, "prefer_private", first, second)
+
+	req := new(dns.Msg).SetQuestion(poolZone, dns.TypeA)
+	w := &test.MockResponseWriter{}
+	pool.ServeDNS(w, req)
+
+	sent := append(first.requests(), second.requests()...)
+	require.Len(t, sent, 2)
+	assert.NotSame(t, sent[0], sent[1], "groups must not share one request")
+	for _, m := range sent {
+		assert.NotSame(t, req, m, "each group gets its own copy of the request")
+		assert.Equal(t, req.Id, m.Id, "the copy keeps the request ID")
+		assert.Equal(t, req.Question, m.Question, "the copy keeps the question")
+	}
+}
+
+// TestResolverPool_FormErrOnQuestionlessRequest pins the one place the pool is
+// stricter than a single resolver, which would index Question[0] and panic.
+func TestResolverPool_FormErrOnQuestionlessRequest(t *testing.T) {
+	group := &fakeGroup{src: "a-first", resp: aReply(privateAddr)}
+	pool := newTestPool(t, "prefer_private", group)
+
+	var got *dns.Msg
+	w := &test.MockResponseWriter{WriteMsgFunc: func(m *dns.Msg) error {
+		got = m
+		return nil
+	}}
+	pool.ServeDNS(w, new(dns.Msg))
+
+	require.NotNil(t, got, "a question-less request must still be answered")
+	assert.Equal(t, dns.RcodeToString[dns.RcodeFormatError], dns.RcodeToString[got.Rcode])
+	assert.Equal(t, int32(0), group.queried.Load(), "nothing to ask an upstream about")
+}
+
+// TestResolverPool_WriteErrorIsNotTheUpstreamsFault pins the other declared
+// difference: a failed local write no longer counts towards a group's health, as
+// it did through the unpooled path's deferred check.
+func TestResolverPool_WriteErrorIsNotTheUpstreamsFault(t *testing.T) {
+	group := &fakeGroup{src: "a-first", resp: aReply(privateAddr)}
+	pool := newTestPool(t, "prefer_private", group)
+
+	w := &test.MockResponseWriter{WriteMsgFunc: func(*dns.Msg) error {
+		return errors.New("write failed")
+	}}
+	pool.ServeDNS(w, new(dns.Msg).SetQuestion(poolZone, dns.TypeA))
+
+	require.Equal(t, []error{nil}, group.reportedErrors(),
+		"the group answered fine; the write error is ours, not its")
+}
+
+// TestResolverPool_WaitsForAStragglerAfterAFailure pins that a group failing
+// outright does not start the grace window: the pool would otherwise cut the wait
+// short after a fast failure and throw away the answer it exists to fetch.
+func TestResolverPool_WaitsForAStragglerAfterAFailure(t *testing.T) {
+	broken := &fakeGroup{src: "a-broken", err: errors.New("connection refused")}
+	slow := &fakeGroup{src: "b-slow", resp: aReply(privateAddr), delay: 2 * testGrace}
+	pool := newTestPool(t, "prefer_private", broken, slow)
+
+	got := serveQuery(t, pool, dns.TypeA)
+
+	assert.Equal(t, []string{privateAddr}, answerAddrs(got),
+		"the straggler's answer must not be cut off by the window")
+}
+
+// TestResolverPool_WarnsOnlyOnRealDisagreement checks the end-to-end path of the
+// ambiguity signal: the selector flags it, the pool consumes one warning slot.
+func TestResolverPool_WarnsOnlyOnRealDisagreement(t *testing.T) {
+	t.Run("identical private answers are normal HA", func(t *testing.T) {
+		pool := newTestPool(t, "prefer_private",
+			&fakeGroup{src: "a-first", resp: aReply(privateAddr)},
+			&fakeGroup{src: "b-second", resp: aReply(privateAddr)},
+		)
+
+		serveQuery(t, pool, dns.TypeA)
+		assert.True(t, pool.lastAmbiguity.IsZero(), "redundant resolvers must not warn")
+	})
+
+	t.Run("different private answers warn once", func(t *testing.T) {
+		pool := newTestPool(t, "prefer_private",
+			&fakeGroup{src: "a-first", resp: aReply(privateAddr)},
+			&fakeGroup{src: "b-second", resp: aReply("10.9.9.9")},
+		)
+
+		serveQuery(t, pool, dns.TypeA)
+		first := pool.lastAmbiguity
+		require.False(t, first.IsZero(), "a genuine conflict must warn")
+
+		serveQuery(t, pool, dns.TypeA)
+		assert.Equal(t, first, pool.lastAmbiguity, "the second conflict is throttled")
+	})
+}
+
+// TestResolverPool_AmbiguityWarningIsThrottled keeps a misconfigured zone from
+// flooding the log: the warning is emitted at most once per interval (ADR-0023 D4).
+func TestResolverPool_AmbiguityWarningIsThrottled(t *testing.T) {
+	pool := newTestPool(t, "prefer_private", &fakeGroup{src: "a-first", resp: aReply(privateAddr)})
+	pool.warnInterval = time.Minute
+
+	now := time.Now()
+	assert.True(t, pool.shouldWarn(now), "the first disagreement warns")
+	assert.False(t, pool.shouldWarn(now.Add(30*time.Second)), "within the interval it stays quiet")
+	assert.True(t, pool.shouldWarn(now.Add(2*time.Minute)), "after the interval it warns again")
+}
+
+// TestResolverPool_StoppedPoolStaysQuiet covers a query that raced a
+// reconfiguration: a stopped pool must not fan out to resolvers whose context is
+// already canceled, which would cost a failing exchange and a log line per
+// upstream server. Like a stopped single resolver, it writes nothing.
+func TestResolverPool_StoppedPoolStaysQuiet(t *testing.T) {
+	groups := []*fakeGroup{
+		{src: "a-first", resp: aReply(privateAddr)},
+		{src: "b-second", resp: aReply(publicAddr)},
+	}
+	pool := newTestPool(t, "prefer_private", groups...)
+	pool.Stop()
+
+	var written *dns.Msg
+	w := &test.MockResponseWriter{WriteMsgFunc: func(m *dns.Msg) error {
+		written = m
+		return nil
+	}}
+	pool.ServeDNS(w, new(dns.Msg).SetQuestion(poolZone, dns.TypeA))
+
+	assert.Nil(t, written, "a stopped pool must not answer")
+	for _, g := range groups {
+		assert.Equal(t, int32(0), g.queried.Load(), "group %s must not be queried", g.src)
+	}
+}
+
+func TestResolverPool_StopAndProbeReachEveryGroup(t *testing.T) {
+	groups := []*fakeGroup{
+		{src: "a-first", resp: aReply(privateAddr)},
+		{src: "b-second", resp: aReply(publicAddr)},
+	}
+	pool := newTestPool(t, "prefer_private", groups...)
+	pool.setMember(1, false)
+
+	pool.ProbeAvailability()
+	pool.Stop()
+
+	for _, g := range groups {
+		assert.Equal(t, int32(1), g.probed.Load(), "group %s probed", g.src)
+		assert.Equal(t, int32(1), g.stops.Load(), "group %s stopped", g.src)
+	}
+}
+
+func TestResolverPool_IDIsStableAndDistinct(t *testing.T) {
+	groups := func() []*fakeGroup {
+		return []*fakeGroup{{src: "1.1.1.1:53"}, {src: "10.0.0.1:53"}}
+	}
+	pool := newTestPool(t, "prefer_private", groups()...)
+
+	assert.Equal(t, pool.ID(), newTestPool(t, "prefer_private", groups()...).ID(),
+		"the same zone and groups keep the same handler ID")
+	assert.NotEqual(t, pool.ID(), pool.ID()[:len(pool.ID())-1], "sanity: IDs are compared whole")
+
+	other := newResolverPool("other.example.com.", pool.policy, []groupResolver{groups()[0], groups()[1]})
+	assert.NotEqual(t, pool.ID(), other.ID(), "a different zone gets a different handler ID")
+
+	fewer := newTestPool(t, "prefer_private", groups()[0])
+	assert.NotEqual(t, pool.ID(), fewer.ID(), "a different group set gets a different handler ID")
+	assert.True(t, pool.MatchSubdomains(), "a pooled zone matches its subdomains, like a single group")
+}

--- a/client/internal/dns/pool_wiring.go
+++ b/client/internal/dns/pool_wiring.go
@@ -6,16 +6,55 @@ package dns
 
 import (
 	"errors"
+	"fmt"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 
+	"github.com/openzro/openzro/client/internal/dns/selection"
 	nbdns "github.com/openzro/openzro/dns"
 )
+
+// resolveSelectionPolicy turns a configured policy name into the policy the
+// server uses. Case and surrounding space are ignored: the only way to set this
+// today is by hand in the client's configuration file, so the likeliest mistake
+// is "Prefer_Private" or a stray space, and neither deserves to be treated as a
+// different policy. A name we still do not know is only warned about — a
+// misspelled preference must not stop the client from resolving — and the
+// warning echoes what was configured so the typo is recognizable.
+//
+// An empty name means the operator did not opt in and yields no policy at all,
+// deliberately not selection.DefaultPolicy: "nothing configured" stays a state
+// the server can represent. Whether a policy actually pools a zone is decided
+// at the handler, by selection.Ranking.
+func resolveSelectionPolicy(configured string) selection.Policy {
+	name := strings.ToLower(strings.TrimSpace(configured))
+	if name == "" {
+		return nil
+	}
+
+	policy, ok := selection.Get(name)
+	if !ok {
+		log.Warnf("ignoring unknown DNS selection policy %q, keeping the default behavior", configured)
+		return nil
+	}
+
+	log.Infof("DNS selection policy is %s", policy.Name())
+	return policy
+}
 
 // createPooledHandler builds the one handler that serves a zone from all of its
 // nameserver groups at once. It replaces the per-group handlers at descending
 // priorities, of which only the highest would ever be consulted.
 func (s *DefaultServer) createPooledHandler(domainGroup nsGroupsByDomain, basePriority int) ([]handlerWrapper, error) {
+	// A pool ranks candidates against each other, so it dereferences its policy on
+	// every query. Establish that here, where the pool is built, instead of
+	// nil-checking each use: the caller only pools for a ranking policy, and if
+	// that ever changes this fails loudly rather than panicking on a query.
+	if !selection.Ranking(s.selectionPolicy) {
+		return nil, fmt.Errorf("pooling zone %s needs a ranking selection policy", domainGroup.domain)
+	}
+
 	handlers := make([]upstreamGroupHandler, 0, len(domainGroup.groups))
 	groups := make([]*nbdns.NameServerGroup, 0, len(domainGroup.groups))
 

--- a/client/internal/dns/pool_wiring.go
+++ b/client/internal/dns/pool_wiring.go
@@ -1,0 +1,116 @@
+package dns
+
+// This file holds the server side of pooling: how a DefaultServer builds a
+// resolverPool for a zone and wires the groups' health hooks to it. The pool
+// itself lives in pool.go.
+
+import (
+	"errors"
+
+	log "github.com/sirupsen/logrus"
+
+	nbdns "github.com/openzro/openzro/dns"
+)
+
+// createPooledHandler builds the one handler that serves a zone from all of its
+// nameserver groups at once. It replaces the per-group handlers at descending
+// priorities, of which only the highest would ever be consulted.
+func (s *DefaultServer) createPooledHandler(domainGroup nsGroupsByDomain, basePriority int) ([]handlerWrapper, error) {
+	handlers := make([]upstreamGroupHandler, 0, len(domainGroup.groups))
+	groups := make([]*nbdns.NameServerGroup, 0, len(domainGroup.groups))
+
+	for _, nsGroup := range domainGroup.groups {
+		handler, err := s.newGroupResolver(nsGroup, domainGroup.domain)
+		if errors.Is(err, errNoUsableNameserver) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		handlers = append(handlers, handler)
+		groups = append(groups, nsGroup)
+	}
+
+	if len(handlers) == 0 {
+		return nil, nil
+	}
+
+	resolvers := make([]groupResolver, 0, len(handlers))
+	for _, handler := range handlers {
+		resolvers = append(resolvers, handler)
+	}
+
+	pool := newResolverPool(domainGroup.domain, s.selectionPolicy, resolvers)
+	log.Debugf("creating %s with policy=%s priority=%d", pool, s.selectionPolicy.Name(), basePriority)
+
+	// The zone-level hooks are derived once for the whole pool, not per member:
+	// they close over the removeIndex that reactivate needs to undo what deactivate
+	// did, so a pair per member would let whichever group comes back first
+	// reactivate through its own empty index, leaving the zone dead until the next
+	// configuration push. zoneScope keeps them to this zone alone, because a
+	// member's group may serve further domains that are pooled separately.
+	zoneDeactivate, zoneReactivate := s.upstreamCallbacks(zoneScope(domainGroup.domain), pool, basePriority)
+
+	for i, handler := range handlers {
+		handler.setCallbacks(s.poolMemberCallbacks(pool, i, groups[i], zoneDeactivate, zoneReactivate))
+	}
+
+	return []handlerWrapper{{
+		domain:   domainGroup.domain,
+		handler:  pool,
+		priority: basePriority,
+	}}, nil
+}
+
+// zoneScope describes the pooled zone as a nameserver group, so the zone-level
+// health hooks cover exactly the domain this pool serves — and not every domain
+// the members' groups happen to serve.
+func zoneScope(domain string) *nbdns.NameServerGroup {
+	return &nbdns.NameServerGroup{
+		Domains: []string{domain},
+		Primary: domain == nbdns.RootZone,
+	}
+}
+
+// poolMemberCallbacks returns the health hooks for one pooled nameserver group,
+// given the zone-level pair shared by every member. A group that stops answering
+// is only dropped from the fan-out — the zone stays served while another group is
+// left, which is the point of pooling — and only the last group going down runs
+// the zone-level deactivation (deregister the handler, mark the domain disabled,
+// re-apply the host config), as a lone upstream resolver does today; the first
+// group back reverses it. The group's own state is reported either way, so the
+// status keeps showing which group is down. Both hooks run the membership change
+// and the zone hook under hookMu — see applyZoneState.
+func (s *DefaultServer) poolMemberCallbacks(
+	pool *resolverPool,
+	member int,
+	nsGroup *nbdns.NameServerGroup,
+	zoneDeactivate func(error),
+	zoneReactivate func(),
+) (deactivate func(error), reactivate func()) {
+	deactivate = func(err error) {
+		// The group's own domains matter here: the same group can sit in several
+		// pools, one per zone, each with its own health.
+		nsGroupLogger(nsGroup).WithField("zone", pool.domain).
+			Info("Temporarily removing nameserver group from the pool")
+		s.updateNSState(nsGroup, err, false)
+
+		pool.hookMu.Lock()
+		defer pool.hookMu.Unlock()
+
+		pool.setMember(member, false)
+		pool.applyZoneState(err, zoneDeactivate, zoneReactivate)
+	}
+
+	reactivate = func() {
+		s.updateNSState(nsGroup, nil, true)
+
+		pool.hookMu.Lock()
+		defer pool.hookMu.Unlock()
+
+		pool.setMember(member, true)
+		pool.applyZoneState(nil, zoneDeactivate, zoneReactivate)
+	}
+
+	return deactivate, reactivate
+}

--- a/client/internal/dns/pool_wiring_test.go
+++ b/client/internal/dns/pool_wiring_test.go
@@ -1,0 +1,129 @@
+package dns
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openzro/openzro/client/internal/dns/selection"
+	"github.com/openzro/openzro/client/internal/peer"
+	nbdns "github.com/openzro/openzro/dns"
+)
+
+// TestResolveSelectionPolicy pins how a configured policy name becomes a policy.
+// Nothing configured and a name we do not know both have to leave the server on
+// its pre-existing path: a DNS knob is not worth refusing to resolve over, so an
+// unknown name is a warning and not an error.
+func TestResolveSelectionPolicy(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured string
+		// normalized is the name the resolved policy must report, when it differs
+		// from what was configured. Empty means "same as configured".
+		normalized string
+		wantNil    bool
+		wantRanks  bool
+	}{
+		{
+			name:       "nothing configured keeps the unpooled path",
+			configured: "",
+			wantNil:    true,
+		},
+		{
+			name:       "the default policy is not pooled",
+			configured: selection.DefaultPolicy,
+		},
+		{
+			name:       "prefer_private ranks, so its zones are pooled",
+			configured: "prefer_private",
+			wantRanks:  true,
+		},
+		{
+			name:       "an unknown name falls back instead of failing",
+			configured: "prefer_pubic",
+			wantNil:    true,
+		},
+		{
+			// Hand-edited config file: case and stray space are typos, not policies.
+			name:       "case is ignored",
+			configured: "Prefer_Private",
+			normalized: "prefer_private",
+			wantRanks:  true,
+		},
+		{
+			name:       "surrounding space is ignored",
+			configured: "  prefer_private\t",
+			normalized: "prefer_private",
+			wantRanks:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			policy := resolveSelectionPolicy(tt.configured)
+
+			if tt.wantNil {
+				assert.Nil(t, policy)
+			} else {
+				require.NotNil(t, policy)
+				want := tt.normalized
+				if want == "" {
+					want = tt.configured
+				}
+				assert.Equal(t, want, policy.Name())
+			}
+			assert.Equal(t, tt.wantRanks, selection.Ranking(policy))
+		})
+	}
+}
+
+// TestCreatePooledHandler_RefusesWithoutARankingPolicy pins the invariant the pool
+// relies on: it dereferences its policy on every query, so building one without a
+// ranking policy has to fail loudly here rather than panic later. Unreachable in
+// production — the caller gates on selection.Ranking — which is exactly why the
+// guard needs a test of its own.
+func TestCreatePooledHandler_RefusesWithoutARankingPolicy(t *testing.T) {
+	zone := nsGroupsByDomain{
+		domain: "example.com",
+		groups: []*nbdns.NameServerGroup{{Domains: []string{"example.com"}}, {Domains: []string{"example.com"}}},
+	}
+
+	for _, policy := range []selection.Policy{nil, mustPolicy(t, selection.DefaultPolicy)} {
+		server := &DefaultServer{selectionPolicy: policy}
+
+		handlers, err := server.createPooledHandler(zone, PriorityUpstream)
+
+		require.Error(t, err, "a %T policy must not yield a pool", policy)
+		assert.Nil(t, handlers)
+	}
+}
+
+func mustPolicy(t *testing.T, name string) selection.Policy {
+	t.Helper()
+	policy, ok := selection.Get(name)
+	require.True(t, ok, "policy %q must exist", name)
+	return policy
+}
+
+// TestNewDefaultServer_ThreadsTheSelectionPolicy pins the constructor seam: the
+// configured name has to reach the server, otherwise the pool is never built in
+// production no matter what the operator configures.
+func TestNewDefaultServer_ThreadsTheSelectionPolicy(t *testing.T) {
+	server, err := NewDefaultServer(
+		context.Background(),
+		&mocWGIface{},
+		"",
+		peer.NewRecorder("mgm"),
+		nil,
+		false,
+		"prefer_private",
+	)
+	require.NoError(t, err)
+	defer server.Stop()
+
+	require.NotNil(t, server.selectionPolicy)
+	assert.Equal(t, "prefer_private", server.selectionPolicy.Name())
+	assert.True(t, selection.Ranking(server.selectionPolicy))
+}

--- a/client/internal/dns/selection/selection.go
+++ b/client/internal/dns/selection/selection.go
@@ -329,12 +329,12 @@ func addrType(qtype uint16) (uint16, bool) {
 // internal network, and unlike "carries one", a property of the whole set cannot be
 // won by adding records to the message.
 //
-// Which of the addresses belong to the queried name is deliberately not determined.
-// That would mean following the answer's alias chain, with the cycles, forks and hop
-// limits such a walk has to rule on. Judging the set as a whole needs none of that
-// and still lets a chain ending in an internal address count — at the price of a
-// reply that pads its answer with unrelated public records losing its preference
-// (ADR-0023 implementation notes).
+// The set is restricted to addrsOf's closure: the queried name plus every CNAME
+// target transitively reachable from it. An address whose owner falls outside that
+// closure — an unrelated off-name record, or padding — never enters the set, so it
+// cannot decide this question, and a chain ending in an internal address still
+// counts — at the price of a reply that pads its answer with unrelated public
+// records losing its own preference (ADR-0023 implementation notes).
 func allAddrsPrivate(resp *dns.Msg, q dns.Question, atype uint16) bool {
 	addrs := addrsOf(resp, q, atype)
 	if len(addrs) == 0 {

--- a/client/internal/dns/selection/selection.go
+++ b/client/internal/dns/selection/selection.go
@@ -62,6 +62,13 @@ type Result struct {
 type Policy interface {
 	// Name is the stable config identifier, e.g. "prefer_private".
 	Name() string
+	// Ranks reports whether this policy compares candidates against each other,
+	// and so needs its caller to gather every resolver's reply before asking. A
+	// policy that does not rank forwards whichever reply came back first — what a
+	// plain sequential resolver already does, and without the arrival-order
+	// dependence a fan-out would add. It sits in the interface so that a new
+	// policy cannot be added without answering it.
+	Ranks() bool
 	// Select returns the chosen Result and true, or (zero, false) when no
 	// candidate is usable — in which case the caller returns SERVFAIL.
 	Select(q dns.Question, cands []Candidate) (Result, bool)
@@ -94,12 +101,16 @@ type firstSuccess struct{}
 // Name implements Policy.
 func (firstSuccess) Name() string { return "first_success" }
 
+// Ranks implements Policy: forwarding the first reply needs no comparison, so
+// gathering for it would only add an arrival-order dependence.
+func (firstSuccess) Ranks() bool { return false }
+
 // Select returns the first candidate that produced a response, in the order
 // given — the resolver's pre-existing sequential behavior 1:1: any response wins
 // (including SERVFAIL), only a non-answering upstream (nil) is skipped.
 func (firstSuccess) Select(_ dns.Question, cands []Candidate) (Result, bool) {
 	for _, c := range cands {
-		if responded(c.Resp) {
+		if Responded(c.Resp) {
 			return Result{Resp: c.Resp, Source: c.Source}, true
 		}
 	}
@@ -110,6 +121,9 @@ type preferPrivate struct{}
 
 // Name implements Policy.
 func (preferPrivate) Name() string { return "prefer_private" }
+
+// Ranks implements Policy: private beats public, which needs every candidate.
+func (preferPrivate) Ranks() bool { return true }
 
 // Select ranks A/AAAA answers by refining the shared base ladder: a private/CGNAT
 // address beats a public one, and within a tier the lowest Source wins, so the
@@ -139,7 +153,7 @@ func (preferPrivate) Select(q dns.Question, cands []Candidate) (Result, bool) {
 	// Non-address query: no address notion — return a responded answer
 	// deterministically by lowest Source.
 	best, top := pickBest(cands, func(c Candidate) int {
-		if responded(c.Resp) {
+		if Responded(c.Resp) {
 			return 1
 		}
 		return 0
@@ -176,7 +190,7 @@ func pickBest(cands []Candidate, score func(Candidate) int) (best Candidate, top
 // A CNAME accompanying an NXDOMAIN is not a referral (the alias resolves to
 // nothing), so it stays NXDOMAIN.
 func baseTier(resp *dns.Msg, q dns.Question, atype uint16) int {
-	if !responded(resp) {
+	if !Responded(resp) {
 		return tierNone
 	}
 	// An EDNS extended rcode (≥16, RFC 6891) lives in the OPT record, not in the
@@ -290,9 +304,11 @@ func aliasesQuestion(resp *dns.Msg, q dns.Question) bool {
 	return false
 }
 
-// responded reports whether the upstream returned a DNS reply at all (any
-// rcode). A nil Resp means it did not answer (transport error / timeout).
-func responded(resp *dns.Msg) bool {
+// Responded reports whether an upstream returned a DNS reply at all (any rcode) —
+// whether a Candidate carries something a policy can rank. Exported so a caller
+// gathering candidates tests it the same way the policies do; see the
+// Candidate.Resp contract.
+func Responded(resp *dns.Msg) bool {
 	return resp != nil && resp.Response
 }
 
@@ -421,6 +437,13 @@ var cgnatPrefix = netip.MustParsePrefix("100.64.0.0/10")
 func isPrivateAddr(addr netip.Addr) bool {
 	addr = addr.Unmap()
 	return addr.IsPrivate() || cgnatPrefix.Contains(addr)
+}
+
+// Ranking reports whether p needs its caller to gather every resolver's reply
+// before asking it — see Policy.Ranks. It is the nil-safe form callers use: a nil
+// policy means nothing was configured, so the caller keeps its unpooled path.
+func Ranking(p Policy) bool {
+	return p != nil && p.Ranks()
 }
 
 // Get returns the policy for name. An empty name resolves to DefaultPolicy; the

--- a/client/internal/dns/selection/selection.go
+++ b/client/internal/dns/selection/selection.go
@@ -1,0 +1,441 @@
+// Package selection chooses which of several valid DNS answers — gathered from
+// multiple upstream resolvers that all serve the same zone — should be returned
+// to the client. A Policy is a pure function of the question and the gathered
+// candidates: no network I/O, no logging (ambiguity is surfaced in Result for the
+// caller), which keeps it exhaustively table-testable and keeps the resolver dumb.
+//
+// baseTier classifies every response onto a policy-independent quality ladder and
+// pickBest picks the highest-scoring candidate with a deterministic tiebreak; a
+// ranking policy refines only the top "answer" tier, so a future one (e.g.
+// prefer_routed) needs no change below it. Both grade a response as an answer to
+// the question asked: a reply is only an answer about a name it actually mentions.
+//
+// Ordering is all this package does. It never suppresses, rewrites or repairs a
+// response — the chosen *dns.Msg is returned unmodified, and a lone candidate is
+// returned however it looks, exactly as an unpooled resolver would.
+//
+// Policy is ADR-0023's SelectionPolicy and Candidate its CandidateResponse; the
+// shorter names avoid stuttering with the package name. The ladder's ordering is
+// reasoned through in docs/adr/0023-policy-based-multi-resolver-dns.md.
+package selection
+
+import (
+	"net/netip"
+	"sort"
+	"strings"
+
+	"github.com/miekg/dns"
+)
+
+// DefaultPolicy is the policy used when none is configured. It reproduces the
+// pre-existing behavior: the first resolver to return a response wins.
+const DefaultPolicy = "first_success"
+
+// Candidate is one resolver's answer to a query, as gathered by the pool. It
+// carries only what selection needs today; a future policy's signals (ADR-0023
+// D11) can be added without changing this interface.
+type Candidate struct {
+	// Resp is the resolver's reply, or nil if it did not answer. It must be an
+	// actual reply — the QR bit set (Resp.Response), as every DNS exchange
+	// yields; a message without it counts as "no reply". The pool sets Resp = nil
+	// for a transport error or timeout.
+	Resp *dns.Msg
+	// Source identifies the resolver (host:port) and is the stable, deterministic
+	// tiebreak key. An identifier, never a secret.
+	Source string
+}
+
+// Result is the outcome of a selection.
+type Result struct {
+	// Resp is the chosen response.
+	Resp *dns.Msg
+	// Source is the resolver that produced Resp (for the caller's logging).
+	Source string
+	// Ambiguous is true only when two or more resolvers returned DIFFERENT
+	// private addresses for the name. Identical private answers from redundant
+	// resolvers are normal HA, not a conflict. The choice is deterministic either
+	// way; the flag lets the pool warn, throttled (ADR-0023 D4).
+	Ambiguous bool
+}
+
+// Policy ranks candidates and returns the winning response.
+type Policy interface {
+	// Name is the stable config identifier, e.g. "prefer_private".
+	Name() string
+	// Select returns the chosen Result and true, or (zero, false) when no
+	// candidate is usable — in which case the caller returns SERVFAIL.
+	Select(q dns.Question, cands []Candidate) (Result, bool)
+}
+
+// Base response tiers: the shared, policy-independent quality ladder, low to
+// high. baseTier maps every response onto one of these; a ranking policy refines
+// only tierAnswer, so the lower ordering is decided once for every policy. Why it
+// is ordered this way is reasoned through in ADR-0023's notes (D3).
+//
+// All tiers but one grade the response's content. tierOffTopic grades its
+// relevance: a reply can be well formed and still say nothing about the name that
+// was asked for, in which case it must not be read as an answer to it.
+const (
+	tierNone     = iota // no reply at all (nil): transport error / timeout — nothing to return
+	tierErrored         // an error-rcode reply (SERVFAIL/REFUSED/…); may carry an RFC 8914 EDE diagnostic
+	tierNXDOMAIN        // the name does not exist (definitive)
+	tierNODATA          // the name exists but has no record of the queried type
+	tierOffTopic        // carries records, but none of them is about the queried name
+	tierReferral        // a NOERROR CNAME/DNAME alias with no resolved address — a referral to follow
+	tierAnswer          // carries an A/AAAA of the queried type — a ranking policy refines this
+)
+
+// scorePrivate is prefer_private's sole refinement of the base ladder: a
+// private/CGNAT answer ranks one step above a public one (which keeps tierAnswer).
+const scorePrivate = tierAnswer + 1
+
+type firstSuccess struct{}
+
+// Name implements Policy.
+func (firstSuccess) Name() string { return "first_success" }
+
+// Select returns the first candidate that produced a response, in the order
+// given — the resolver's pre-existing sequential behavior 1:1: any response wins
+// (including SERVFAIL), only a non-answering upstream (nil) is skipped.
+func (firstSuccess) Select(_ dns.Question, cands []Candidate) (Result, bool) {
+	for _, c := range cands {
+		if responded(c.Resp) {
+			return Result{Resp: c.Resp, Source: c.Source}, true
+		}
+	}
+	return Result{}, false
+}
+
+type preferPrivate struct{}
+
+// Name implements Policy.
+func (preferPrivate) Name() string { return "prefer_private" }
+
+// Select ranks A/AAAA answers by refining the shared base ladder: a private/CGNAT
+// address beats a public one, and within a tier the lowest Source wins, so the
+// outcome does not depend on arrival order (ADR-0023 D3/D4). It returns false only
+// when no candidate replied; the caller then synthesizes SERVFAIL. A non-address
+// query has no address notion — the pool does not fan those out (D5) — and yields
+// a responded answer by lowest Source.
+func (preferPrivate) Select(q dns.Question, cands []Candidate) (Result, bool) {
+	if atype, isAddr := addrType(q.Qtype); isAddr {
+		best, top := pickBest(cands, func(c Candidate) int {
+			t := baseTier(c.Resp, q, atype)
+			if t == tierAnswer && allAddrsPrivate(c.Resp, q, atype) {
+				return scorePrivate
+			}
+			return t
+		})
+		if top == tierNone {
+			return Result{}, false
+		}
+		return Result{
+			Resp:      best.Resp,
+			Source:    best.Source,
+			Ambiguous: top == scorePrivate && privateDisagreement(cands, q, atype),
+		}, true
+	}
+
+	// Non-address query: no address notion — return a responded answer
+	// deterministically by lowest Source.
+	best, top := pickBest(cands, func(c Candidate) int {
+		if responded(c.Resp) {
+			return 1
+		}
+		return 0
+	})
+	if top == 0 {
+		return Result{}, false
+	}
+	return Result{Resp: best.Resp, Source: best.Source}, true
+}
+
+// pickBest returns the candidate with the highest positive score and that score.
+// Ties are broken by the lowest Source, so the result is deterministic
+// regardless of arrival order. topScore is 0 when no candidate scores > 0. This
+// is the shared ranking spine; policies differ only in the score they supply.
+func pickBest(cands []Candidate, score func(Candidate) int) (best Candidate, topScore int) {
+	for _, c := range cands {
+		s := score(c)
+		if s <= 0 {
+			continue
+		}
+		switch {
+		case s > topScore:
+			best, topScore = c, s
+		case s == topScore && c.Source < best.Source:
+			best = c
+		}
+	}
+	return best, topScore
+}
+
+// baseTier classifies a response onto the shared, policy-independent quality
+// ladder (tierNone … tierAnswer), as an answer to q. tierAnswer means "gives an
+// A/AAAA of the queried type for the queried name"; a ranking policy refines that.
+// A CNAME accompanying an NXDOMAIN is not a referral (the alias resolves to
+// nothing), so it stays NXDOMAIN.
+func baseTier(resp *dns.Msg, q dns.Question, atype uint16) int {
+	if !responded(resp) {
+		return tierNone
+	}
+	// An EDNS extended rcode (≥16, RFC 6891) lives in the OPT record, not in the
+	// 4-bit header field resp.Rcode holds. Without this guard BADVERS (16, nibble
+	// 0) would look like NOERROR and BADMODE (19, nibble 3) like NXDOMAIN.
+	if opt := resp.IsEdns0(); opt != nil && opt.ExtendedRcode() != 0 {
+		return tierErrored
+	}
+	if resp.Rcode == dns.RcodeNameError {
+		return tierNXDOMAIN
+	}
+	if resp.Rcode != dns.RcodeSuccess {
+		return tierErrored // SERVFAIL, REFUSED, NOTIMP, …
+	}
+	// An empty answer section is the ordinary NODATA reply, handled below — there
+	// is nothing in it that could be about a name. A section that carries records
+	// but never mentions the queried one says nothing about it, so whatever else
+	// those records hold must not be read as this name's answer.
+	if len(resp.Answer) > 0 && !mentions(resp, q) {
+		return tierOffTopic
+	}
+
+	switch {
+	case len(addrsOf(resp, q, atype)) > 0:
+		return tierAnswer
+	case aliasesQuestion(resp, q):
+		return tierReferral
+	default:
+		return tierNODATA
+	}
+}
+
+// mentions reports whether any record in the answer section is about the queried
+// name — of any type, because an MX or TXT for it still makes the reply an answer
+// about that name, just not an address one. Names are compared in canonical form:
+// DNS 0x20 case randomization makes that a requirement, not a nicety. A record in
+// another class says nothing about this question, whatever name it carries.
+func mentions(resp *dns.Msg, q dns.Question) bool {
+	name := dns.CanonicalName(q.Name)
+	for _, rr := range resp.Answer {
+		if rr.Header().Class == q.Qclass && dns.CanonicalName(rr.Header().Name) == name {
+			return true
+		}
+	}
+	return false
+}
+
+// aliasSet returns the names this reply presents as aliases of the queried name:
+// the question's own name plus every CNAME target reachable from it, in the
+// question's class and in canonical form.
+//
+// It is a reachability set, not a resolved chain, which is why it needs none of
+// the rulings a chain walk would: a cycle is harmless because adding to a set is
+// idempotent, a name aliased twice simply contributes both targets, and there is
+// no hop limit to choose — every round either adds at least one name or ends the
+// loop, and the only candidates are CNAME targets of this answer section, so there
+// are at most len(resp.Answer) rounds.
+//
+// Only CNAME extends the set. A DNAME aliases a subtree rather than a name: its
+// owner is a proper ancestor of the queried name, and it reaches this answer
+// through the synthesized CNAME that RFC 6672 requires alongside it. Without that
+// CNAME the set does not grow and the ladder settles on a referral or NODATA,
+// which is the safe direction.
+func aliasSet(resp *dns.Msg, q dns.Question) map[string]bool {
+	set := map[string]bool{dns.CanonicalName(q.Name): true}
+	for changed := true; changed; {
+		changed = false
+		for _, rr := range resp.Answer {
+			cname, ok := rr.(*dns.CNAME)
+			if !ok || cname.Hdr.Class != q.Qclass {
+				continue
+			}
+			if !set[dns.CanonicalName(cname.Hdr.Name)] {
+				continue
+			}
+			if target := dns.CanonicalName(cname.Target); !set[target] {
+				set[target] = true
+				changed = true
+			}
+		}
+	}
+	return set
+}
+
+// aliased reports whether name carries a CNAME of its own in this answer section.
+// An address at such a name is not this reply's answer: RFC 1034 §3.6.2 forbids a
+// CNAME owner from holding other data, so a reply doing both is malformed, and a
+// client that follows the alias ends up somewhere other than the address suggests.
+// Only CNAME counts — a DNAME owner may legitimately carry other types.
+func aliased(resp *dns.Msg, name string, qclass uint16) bool {
+	for _, rr := range resp.Answer {
+		cname, ok := rr.(*dns.CNAME)
+		if ok && cname.Hdr.Class == qclass && dns.CanonicalName(cname.Hdr.Name) == name {
+			return true
+		}
+	}
+	return false
+}
+
+// aliasesQuestion reports whether the reply carries an alias for a name the
+// question resolves through — a referral to follow, as opposed to an alias for
+// some unrelated name, which says nothing about this question.
+func aliasesQuestion(resp *dns.Msg, q dns.Question) bool {
+	set := aliasSet(resp, q)
+	for _, rr := range resp.Answer {
+		cname, ok := rr.(*dns.CNAME)
+		if ok && cname.Hdr.Class == q.Qclass && set[dns.CanonicalName(cname.Hdr.Name)] {
+			return true
+		}
+	}
+	return false
+}
+
+// responded reports whether the upstream returned a DNS reply at all (any
+// rcode). A nil Resp means it did not answer (transport error / timeout).
+func responded(resp *dns.Msg) bool {
+	return resp != nil && resp.Response
+}
+
+// addrType maps a query type to the record type that carries its address.
+// Only A and AAAA carry addresses; the bool is false for anything else.
+func addrType(qtype uint16) (uint16, bool) {
+	switch qtype {
+	case dns.TypeA, dns.TypeAAAA:
+		return qtype, true
+	default:
+		return 0, false
+	}
+}
+
+// allAddrsPrivate reports whether every address of type atype in resp is internal,
+// and that there is at least one. The whole set decides, not a single member: an
+// answer that also hands out a public address does not resolve the name into the
+// internal network, and unlike "carries one", a property of the whole set cannot be
+// won by adding records to the message.
+//
+// Which of the addresses belong to the queried name is deliberately not determined.
+// That would mean following the answer's alias chain, with the cycles, forks and hop
+// limits such a walk has to rule on. Judging the set as a whole needs none of that
+// and still lets a chain ending in an internal address count — at the price of a
+// reply that pads its answer with unrelated public records losing its preference
+// (ADR-0023 implementation notes).
+func allAddrsPrivate(resp *dns.Msg, q dns.Question, atype uint16) bool {
+	addrs := addrsOf(resp, q, atype)
+	if len(addrs) == 0 {
+		return false
+	}
+	for _, a := range addrs {
+		if !isPrivateAddr(a) {
+			return false
+		}
+	}
+	return true
+}
+
+// privateDisagreement reports whether two or more candidates are internal answers
+// that do not name the same addresses — i.e. the resolvers disagree on which
+// internal endpoint the name maps to. Identical answers from redundant resolvers
+// are not a disagreement, and a candidate that is not an internal answer at all
+// cannot disagree about one. See ADR-0023 D4.
+func privateDisagreement(cands []Candidate, q dns.Question, atype uint16) bool {
+	first, seen := "", false
+	for _, c := range cands {
+		if !allAddrsPrivate(c.Resp, q, atype) {
+			continue
+		}
+		sig := addrSig(c.Resp, q, atype)
+		if !seen {
+			first, seen = sig, true
+			continue
+		}
+		if sig != first {
+			return true
+		}
+	}
+	return false
+}
+
+// addrSig returns a canonical signature of the addresses resp gives for q (sorted,
+// comma-joined), so two answers can be compared for naming the same set. It reads
+// the same restricted set the ranking does, so the two cannot drift apart.
+func addrSig(resp *dns.Msg, q dns.Question, atype uint16) string {
+	addrs := addrsOf(resp, q, atype)
+	ss := make([]string, 0, len(addrs))
+	for _, a := range addrs {
+		ss = append(ss, a.String())
+	}
+	sort.Strings(ss)
+	return strings.Join(ss, ",")
+}
+
+// addrsOf returns the (unmapped) addresses of type atype that resp gives as the
+// answer to q: in the question's class, owned by a name the reply aliases the
+// question to, and not sitting at a name that is itself aliased. Everything else
+// in the answer section belongs to some other question and must not decide this
+// one. The record's Go type — not its header Rrtype — decides A vs AAAA, so
+// hand-built records classify correctly too.
+func addrsOf(resp *dns.Msg, q dns.Question, atype uint16) []netip.Addr {
+	if resp == nil {
+		return nil
+	}
+	set := aliasSet(resp, q)
+	var addrs []netip.Addr
+	for _, rr := range resp.Answer {
+		var addr netip.Addr
+		var ok bool
+		switch v := rr.(type) {
+		case *dns.A:
+			if atype != dns.TypeA {
+				continue
+			}
+			addr, ok = netip.AddrFromSlice(v.A)
+		case *dns.AAAA:
+			if atype != dns.TypeAAAA {
+				continue
+			}
+			addr, ok = netip.AddrFromSlice(v.AAAA)
+		default:
+			continue
+		}
+		if !ok || rr.Header().Class != q.Qclass {
+			continue
+		}
+		owner := dns.CanonicalName(rr.Header().Name)
+		if !set[owner] || aliased(resp, owner, q.Qclass) {
+			continue
+		}
+		addrs = append(addrs, addr.Unmap())
+	}
+	return addrs
+}
+
+// cgnatPrefix is the shared address space (RFC 6598) openZro peers use.
+// netip.Addr.IsPrivate excludes it, so we test it explicitly, with our own prefix:
+// the range is only checked inline elsewhere (e.g. isWellKnown in
+// client/anonymize), never through an exported helper.
+var cgnatPrefix = netip.MustParsePrefix("100.64.0.0/10")
+
+// isPrivateAddr reports whether addr is internal/mesh-reachable: RFC1918 or
+// IPv6-ULA (via IsPrivate) plus the CGNAT range. Best-effort by design
+// (ADR-0023 D3); a routing-aware signal is future work (D11).
+func isPrivateAddr(addr netip.Addr) bool {
+	addr = addr.Unmap()
+	return addr.IsPrivate() || cgnatPrefix.Contains(addr)
+}
+
+// Get returns the policy for name. An empty name resolves to DefaultPolicy; the
+// bool is false for an unknown name. A switch rather than a package-level map
+// keeps this free of global mutable state.
+func Get(name string) (Policy, bool) {
+	if name == "" {
+		name = DefaultPolicy
+	}
+	switch name {
+	case "first_success":
+		return firstSuccess{}, true
+	case "prefer_private":
+		return preferPrivate{}, true
+	default:
+		return nil, false
+	}
+}

--- a/client/internal/dns/selection/selection.go
+++ b/client/internal/dns/selection/selection.go
@@ -84,7 +84,7 @@ type Policy interface {
 // was asked for, in which case it must not be read as an answer to it.
 const (
 	tierNone     = iota // no reply at all (nil): transport error / timeout — nothing to return
-	tierErrored         // an error-rcode reply (SERVFAIL/REFUSED/…); may carry an RFC 8914 EDE diagnostic
+	tierErrored         // an error-rcode reply (SERVFAIL/REFUSED/…); may carry an RFC 8914 extended-error diagnostic
 	tierNXDOMAIN        // the name does not exist (definitive)
 	tierNODATA          // the name exists but has no record of the queried type
 	tierOffTopic        // carries records, but none of them is about the queried name

--- a/client/internal/dns/selection/selection_test.go
+++ b/client/internal/dns/selection/selection_test.go
@@ -59,6 +59,14 @@ func rrAAt(owner, ip string) dns.RR {
 	return &dns.A{Hdr: hdr(owner, dns.TypeA), A: net.ParseIP(ip)}
 }
 
+// rrAAAAAt builds a raw AAAA record, unlike msg()/cand(), which route a
+// v4-mapped literal (::ffff:a.b.c.d) to an A record because net.IP.To4()
+// treats it as IPv4 — this is what lets a test put such a literal in an
+// actual AAAA RRset.
+func rrAAAAAt(owner, ip string) dns.RR {
+	return &dns.AAAA{Hdr: hdr(owner, dns.TypeAAAA), AAAA: net.ParseIP(ip)}
+}
+
 func rrCNAMEAt(owner, target string) dns.RR {
 	return &dns.CNAME{Hdr: hdr(owner, dns.TypeCNAME), Target: dns.Fqdn(target)}
 }
@@ -195,6 +203,16 @@ func TestPreferPrivate_Select(t *testing.T) {
 			wantIdx: 0, wantOK: true,
 		},
 		{
+			// The mirror of the padding shape above: a genuinely private answer at the
+			// queried name must stay private when an unrelated PUBLIC record is padded
+			// in elsewhere. The exact case the stale allAddrsPrivate comment (finding
+			// #1, corrected above) would have gotten wrong had anyone trusted it and
+			// "simplified" the function back to scanning the whole message.
+			name:    "a private answer stays private despite an unrelated public record elsewhere",
+			cands:   []Candidate{cand("a", dns.RcodeSuccess, "203.0.113.10"), candRR("z", rrA("10.0.0.5"), rrAAt("pad.other.example.", "203.0.113.66"))},
+			wantIdx: 1, wantOK: true,
+		},
+		{
 			// Nothing in it is about the name we asked for, so it is no answer to that
 			// question — but it is still a reply that was received, and it is served if
 			// nothing better exists. Hence above the negatives, not below them.
@@ -317,9 +335,60 @@ func TestPreferPrivate_Select(t *testing.T) {
 			wantIdx: 1, wantOK: true,
 		},
 		{
+			name:    "100.63.255.255 (just below the CGNAT block) is public",
+			cands:   []Candidate{cand("a", dns.RcodeSuccess, "100.63.255.255"), cand("b", dns.RcodeSuccess, "10.0.0.1")},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			name:    "100.127.255.255 (the CGNAT block's top address) is private",
+			cands:   []Candidate{cand("a", dns.RcodeSuccess, "203.0.113.10"), cand("b", dns.RcodeSuccess, "100.127.255.255")},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			name:    "100.128.0.1 (just above the CGNAT block) is public",
+			cands:   []Candidate{cand("a", dns.RcodeSuccess, "100.128.0.1"), cand("b", dns.RcodeSuccess, "10.0.0.1")},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			// IsPrivate() covers RFC1918/ULA only; link-local and the unspecified
+			// address are neither of those, so they must not out-rank or tie with a
+			// genuinely private answer.
+			name:    "0.0.0.0 (unspecified) is public",
+			cands:   []Candidate{cand("a", dns.RcodeSuccess, "0.0.0.0"), cand("b", dns.RcodeSuccess, "10.0.0.1")},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			name:    "169.254.1.1 (IPv4 link-local) is public",
+			cands:   []Candidate{cand("a", dns.RcodeSuccess, "169.254.1.1"), cand("b", dns.RcodeSuccess, "10.0.0.1")},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			name:    ":: and IPv6 link-local are public (AAAA query)",
+			qtype:   dns.TypeAAAA,
+			cands:   []Candidate{cand("a", dns.RcodeSuccess, "::"), cand("b", dns.RcodeSuccess, "fd00::1")},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			name:    "fe80::1 (IPv6 link-local) is public",
+			qtype:   dns.TypeAAAA,
+			cands:   []Candidate{cand("a", dns.RcodeSuccess, "fe80::1"), cand("b", dns.RcodeSuccess, "fd00::1")},
+			wantIdx: 1, wantOK: true,
+		},
+		{
 			name:    "IPv6 ULA private beats public v6 (AAAA query)",
 			qtype:   dns.TypeAAAA,
 			cands:   []Candidate{cand("a", dns.RcodeSuccess, "2606:4700::1111"), cand("b", dns.RcodeSuccess, "fd00::1")},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			// RFC 4291 §2.5.5.2: this IS 100.64.0.1, only IPv6-dressed. isPrivateAddr
+			// unmaps before classifying, so it counts as CGNAT-private like the plain
+			// IPv4 form would — a real AAAA record almost never carries one of these,
+			// but if it does, treating it as anything other than its real address
+			// would be the surprising choice.
+			name:    "v4-mapped IPv6 (::ffff:100.64.0.1) unmaps to CGNAT and counts as private",
+			qtype:   dns.TypeAAAA,
+			cands:   []Candidate{candRR("a", rrAAAAAt(zone, "2606:4700::1111")), candRR("b", rrAAAAAt(zone, "::ffff:100.64.0.1"))},
 			wantIdx: 1, wantOK: true,
 		},
 		{

--- a/client/internal/dns/selection/selection_test.go
+++ b/client/internal/dns/selection/selection_test.go
@@ -1,0 +1,449 @@
+package selection
+
+import (
+	"net"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// msg builds a response with the given rcode and A/AAAA answers for the queried
+// name. Records carry an owner name on purpose: a reply is only an answer about a
+// name it mentions, so a helper that left the header zero would make every
+// assertion about that rule vacuous.
+func msg(rcode int, ips ...string) *dns.Msg {
+	m := new(dns.Msg)
+	m.Rcode = rcode
+	m.Response = true
+	for _, s := range ips {
+		ip := net.ParseIP(s)
+		if v4 := ip.To4(); v4 != nil {
+			m.Answer = append(m.Answer, &dns.A{Hdr: hdr(zone, dns.TypeA), A: v4})
+			continue
+		}
+		m.Answer = append(m.Answer, &dns.AAAA{Hdr: hdr(zone, dns.TypeAAAA), AAAA: ip})
+	}
+	return m
+}
+
+// hdr builds a record header owned by owner.
+func hdr(owner string, rrtype uint16) dns.RR_Header {
+	return dns.RR_Header{Name: dns.Fqdn(owner), Rrtype: rrtype, Class: dns.ClassINET, Ttl: 60}
+}
+
+func cand(source string, rcode int, ips ...string) Candidate {
+	return Candidate{Source: source, Resp: msg(rcode, ips...)}
+}
+
+// candRRCode builds a candidate from raw records with an explicit rcode.
+func candRRCode(source string, rcode int, rrs ...dns.RR) Candidate {
+	m := new(dns.Msg)
+	m.Rcode = rcode
+	m.Response = true
+	m.Answer = rrs
+	return Candidate{Source: source, Resp: m}
+}
+
+// candRR builds a NOERROR candidate from raw records (CNAME chains / mixed answers).
+func candRR(source string, rrs ...dns.RR) Candidate {
+	return candRRCode(source, dns.RcodeSuccess, rrs...)
+}
+
+// Records default to the queried name as their owner; the *At helpers place one
+// somewhere else, which is what tells an answer about this name apart from an
+// answer that merely arrived in the same message.
+func rrA(ip string) dns.RR    { return rrAAt(zone, ip) }
+func rrCNAME(t string) dns.RR { return rrCNAMEAt(zone, t) }
+
+func rrAAt(owner, ip string) dns.RR {
+	return &dns.A{Hdr: hdr(owner, dns.TypeA), A: net.ParseIP(ip)}
+}
+
+func rrCNAMEAt(owner, target string) dns.RR {
+	return &dns.CNAME{Hdr: hdr(owner, dns.TypeCNAME), Target: dns.Fqdn(target)}
+}
+
+func rrMX(pref uint16, h string) dns.RR {
+	return &dns.MX{Hdr: hdr(zone, dns.TypeMX), Preference: pref, Mx: dns.Fqdn(h)}
+}
+
+func rrTXTAt(owner, text string) dns.RR {
+	return &dns.TXT{Hdr: hdr(owner, dns.TypeTXT), Txt: []string{text}}
+}
+
+func rrDNAMEAt(owner, target string) dns.RR {
+	return &dns.DNAME{Hdr: hdr(owner, dns.TypeDNAME), Target: dns.Fqdn(target)}
+}
+
+// rrAClassAt places an address record in a class other than the question's. The
+// class is part of a record's identity, so such a record answers a different
+// question — the client matches on (name, class, type) and discards it.
+func rrAClassAt(owner string, class uint16, ip string) dns.RR {
+	h := hdr(owner, dns.TypeA)
+	h.Class = class
+	return &dns.A{Hdr: h, A: net.ParseIP(ip)}
+}
+
+func failCand(source string) Candidate { return Candidate{Source: source, Resp: nil} }
+func servfail(source string) Candidate { return candRRCode(source, dns.RcodeServerFailure) }
+
+// extRcodeCand builds a candidate carrying an EDNS extended rcode (≥16): the
+// header holds only the low 4 bits, the OPT record the upper 8 (RFC 6891).
+func extRcodeCand(source string, extRcode uint16) Candidate {
+	m := new(dns.Msg)
+	m.Response = true
+	m.Rcode = int(extRcode) & 0xF
+	opt := &dns.OPT{Hdr: dns.RR_Header{Name: ".", Rrtype: dns.TypeOPT}}
+	opt.SetExtendedRcode(extRcode)
+	m.Extra = append(m.Extra, opt)
+	return Candidate{Source: source, Resp: m}
+}
+
+// zone is the queried name in the tables below. The questions all carry
+// Qclass: dns.ClassINET on purpose: classification compares a record's class
+// against the question's, so a fixture leaving the question's class at zero would
+// match nothing and quietly make every row about it meaningless.
+const zone = "myaccount.blob.core.windows.net."
+
+func TestPreferPrivate_Select(t *testing.T) {
+	p, _ := Get("prefer_private")
+
+	tests := []struct {
+		name      string
+		qtype     uint16 // 0 => A
+		cands     []Candidate
+		wantIdx   int // index of the candidate whose Resp must be returned; -1 = none
+		wantOK    bool
+		wantAmbig bool
+	}{
+		{
+			name:    "private beats public even when listed last",
+			cands:   []Candidate{cand("b", dns.RcodeSuccess, "1.2.3.4"), cand("a", dns.RcodeSuccess, "10.0.0.5")},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			name:    "no private falls back to public, lowest source wins",
+			cands:   []Candidate{cand("b", dns.RcodeSuccess, "1.2.3.4"), cand("a", dns.RcodeSuccess, "5.6.7.8")},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			name:    "private beats public, CNAME, NODATA and NXDOMAIN",
+			cands:   []Candidate{cand("a", dns.RcodeNameError), cand("b", dns.RcodeSuccess, "1.2.3.4"), cand("c", dns.RcodeSuccess, "10.1.2.3")},
+			wantIdx: 2, wantOK: true,
+		},
+		{
+			name:    "public beats CNAME referral",
+			cands:   []Candidate{candRR("a", rrCNAME("x.privatelink.example")), cand("b", dns.RcodeSuccess, "1.2.3.4")},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			name:    "CNAME referral beats NODATA (tier over source)",
+			cands:   []Candidate{cand("a", dns.RcodeSuccess), candRR("z", rrCNAME("x.privatelink.example"))},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			name:    "CNAME referral beats NXDOMAIN",
+			cands:   []Candidate{cand("a", dns.RcodeNameError), candRR("z", rrCNAME("x.privatelink.example"))},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			name:    "NODATA beats NXDOMAIN (tier over source)",
+			cands:   []Candidate{cand("a", dns.RcodeNameError), cand("z", dns.RcodeSuccess)},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			name:    "NXDOMAIN carrying a CNAME stays NXDOMAIN, loses to a NOERROR referral",
+			cands:   []Candidate{candRRCode("a", dns.RcodeNameError, rrCNAME("x.example")), candRR("z", rrCNAME("y.example"))},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			name:    "NXDOMAIN (definitive) beats a SERVFAIL reply",
+			cands:   []Candidate{servfail("a"), cand("b", dns.RcodeNameError)},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			name:    "extended rcode (BADVERS, header nibble 0) is an error, not NODATA; NXDOMAIN beats it",
+			cands:   []Candidate{extRcodeCand("a", 16), cand("b", dns.RcodeNameError)},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			name:    "all NXDOMAIN: lowest source wins deterministically",
+			cands:   []Candidate{cand("b", dns.RcodeNameError), cand("a", dns.RcodeNameError)},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			// The address sits at the end of the chain, not at the queried name, and
+			// still counts: the address set is judged as a whole, so a chain needs no
+			// walking to be understood.
+			name:    "CNAME chain to a private A is private (real Azure shape)",
+			cands:   []Candidate{cand("b", dns.RcodeSuccess, "1.2.3.4"), candRR("a", rrCNAME("x.privatelink.blob.core.windows.net"), rrAAt("x.privatelink.blob.core.windows.net.", "10.0.0.7"))},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			// An answer that also hands out a public address does not resolve the name
+			// into the internal network. It ranks as the public answer it also is, so
+			// the source decides — it does not win on tier.
+			name:    "a mixed public+private answer is not internal",
+			cands:   []Candidate{cand("a", dns.RcodeSuccess, "9.9.9.9"), candRR("z", rrA("1.2.3.4"), rrA("10.0.0.9"))},
+			wantIdx: 0, wantOK: true,
+		},
+		{
+			// The padding shape: without this rule an attacker wins with an arbitrary
+			// public payload plus one unrelated private record.
+			name:    "a private record for another name does not make an answer internal",
+			cands:   []Candidate{cand("a", dns.RcodeSuccess, "203.0.113.10"), candRR("z", rrA("203.0.113.66"), rrAAt("pad.other.example.", "10.0.0.1"))},
+			wantIdx: 0, wantOK: true,
+		},
+		{
+			// Nothing in it is about the name we asked for, so it is no answer to that
+			// question — but it is still a reply that was received, and it is served if
+			// nothing better exists. Hence above the negatives, not below them.
+			name:    "a reply about no name of ours is off-topic, and still beats NXDOMAIN",
+			cands:   []Candidate{cand("a", dns.RcodeNameError), candRR("z", rrAAt("pad.other.example.", "10.0.0.1"))},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			name:    "off-topic loses to a referral for the queried name, despite the lower source",
+			cands:   []Candidate{candRR("a", rrAAt("pad.other.example.", "10.0.0.1")), candRR("z", rrCNAME("x.privatelink.example"))},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			// An empty answer is the ordinary NODATA reply, not an off-topic one: there
+			// is nothing in it that could be about a name. Were it treated as
+			// off-topic the two would tie here and the lower source would win.
+			name:    "off-topic outranks NODATA, which is how an empty answer stays NODATA",
+			cands:   []Candidate{cand("a", dns.RcodeSuccess), candRR("z", rrAAt("pad.other.example.", "10.0.0.1"))},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			// DNS 0x20: a resolver may echo the name in randomized case, so folding it
+			// is a requirement — otherwise a legitimate answer turns off-topic.
+			name:    "an owner name in different case still anchors the answer",
+			cands:   []Candidate{cand("a", dns.RcodeSuccess, "203.0.113.10"), candRR("z", rrAAt("MyAccount.BLOB.core.WINDOWS.net.", "10.0.0.5"))},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			// Only internal answers can disagree about an internal address, and a
+			// mixed answer is not one — so it must not raise the flag either.
+			name:    "a mixed answer does not make the internal answer ambiguous",
+			cands:   []Candidate{cand("a", dns.RcodeSuccess, "10.0.0.1"), candRR("z", rrA("203.0.113.9"), rrA("10.0.0.2"))},
+			wantIdx: 0, wantOK: true,
+		},
+		{
+			// The alias-anchored padding shape: an alias for the queried name makes the
+			// reply relevant, but the private address belongs to an unrelated name and
+			// so is not this answer. Were it counted, the reply would outrank the
+			// honest one while the client follows the alias to the attacker instead.
+			name:    "a private record for another name does not promote an aliased answer",
+			cands:   []Candidate{cand("a", dns.RcodeSuccess, "203.0.113.10"), candRR("z", rrCNAME("evil.attacker.example"), rrAAt("pad.other.example.", "10.0.0.1"))},
+			wantIdx: 0, wantOK: true,
+		},
+		{
+			// Reachability is directed: an alias of some unrelated name does not make
+			// its target an alias of the question, so the address there stays outside.
+			name: "an unrelated alias does not pull a name into the answer",
+			cands: []Candidate{cand("a", dns.RcodeSuccess, "203.0.113.10"), candRR("z",
+				rrCNAME("evil.attacker.example"),
+				rrCNAMEAt("junk.example.", "pad.example"),
+				rrAAt("pad.example.", "10.0.0.1"))},
+			wantIdx: 0, wantOK: true,
+		},
+		{
+			// Records arrive in whatever order the upstream packed them, so the chain
+			// is followed by re-scanning, not by reading the section top to bottom.
+			name: "a two-step chain promotes regardless of record order",
+			cands: []Candidate{cand("b", dns.RcodeSuccess, "203.0.113.10"), candRR("a",
+				rrAAt("second.example.", "10.0.0.7"),
+				rrCNAMEAt("first.example.", "second.example"),
+				rrCNAME("first.example"))},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			// RFC 1034 §3.6.2: a CNAME owner may hold no other data. A reply doing both
+			// is malformed, and whichever half a stub believes must not be decided by
+			// us — so the address at an aliased name is not counted.
+			name:    "an alias and an address at the same name do not promote",
+			cands:   []Candidate{cand("a", dns.RcodeSuccess, "203.0.113.10"), candRR("z", rrCNAME("evil.attacker.example"), rrA("10.0.0.1"))},
+			wantIdx: 0, wantOK: true,
+		},
+		{
+			// Pins that the closure terminates: a cycle merely stops adding names. The
+			// address sits at an aliased name, so it is not counted either.
+			name: "an alias cycle terminates and does not promote",
+			cands: []Candidate{cand("a", dns.RcodeSuccess, "203.0.113.10"), candRR("z",
+				rrCNAME("x.example"),
+				rrCNAMEAt("x.example.", "y.example"),
+				rrCNAMEAt("y.example.", "x.example"),
+				rrAAt("y.example.", "10.0.0.1"))},
+			wantIdx: 0, wantOK: true,
+		},
+		{
+			// A DNAME owner may legitimately carry other types (RFC 6672), unlike a
+			// CNAME owner — so the terminality rule must ask about CNAMEs only, or this
+			// address quietly stops counting.
+			name:    "an address next to a DNAME at the queried name still counts",
+			cands:   []Candidate{cand("a", dns.RcodeSuccess, "203.0.113.10"), candRR("z", rrA("10.0.0.5"), rrDNAMEAt(zone, "foo.example"))},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			// A DNAME aliases a subtree, not a name, and reaches an answer through the
+			// synthesized CNAME. An unrelated one must not turn this into a referral —
+			// it would outrank another resolver's NODATA on nothing.
+			name:    "an unrelated DNAME does not make a reply a referral",
+			cands:   []Candidate{cand("a", dns.RcodeSuccess), candRR("z", rrTXTAt(zone, "x"), rrDNAMEAt("junk.example.", "pad.example"))},
+			wantIdx: 0, wantOK: true,
+		},
+		{
+			// Class is part of a record's identity: an address in another class answers
+			// a different question, the client discards it, and counting it would let
+			// it decide this one.
+			name:    "an address in another class does not count",
+			cands:   []Candidate{cand("a", dns.RcodeSuccess, "203.0.113.10"), candRR("z", rrCNAME("evil.attacker.example"), rrAClassAt("evil.attacker.example.", dns.ClassCHAOS, "10.0.0.1"))},
+			wantIdx: 0, wantOK: true,
+		},
+		{
+			name:    "two private, different addresses: lowest source wins, flagged ambiguous",
+			cands:   []Candidate{cand("z", dns.RcodeSuccess, "10.0.0.1"), cand("a", dns.RcodeSuccess, "10.0.0.2")},
+			wantIdx: 1, wantOK: true, wantAmbig: true,
+		},
+		{
+			name:    "two private, SAME address: redundant HA, not ambiguous",
+			cands:   []Candidate{cand("b", dns.RcodeSuccess, "10.0.0.5"), cand("a", dns.RcodeSuccess, "10.0.0.5")},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			name:    "CGNAT 100.64/10 counts as private",
+			cands:   []Candidate{cand("a", dns.RcodeSuccess, "1.1.1.1"), cand("b", dns.RcodeSuccess, "100.100.0.5")},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			name:    "IPv6 ULA private beats public v6 (AAAA query)",
+			qtype:   dns.TypeAAAA,
+			cands:   []Candidate{cand("a", dns.RcodeSuccess, "2606:4700::1111"), cand("b", dns.RcodeSuccess, "fd00::1")},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			name:    "a SERVFAIL reply beats a no-reply (nil): a real error reply is worth more than nothing",
+			cands:   []Candidate{failCand("a"), servfail("b")},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			name:    "all SERVFAIL: returns the upstream error reply (lowest source), not a synthesized one",
+			cands:   []Candidate{servfail("a"), servfail("b")},
+			wantIdx: 0, wantOK: true,
+		},
+		{
+			name:    "all resolvers failed to reply (nil): returns none, caller synthesizes SERVFAIL",
+			cands:   []Candidate{failCand("a"), failCand("b")},
+			wantIdx: -1, wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			qtype := tt.qtype
+			if qtype == 0 {
+				qtype = dns.TypeA
+			}
+			got, ok := p.Select(dns.Question{Name: zone, Qtype: qtype, Qclass: dns.ClassINET}, tt.cands)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				if got.Resp != nil {
+					t.Fatalf("got non-nil response, want nil")
+				}
+				return
+			}
+			want := tt.cands[tt.wantIdx]
+			if got.Resp != want.Resp {
+				t.Fatalf("wrong candidate: got %v, want candidate[%d] (source %q)", got.Resp.Answer, tt.wantIdx, want.Source)
+			}
+			if got.Source != want.Source {
+				t.Fatalf("Source = %q, want %q", got.Source, want.Source)
+			}
+			if got.Ambiguous != tt.wantAmbig {
+				t.Fatalf("Ambiguous = %v, want %v", got.Ambiguous, tt.wantAmbig)
+			}
+		})
+	}
+}
+
+func TestFirstSuccess_Select(t *testing.T) {
+	p, _ := Get("first_success")
+	q := dns.Question{Name: zone, Qtype: dns.TypeA, Qclass: dns.ClassINET}
+
+	tests := []struct {
+		name    string
+		cands   []Candidate
+		wantIdx int
+		wantOK  bool
+	}{
+		{
+			name:    "first response in order wins",
+			cands:   []Candidate{cand("b", dns.RcodeSuccess, "1.2.3.4"), cand("a", dns.RcodeSuccess, "10.0.0.5")},
+			wantIdx: 0, wantOK: true,
+		},
+		{
+			// Backward-compatible with the resolver's sequential path: a SERVFAIL
+			// IS a response and is returned; only a non-answering upstream (nil) is
+			// skipped. (Whether SERVFAIL should count is arguably a pre-existing bug,
+			// tracked separately — not changed here.)
+			name:    "skips non-answers (nil), but a SERVFAIL response is returned",
+			cands:   []Candidate{failCand("a"), servfail("b"), cand("c", dns.RcodeNameError)},
+			wantIdx: 1, wantOK: true,
+		},
+		{
+			name:    "all non-answers (nil) returns none",
+			cands:   []Candidate{failCand("a"), failCand("b")},
+			wantIdx: -1, wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := p.Select(q, tt.cands)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if got.Resp != tt.cands[tt.wantIdx].Resp {
+				t.Fatalf("wrong candidate: want candidate[%d] (source %q)", tt.wantIdx, tt.cands[tt.wantIdx].Source)
+			}
+		})
+	}
+}
+
+// prefer_private ranks only A/AAAA addresses. For any other query type it has no
+// private/public distinction, so it returns a responded answer chosen
+// deterministically by lowest Source — independent of arrival order, and never
+// flagged ambiguous. The pool never fans out for non-A/AAAA anyway (ADR-0023 D5).
+func TestPreferPrivate_NonAddressPicksLowestSourceDeterministically(t *testing.T) {
+	pp, _ := Get("prefer_private")
+	qMX := dns.Question{Name: zone, Qtype: dns.TypeMX, Qclass: dns.ClassINET}
+
+	// "z" is first in arrival order, but "a" has the lower Source and must win.
+	cands := []Candidate{candRR("z", rrMX(10, "m1.example.com")), candRR("a", rrMX(20, "m2.example.com"))}
+
+	got, ok := pp.Select(qMX, cands)
+	if !ok || got.Source != "a" {
+		t.Fatalf("non-address query must pick lowest Source deterministically: got %q ok=%v, want \"a\"", got.Source, ok)
+	}
+	if got.Ambiguous {
+		t.Fatalf("Ambiguous must be false for non-address queries")
+	}
+}
+
+func TestGetPolicy(t *testing.T) {
+	if p, ok := Get(""); !ok || p.Name() != "first_success" {
+		t.Fatalf("empty name should resolve to first_success, got ok=%v", ok)
+	}
+	if p, ok := Get("prefer_private"); !ok || p.Name() != "prefer_private" {
+		t.Fatalf("prefer_private not resolved, got ok=%v", ok)
+	}
+	if _, ok := Get("nope"); ok {
+		t.Fatalf("unknown policy should return ok=false")
+	}
+}

--- a/client/internal/dns/selection/selection_test.go
+++ b/client/internal/dns/selection/selection_test.go
@@ -447,3 +447,39 @@ func TestGetPolicy(t *testing.T) {
 		t.Fatalf("unknown policy should return ok=false")
 	}
 }
+
+// TestRanking pins which policies a caller must gather candidates for.
+func TestRanking(t *testing.T) {
+	// The nil case carries the whole opt-in: nothing configured must never be
+	// gathered for. It is the only one live in production until the config knob
+	// lands, and it is why Ranking exists next to Policy.Ranks.
+	if Ranking(nil) {
+		t.Error("a nil policy must not rank")
+	}
+
+	// One row per name Get resolves. A new policy has to answer Ranks() to
+	// compile at all; this table is where the answer is stated out loud.
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: "", want: false}, // resolves to DefaultPolicy
+		{name: "first_success", want: false},
+		{name: "prefer_private", want: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p, ok := Get(tc.name)
+			if !ok {
+				t.Fatalf("policy %q does not resolve", tc.name)
+			}
+			if got := p.Ranks(); got != tc.want {
+				t.Errorf("%s.Ranks() = %v, want %v", p.Name(), got, tc.want)
+			}
+			if got := Ranking(p); got != tc.want {
+				t.Errorf("Ranking(%s) = %v, want %v", p.Name(), got, tc.want)
+			}
+		})
+	}
+}

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/openzro/openzro/client/iface/netstack"
 	"github.com/openzro/openzro/client/internal/dns/local"
+	"github.com/openzro/openzro/client/internal/dns/selection"
 	"github.com/openzro/openzro/client/internal/dns/types"
 	"github.com/openzro/openzro/client/internal/listener"
 	"github.com/openzro/openzro/client/internal/peer"
@@ -23,6 +24,11 @@ import (
 	nbdns "github.com/openzro/openzro/dns"
 	"github.com/openzro/openzro/management/domain"
 )
+
+// errNoUsableNameserver marks a nameserver group this peer cannot resolve
+// through: it carries no nameserver of a supported type. Callers skip such a
+// group instead of failing the whole configuration.
+var errNoUsableNameserver = errors.New("nameserver group has no usable nameserver")
 
 // ReadyListener is a notification mechanism what indicate the server is ready to handle host dns address changes
 type ReadyListener interface {
@@ -87,6 +93,12 @@ type DefaultServer struct {
 
 	statusRecorder *peer.Status
 	stateManager   *statemanager.Manager
+
+	// selectionPolicy decides which answer wins when a zone is served by more
+	// than one nameserver group: the groups are then pooled behind a single
+	// handler and all of them are asked. nil — the default — keeps the
+	// pre-existing behavior, where the highest-priority group answers alone.
+	selectionPolicy selection.Policy
 }
 
 type handlerWithStop interface {
@@ -664,6 +676,14 @@ func (s *DefaultServer) buildUpstreamHandlerUpdate(nameServerGroups []*nbdns.Nam
 }
 
 func (s *DefaultServer) createHandlersForDomainGroup(domainGroup nsGroupsByDomain, basePriority int) ([]handlerWrapper, error) {
+	// With a ranking selection policy the groups of a zone are pooled behind one
+	// handler and all of them are asked, instead of only the highest-priority
+	// one. Whether a policy ranks — and so needs the pool — is the selection
+	// package's call, not ours.
+	if selection.Ranking(s.selectionPolicy) && len(domainGroup.groups) > 1 {
+		return s.createPooledHandler(domainGroup, basePriority)
+	}
+
 	var muxUpdates []handlerWrapper
 
 	for i, nsGroup := range domainGroup.groups {
@@ -676,32 +696,12 @@ func (s *DefaultServer) createHandlersForDomainGroup(domainGroup nsGroupsByDomai
 		}
 
 		log.Debugf("creating handler for domain=%s with priority=%d", domainGroup.domain, priority)
-		handler, err := newUpstreamResolver(
-			s.ctx,
-			s.wgInterface.Name(),
-			s.wgInterface.Address().IP,
-			s.wgInterface.Address().Network,
-			s.statusRecorder,
-			s.hostsDNSHolder,
-			domainGroup.domain,
-		)
-		if err != nil {
-			return nil, fmt.Errorf("create upstream resolver: %v", err)
-		}
-
-		for _, ns := range nsGroup.NameServers {
-			if ns.NSType != nbdns.UDPNameServerType {
-				log.Warnf("skipping nameserver %s with type %s, this peer supports only %s",
-					ns.IP.String(), ns.NSType.String(), nbdns.UDPNameServerType.String())
-				continue
-			}
-			handler.upstreamServers = append(handler.upstreamServers, getNSHostPort(ns))
-		}
-
-		if len(handler.upstreamServers) == 0 {
-			handler.Stop()
-			log.Errorf("received a nameserver group with an invalid nameserver list")
+		handler, err := s.newGroupResolver(nsGroup, domainGroup.domain)
+		if errors.Is(err, errNoUsableNameserver) {
 			continue
+		}
+		if err != nil {
+			return nil, err
 		}
 
 		// when upstream fails to resolve domain several times over all it servers
@@ -712,7 +712,7 @@ func (s *DefaultServer) createHandlersForDomainGroup(domainGroup nsGroupsByDomai
 		// after some period defined by upstream it tries to reactivate self by calling this hook
 		// everything we need here is just to re-apply current configuration because it already
 		// contains this upstream settings (temporal deactivation not removed it)
-		handler.deactivate, handler.reactivate = s.upstreamCallbacks(nsGroup, handler, priority)
+		handler.setCallbacks(s.upstreamCallbacks(nsGroup, handler, priority))
 
 		muxUpdates = append(muxUpdates, handlerWrapper{
 			domain:   domainGroup.domain,
@@ -722,6 +722,40 @@ func (s *DefaultServer) createHandlersForDomainGroup(domainGroup nsGroupsByDomai
 	}
 
 	return muxUpdates, nil
+}
+
+// newGroupResolver builds the resolver for a single nameserver group. It returns
+// errNoUsableNameserver when the group carries no nameserver this peer can use.
+func (s *DefaultServer) newGroupResolver(nsGroup *nbdns.NameServerGroup, domain string) (upstreamGroupHandler, error) {
+	handler, err := newUpstreamResolver(
+		s.ctx,
+		s.wgInterface.Name(),
+		s.wgInterface.Address().IP,
+		s.wgInterface.Address().Network,
+		s.statusRecorder,
+		s.hostsDNSHolder,
+		domain,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("create upstream resolver: %w", err)
+	}
+
+	for _, ns := range nsGroup.NameServers {
+		if ns.NSType != nbdns.UDPNameServerType {
+			log.Warnf("skipping nameserver %s with type %s, this peer supports only %s",
+				ns.IP.String(), ns.NSType.String(), nbdns.UDPNameServerType.String())
+			continue
+		}
+		handler.upstreamServers = append(handler.upstreamServers, getNSHostPort(ns))
+	}
+
+	if len(handler.upstreamServers) == 0 {
+		handler.Stop()
+		log.Errorf("received a nameserver group with an invalid nameserver list")
+		return nil, errNoUsableNameserver
+	}
+
+	return handler, nil
 }
 
 func (s *DefaultServer) leaksPriority(domainGroup nsGroupsByDomain, basePriority int, priority int) bool {
@@ -795,7 +829,7 @@ func (s *DefaultServer) upstreamCallbacks(
 		s.mux.Lock()
 		defer s.mux.Unlock()
 
-		l := log.WithField("nameservers", nsGroup.NameServers)
+		l := nsGroupLogger(nsGroup)
 		l.Info("Temporarily deactivating nameservers group due to timeout")
 
 		removeIndex = make(map[string]int)
@@ -843,7 +877,7 @@ func (s *DefaultServer) upstreamCallbacks(
 			s.registerHandler([]string{domain}, handler, priority)
 		}
 
-		l := log.WithField("nameservers", nsGroup.NameServers)
+		l := nsGroupLogger(nsGroup)
 		l.Debug("reactivate temporary disabled nameserver group")
 
 		if nsGroup.Primary {
@@ -912,16 +946,27 @@ func (s *DefaultServer) updateNSGroupStates(groups []*nbdns.NameServerGroup) {
 }
 
 func (s *DefaultServer) updateNSState(nsGroup *nbdns.NameServerGroup, err error, enabled bool) {
-	states := s.statusRecorder.GetDNSStates()
-	id := generateGroupKey(nsGroup)
-	for i, state := range states {
-		if state.ID == id {
-			states[i].Enabled = enabled
-			states[i].Error = err
-			break
-		}
+	// A group without nameservers is a synthetic one standing for a pooled zone,
+	// not something updateNSGroupStates ever created a state for. Its members
+	// report their own state, so there is nothing to look up here.
+	if len(nsGroup.NameServers) == 0 {
+		return
 	}
-	s.statusRecorder.UpdateDNSStates(states)
+
+	// Updating the single group is atomic, where reading every state, editing one
+	// and writing them all back is not — pooled groups report their health
+	// without holding the server lock, so two of them can flip at once.
+	s.statusRecorder.UpdateDNSState(generateGroupKey(nsGroup), err, enabled)
+}
+
+// nsGroupLogger returns a logger naming both the group's servers and the domains
+// it serves. The domains matter for a pooled zone, where the zone-level events
+// come from a synthetic group that has no servers to name.
+func nsGroupLogger(nsGroup *nbdns.NameServerGroup) *log.Entry {
+	return log.WithFields(log.Fields{
+		"nameservers": nsGroup.NameServers,
+		"domains":     nsGroup.Domains,
+	})
 }
 
 func generateGroupKey(nsGroup *nbdns.NameServerGroup) string {

--- a/client/internal/dns/server.go
+++ b/client/internal/dns/server.go
@@ -116,7 +116,9 @@ type handlerWrapper struct {
 
 type registeredHandlerMap map[types.HandlerID]handlerWrapper
 
-// NewDefaultServer returns a new dns server
+// NewDefaultServer returns a new dns server. selectionPolicy names the response
+// selection policy to use for zones served by more than one nameserver group; an
+// empty name keeps the pre-existing behavior.
 func NewDefaultServer(
 	ctx context.Context,
 	wgInterface WGIface,
@@ -124,6 +126,7 @@ func NewDefaultServer(
 	statusRecorder *peer.Status,
 	stateManager *statemanager.Manager,
 	disableSys bool,
+	selectionPolicy string,
 ) (*DefaultServer, error) {
 	var addrPort *netip.AddrPort
 	if customAddress != "" {
@@ -141,7 +144,7 @@ func NewDefaultServer(
 		dnsService = newServiceViaListener(wgInterface, addrPort)
 	}
 
-	return newDefaultServer(ctx, wgInterface, dnsService, statusRecorder, stateManager, disableSys), nil
+	return newDefaultServer(ctx, wgInterface, dnsService, statusRecorder, stateManager, disableSys, selectionPolicy), nil
 }
 
 // NewDefaultServerPermanentUpstream returns a new dns server. It optimized for mobile systems
@@ -155,7 +158,9 @@ func NewDefaultServerPermanentUpstream(
 	disableSys bool,
 ) *DefaultServer {
 	log.Debugf("host dns address list is: %v", hostsDnsList)
-	ds := newDefaultServer(ctx, wgInterface, NewServiceViaMemory(wgInterface), statusRecorder, nil, disableSys)
+	// No selection policy: the mobile clients do not carry the client config field
+	// that opts into one.
+	ds := newDefaultServer(ctx, wgInterface, NewServiceViaMemory(wgInterface), statusRecorder, nil, disableSys, "")
 	ds.hostsDNSHolder.set(hostsDnsList)
 	ds.permanent = true
 	ds.addHostRootZone()
@@ -174,7 +179,7 @@ func NewDefaultServerIos(
 	statusRecorder *peer.Status,
 	disableSys bool,
 ) *DefaultServer {
-	ds := newDefaultServer(ctx, wgInterface, NewServiceViaMemory(wgInterface), statusRecorder, nil, disableSys)
+	ds := newDefaultServer(ctx, wgInterface, NewServiceViaMemory(wgInterface), statusRecorder, nil, disableSys, "")
 	ds.iosDnsManager = iosDnsManager
 	return ds
 }
@@ -186,23 +191,25 @@ func newDefaultServer(
 	statusRecorder *peer.Status,
 	stateManager *statemanager.Manager,
 	disableSys bool,
+	selectionPolicy string,
 ) *DefaultServer {
 	handlerChain := NewHandlerChain()
 	ctx, stop := context.WithCancel(ctx)
 	defaultServer := &DefaultServer{
-		ctx:            ctx,
-		ctxCancel:      stop,
-		disableSys:     disableSys,
-		service:        dnsService,
-		handlerChain:   handlerChain,
-		extraDomains:   make(map[domain.Domain]int),
-		dnsMuxMap:      make(registeredHandlerMap),
-		localResolver:  local.NewResolver(),
-		wgInterface:    wgInterface,
-		statusRecorder: statusRecorder,
-		stateManager:   stateManager,
-		hostsDNSHolder: newHostsDNSHolder(),
-		hostManager:    &noopHostConfigurator{},
+		ctx:             ctx,
+		ctxCancel:       stop,
+		disableSys:      disableSys,
+		service:         dnsService,
+		handlerChain:    handlerChain,
+		extraDomains:    make(map[domain.Domain]int),
+		dnsMuxMap:       make(registeredHandlerMap),
+		localResolver:   local.NewResolver(),
+		wgInterface:     wgInterface,
+		statusRecorder:  statusRecorder,
+		stateManager:    stateManager,
+		hostsDNSHolder:  newHostsDNSHolder(),
+		hostManager:     &noopHostConfigurator{},
+		selectionPolicy: resolveSelectionPolicy(selectionPolicy),
 	}
 
 	// register with root zone, handler chain takes care of the routing

--- a/client/internal/dns/server_test.go
+++ b/client/internal/dns/server_test.go
@@ -383,7 +383,7 @@ func TestUpdateDNSServer(t *testing.T) {
 					t.Log(err)
 				}
 			}()
-			dnsServer, err := NewDefaultServer(context.Background(), wgIface, "", peer.NewRecorder("mgm"), nil, false)
+			dnsServer, err := NewDefaultServer(context.Background(), wgIface, "", peer.NewRecorder("mgm"), nil, false, "")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -493,7 +493,7 @@ func TestDNSFakeResolverHandleUpdates(t *testing.T) {
 		return
 	}
 
-	dnsServer, err := NewDefaultServer(context.Background(), wgIface, "", peer.NewRecorder("mgm"), nil, false)
+	dnsServer, err := NewDefaultServer(context.Background(), wgIface, "", peer.NewRecorder("mgm"), nil, false, "")
 	if err != nil {
 		t.Errorf("create DNS server: %v", err)
 		return
@@ -603,7 +603,7 @@ func TestDNSServerStartStop(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			dnsServer, err := NewDefaultServer(context.Background(), &mocWGIface{}, testCase.addrPort, peer.NewRecorder("mgm"), nil, false)
+			dnsServer, err := NewDefaultServer(context.Background(), &mocWGIface{}, testCase.addrPort, peer.NewRecorder("mgm"), nil, false, "")
 			if err != nil {
 				t.Fatalf("%v", err)
 			}

--- a/client/internal/dns/upstream.go
+++ b/client/internal/dns/upstream.go
@@ -97,9 +97,36 @@ func (u *upstreamResolverBase) MatchSubdomains() bool {
 	return true
 }
 
+// source returns a stable identifier for this group's upstream servers. It is
+// used as the deterministic tiebreak key when several groups serve one zone, and
+// in log lines: server addresses are identifiers, not secrets.
+func (u *upstreamResolverBase) source() string {
+	servers := slices.Clone(u.upstreamServers)
+	slices.Sort(servers)
+	return strings.Join(servers, ",")
+}
+
+// setCallbacks installs the deactivate/reactivate health hooks. Not allowed to
+// call reactivate before deactivate.
+func (u *upstreamResolverBase) setCallbacks(deactivate func(error), reactivate func()) {
+	u.deactivate, u.reactivate = deactivate, reactivate
+}
+
 func (u *upstreamResolverBase) Stop() {
 	log.Debugf("stopping serving DNS for upstreams %s", u.upstreamServers)
 	u.cancel()
+}
+
+// stopped reports whether this resolver has been stopped and will not answer
+// again, so a caller can leave it out instead of paying a failing exchange per
+// upstream server — and the log lines that come with it.
+func (u *upstreamResolverBase) stopped() bool {
+	select {
+	case <-u.ctx.Done():
+		return true
+	default:
+		return false
+	}
 }
 
 // ServeDNS handles a DNS request
@@ -116,12 +143,39 @@ func (u *upstreamResolverBase) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 		r.MsgHdr.AuthenticatedData = true
 	}
 
-	select {
-	case <-u.ctx.Done():
+	if u.stopped() {
 		logger.Tracef("%s has been stopped", u)
 		return
-	default:
 	}
+
+	var rm *dns.Msg
+	if rm, err = u.queryUpstreams(logger, r); rm == nil {
+		logger.Errorf("all queries to the %s failed for question domain=%s", u, r.Question[0].Name)
+
+		m := new(dns.Msg)
+		m.SetRcode(r, dns.RcodeServerFailure)
+		if err := w.WriteMsg(m); err != nil {
+			logger.Errorf("failed to write error response for %s for question domain=%s: %s", u, r.Question[0].Name, err)
+		}
+		return
+	}
+
+	if err = w.WriteMsg(rm); err != nil {
+		logger.Errorf("failed to write DNS response for question domain=%s: %s", r.Question[0].Name, err)
+	}
+}
+
+// queryUpstreams asks this group's upstream servers in order and returns the
+// first reply, or nil when none of them answered, together with the last error
+// seen. It keeps the group's fail and success counters up to date; deciding what
+// to write, and whether the group is still healthy (checkUpstreamFails), is left
+// to the caller — so a resolver pool can gather several groups' replies before
+// any of them is written.
+//
+// Cancellation comes from u.ctx through the per-exchange context: once the
+// resolver is stopped every exchange fails immediately.
+func (u *upstreamResolverBase) queryUpstreams(logger *log.Entry, r *dns.Msg) (*dns.Msg, error) {
+	var err error
 
 	for _, upstream := range u.upstreamServers {
 		var rm *dns.Msg
@@ -149,22 +203,13 @@ func (u *upstreamResolverBase) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 
 		u.successCount.Add(1)
 		logger.Tracef("took %s to query the upstream %s for question domain=%s", t, upstream, r.Question[0].Name)
-
-		if err = w.WriteMsg(rm); err != nil {
-			logger.Errorf("failed to write DNS response for question domain=%s: %s", r.Question[0].Name, err)
-		}
 		// count the fails only if they happen sequentially
 		u.failsCount.Store(0)
-		return
+		return rm, nil
 	}
-	u.failsCount.Add(1)
-	logger.Errorf("all queries to the %s failed for question domain=%s", u, r.Question[0].Name)
 
-	m := new(dns.Msg)
-	m.SetRcode(r, dns.RcodeServerFailure)
-	if err := w.WriteMsg(m); err != nil {
-		logger.Errorf("failed to write error response for %s for question domain=%s: %s", u, r.Question[0].Name, err)
-	}
+	u.failsCount.Add(1)
+	return nil, err
 }
 
 // checkUpstreamFails counts fails and disables or enables upstream resolving

--- a/client/internal/engine.go
+++ b/client/internal/engine.go
@@ -117,6 +117,11 @@ type EngineConfig struct {
 
 	DNSRouteInterval time.Duration
 
+	// DNSSelectionPolicy names the policy that picks the answer when a zone is
+	// served by more than one nameserver group. Empty keeps the pre-existing
+	// behavior. See profilemanager.Config.DNSSelectionPolicy.
+	DNSSelectionPolicy string
+
 	DisableClientRoutes bool
 	DisableServerRoutes bool
 	DisableDNS          bool
@@ -1661,7 +1666,15 @@ func (e *Engine) newDnsServer(dnsConfig *nbdns.Config) (dns.Server, error) {
 		return dnsServer, nil
 
 	default:
-		dnsServer, err := dns.NewDefaultServer(e.ctx, e.wgInterface, e.config.CustomDNSAddress, e.statusRecorder, e.stateManager, e.config.DisableDNS)
+		dnsServer, err := dns.NewDefaultServer(
+			e.ctx,
+			e.wgInterface,
+			e.config.CustomDNSAddress,
+			e.statusRecorder,
+			e.stateManager,
+			e.config.DisableDNS,
+			e.config.DNSSelectionPolicy,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/client/internal/peer/status.go
+++ b/client/internal/peer/status.go
@@ -788,6 +788,24 @@ func (d *Status) UpdateDNSStates(dnsStates []NSGroupState) {
 	d.nsGroupStates = dnsStates
 }
 
+// UpdateDNSState updates the health of a single nameserver group, identified by
+// its ID. Unknown IDs are ignored. Doing it here keeps the update atomic, which
+// GetDNSStates followed by UpdateDNSStates is not: two groups whose health
+// changes at the same time would each write back a slice that predates the
+// other's change, and one of the two updates would be lost.
+func (d *Status) UpdateDNSState(id string, err error, enabled bool) {
+	d.mux.Lock()
+	defer d.mux.Unlock()
+
+	for i := range d.nsGroupStates {
+		if d.nsGroupStates[i].ID == id {
+			d.nsGroupStates[i].Enabled = enabled
+			d.nsGroupStates[i].Error = err
+			return
+		}
+	}
+}
+
 func (d *Status) UpdateResolvedDomainsStates(originalDomain domain.Domain, resolvedDomain domain.Domain, prefixes []netip.Prefix, resourceId route.ResID) {
 	d.mux.Lock()
 	defer d.mux.Unlock()

--- a/client/internal/peer/status_test.go
+++ b/client/internal/peer/status_test.go
@@ -62,6 +62,104 @@ func TestUpdatePeerState(t *testing.T) {
 	assert.Equal(t, ip, state.IP, "ip should be equal")
 }
 
+func TestUpdateDNSState(t *testing.T) {
+	const (
+		groupA = "group-a"
+		groupB = "group-b"
+	)
+	failed := errors.New("all nameservers timed out")
+
+	// recorderWithNSGroups returns a recorder holding two healthy nameserver
+	// groups serving one zone — the shape a pooled zone reports through.
+	recorderWithNSGroups := func() *Status {
+		status := NewRecorder("https://mgm")
+		status.UpdateDNSStates([]NSGroupState{
+			{ID: groupA, Servers: []string{"10.0.0.1:53"}, Domains: []string{"eu.example.com"}, Enabled: true},
+			{ID: groupB, Servers: []string{"10.0.0.2:53"}, Domains: []string{"eu.example.com"}, Enabled: true},
+		})
+		return status
+	}
+
+	stateOf := func(t *testing.T, status *Status, id string) NSGroupState {
+		t.Helper()
+
+		for _, state := range status.GetDNSStates() {
+			if state.ID == id {
+				return state
+			}
+		}
+		t.Fatalf("no state for nameserver group %s", id)
+		return NSGroupState{}
+	}
+
+	t.Run("a failing group is disabled with its error", func(t *testing.T) {
+		status := recorderWithNSGroups()
+
+		status.UpdateDNSState(groupA, failed, false)
+
+		failing := stateOf(t, status, groupA)
+		assert.False(t, failing.Enabled, "the failing group should be disabled")
+		assert.Equal(t, failed, failing.Error, "the failing group should carry its error")
+		assert.Equal(t, []string{"10.0.0.1:53"}, failing.Servers, "the rest of the state should be untouched")
+
+		healthy := stateOf(t, status, groupB)
+		assert.True(t, healthy.Enabled, "the other group should stay enabled")
+		assert.NoError(t, healthy.Error, "the other group should stay error-free")
+	})
+
+	t.Run("a recovered group is enabled and its error cleared", func(t *testing.T) {
+		status := recorderWithNSGroups()
+
+		status.UpdateDNSState(groupA, failed, false)
+		status.UpdateDNSState(groupA, nil, true)
+
+		recovered := stateOf(t, status, groupA)
+		assert.True(t, recovered.Enabled, "the recovered group should be enabled")
+		assert.NoError(t, recovered.Error, "the recovered group's error should be cleared")
+	})
+
+	t.Run("an unknown ID changes nothing", func(t *testing.T) {
+		status := recorderWithNSGroups()
+		before := status.GetDNSStates()
+
+		status.UpdateDNSState("no-such-group", failed, false)
+
+		assert.Equal(t, before, status.GetDNSStates(), "an unknown group should leave every state alone")
+	})
+
+	t.Run("groups failing at the same time do not overwrite each other", func(t *testing.T) {
+		// This is what the method exists for: pooled nameserver groups report their
+		// health without holding the DNS server's lock, so two of them can flip at
+		// once. Reading every state, editing one and writing them all back would
+		// lose one of the two updates. Repeated because that loss depends on the
+		// schedule: a single round hits the losing interleaving too rarely to
+		// notice a regression, a few hundred hit it reliably.
+		for range 500 {
+			status := recorderWithNSGroups()
+
+			start := make(chan struct{})
+			var wg sync.WaitGroup
+			for _, id := range []string{groupA, groupB} {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+
+					<-start
+					status.UpdateDNSState(id, failed, false)
+				}()
+			}
+			close(start)
+			wg.Wait()
+
+			for _, id := range []string{groupA, groupB} {
+				state := stateOf(t, status, id)
+				assert.False(t, state.Enabled, "%s should be disabled", id)
+				assert.Equal(t, failed, state.Error, "%s should carry its error", id)
+			}
+		}
+	})
+}
+
 func TestStatus_UpdatePeerFQDN(t *testing.T) {
 	key := "abc"
 	fqdn := "peer-a.openzro.local"

--- a/client/internal/profilemanager/config.go
+++ b/client/internal/profilemanager/config.go
@@ -133,6 +133,21 @@ type Config struct {
 
 	// DNSRouteInterval is the interval in which the DNS routes are updated
 	DNSRouteInterval time.Duration
+
+	// DNSSelectionPolicy opts into a response-selection policy for zones that are
+	// served by more than one nameserver group (ADR-0023). Empty — the default —
+	// keeps the pre-existing behavior, where the highest-priority group answers
+	// alone. "prefer_private" prefers the answer that points into the mesh or a
+	// private network, which is what split-horizon deployments want. An unknown
+	// name is logged and ignored rather than fatal. There is no command line flag
+	// yet: that needs a daemon IPC field, so v1 is configured here.
+	// The preference is best-effort: it classifies the addresses in each
+	// candidate's answer, so a compromised or misconfigured nameserver group
+	// could still name a spoofed private address — this trades a narrower
+	// window for a real usability gain, it does not add authentication of the
+	// source.
+	DNSSelectionPolicy string
+
 	// Path to a certificate used for mTLS authentication
 	ClientCertPath string
 

--- a/client/internal/profilemanager/config_test.go
+++ b/client/internal/profilemanager/config_test.go
@@ -105,6 +105,34 @@ func TestExtraIFaceBlackList(t *testing.T) {
 	assert.Contains(t, readConf.(*Config).IFaceBlackList, "eth1")
 }
 
+// TestDNSSelectionPolicySurvivesUpdate pins the opt-in mechanism of the DNS
+// response-selection policy (ADR-0023 D8): it is a persisted config field with no
+// command line flag of its own, so an operator writes it into config.json and
+// every later config update — which rewrites the whole file — has to leave it
+// alone. Defaulting to empty keeps the pre-existing resolver behavior.
+func TestDNSSelectionPolicySurvivesUpdate(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.json")
+	config, err := UpdateOrCreateConfig(ConfigInput{ConfigPath: path})
+	require.NoError(t, err)
+	require.Empty(t, config.DNSSelectionPolicy, "no selection policy by default")
+
+	config.DNSSelectionPolicy = "prefer_private"
+	require.NoError(t, WriteOutConfig(path, config))
+
+	// An unrelated change re-persists the file, which is where a field the input
+	// does not carry would be lost.
+	updated, err := UpdateConfig(ConfigInput{
+		ConfigPath:    path,
+		ManagementURL: "https://mgm.example.com:443",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "prefer_private", updated.DNSSelectionPolicy)
+
+	reread, err := GetConfig(path)
+	require.NoError(t, err)
+	assert.Equal(t, "prefer_private", reread.DNSSelectionPolicy)
+}
+
 func TestHiddenPreSharedKey(t *testing.T) {
 	hidden := "**********"
 	samplePreSharedKey := "mysecretpresharedkey"

--- a/docs/adr/0023-policy-based-multi-resolver-dns.md
+++ b/docs/adr/0023-policy-based-multi-resolver-dns.md
@@ -489,6 +489,48 @@ visible once the pool existed, both covered by regression tests:
   against a synthetic group covering just that zone; per-source status keeps
   coming from the sources themselves.
 
+### The opt-in surface as built (D8)
+
+D8 leaves the choice between a CLI flag and a config file open. v1 ships the
+config file alone: `Config.DNSSelectionPolicy` in the client's persisted
+configuration, threaded `config → EngineConfig → DefaultServer → resolverPool`.
+
+A flag would have to travel through the daemon's IPC to reach the same field,
+which means a `client/proto` change and a regenerated `daemon.pb.go` — a
+protoc-version risk taken for an opt-in that hardly anyone sets, and one that can
+be added later without touching anything below it. The field is not part of
+`ConfigInput` for the same reason: nothing would write it yet, and the flag commit
+would add both together. `DisableIPv6Discovery` is configured the same way today.
+
+Empty means "not configured" and keeps a nil policy, so the mobile constructors —
+which have no client config field to read — stay exactly as they are.
+
+An unknown policy name is **warned about and ignored**, not fatal: refusing to
+resolve DNS at all because a preference is misspelled is the worse failure, and
+the warning names the value that was dropped. Strict validation belongs to the
+flag, where a typo can be rejected while the operator is still watching.
+
+### Two examples in the Decision and Verification sections that drifted
+
+D4's example warning line, `ambiguous: N private answers for <name> from X,Y —
+picked X`, was illustrative and is not what shipped. The actual line
+(`pool.go`, logged at most once per five minutes per the throttling in "Where
+the implementation refines D4" above) is:
+
+    nameserver groups of <zone> disagree on the internal address for
+    domain=<name> (answered: <sources>), serving the answer from <source>.
+    Check the zone's nameserver configuration.
+
+The Verification section's `go test -run` pattern predates the zone-hook and
+ranking regression tests added since and does not select them (no alternative
+in the regex matches `TestServer_Pooled...` or `TestRanking`). The command that
+actually covers everything this ADR claims is regression-tested:
+
+    go test -race -timeout 5m -count=1 ./client/internal/dns/...
+
+Running the whole package is also simpler to keep accurate than maintaining a
+name filter against tests that get renamed or added.
+
 ## References
 
 - Proposal & maintainer greenlight: [openzro/openzro#140](https://github.com/openzro/openzro/issues/140).

--- a/docs/adr/0023-policy-based-multi-resolver-dns.md
+++ b/docs/adr/0023-policy-based-multi-resolver-dns.md
@@ -277,6 +277,218 @@ answer from the slower group; assert the private answer is returned) and stays
 in the tree. Pre-PR: working-tree test image (`Dockerfile.testbuild` →
 `hri4711/openzrotest`), smoke-tested on a peer with two NS-groups for one zone.
 
+## Implementation notes
+
+Append-only. Added while implementing the decisions above; the sections before
+this one are left as they were accepted.
+
+### Two components, not three (D1)
+
+D1 draws the pipeline as resolver pool → `ResponseSelector` → `SelectionPolicy`.
+The code has no `ResponseSelector` type: the pool hands the gathered candidates
+straight to the policy. A separate selector would have been a shell doing nothing
+but forwarding, while the part that is genuinely shared between policies — the
+quality ladder and the ranking spine with its deterministic tiebreak — lives in
+the selection package as internal helpers every policy reuses.
+
+The boundary D1 exists for is unchanged and is what the seam is worth: the
+resolver never learns about policies, and a policy never does I/O and never logs.
+Both are enforced by construction — the policies are pure functions of the
+candidate list, which is why they are exhaustively table-tested without a network.
+
+`CandidateResponse.Latency`, which D1 prints as part of the struct, is not
+carried: no policy uses it, and adding a field later is source-compatible for
+callers that construct candidates by field name. The struct's documented purpose
+of taking further signals (D11) is unaffected.
+
+### The response ladder (D3)
+
+D3 orders four classes: private > public > negative > none. The implementation
+splits that into a **policy-independent ladder** plus a **policy refinement**,
+because "negative" turned out to be several different things whose order the ADR
+does not decide:
+
+    no reply < error reply < NXDOMAIN < NODATA < off-topic < referral < answer
+
+- **No reply < error reply.** A SERVFAIL or REFUSED *reply* is content — it can
+  carry an RFC 8914 extended DNS error. Forwarding the upstream's own failure
+  beats synthesizing a bare SERVFAIL, so a real error reply outranks a resolver
+  that never answered.
+- **Error reply < NXDOMAIN.** A definitive "this name does not exist" beats a
+  server failure.
+- **NXDOMAIN < NODATA.** The name exists but carries no record of the queried
+  type — often it has the *other* address family. Answering NXDOMAIN when another
+  resolver said the name exists would be wrong.
+- **NODATA < off-topic.** Every other rung grades a response's *content*; this one
+  grades its *relevance*. A reply whose answer section carries records but never
+  the queried name says nothing about that name, so nothing in it may decide what
+  that name resolves to — a private address belonging to some unrelated name must
+  not make the reply the internal answer. It still outranks the negatives, because
+  it is a reply that was received and is served when nothing better exists: ranking
+  it below them would mean a false positive of this very check suppresses a
+  legitimate answer in favour of another resolver's NXDOMAIN. That it therefore
+  outranks another resolver's NXDOMAIN is deliberate and costs availability only,
+  never a redirect. An **empty** answer section is not off-topic — that is the
+  ordinary NODATA reply, and there is nothing in it that could be about a name.
+  Owner names are compared in canonical form, because DNS 0x20 case randomization
+  makes a resolver echo the name in mixed case. A reply that does mention the
+  queried name but gives no address for it — a TXT, say — lands on NODATA, which is
+  what it is: the name exists and has no address here.
+- **Off-topic < referral.** A NOERROR CNAME/DNAME with no address resolved is a
+  pointer to follow, which is more than a negative answer, and it is about the
+  queried name. An NXDOMAIN that happens to carry a CNAME stays NXDOMAIN — the
+  alias resolves to nothing.
+- **Referral < answer**, and a ranking policy refines only that top tier:
+  `prefer_private` splits it into public < private.
+
+Two details worth recording. EDNS extended rcodes (≥ 16, RFC 6891) live in the
+OPT record, not in the 4-bit header field, so they are read from OPT before
+anything else — otherwise BADVERS (16, header nibble 0) would look like NOERROR
+and BADMODE (19, nibble 3) like NXDOMAIN. And because the ladder is shared, the
+`prefer_routed` idea of D11 becomes a different refinement of the top tier alone,
+with the ordering of everything below it decided once, here.
+
+### An answer is internal only if all of it is (D3)
+
+D3's private/public split reads naturally as "the answer holds a private address".
+The implementation requires **every** address of the queried type to be private
+instead. A message that also hands out a public address does not resolve the name
+into the internal network, and unlike "holds one" — which is decided by whichever
+record was appended last — a property of the whole set cannot be won by adding
+records to the message.
+
+Which addresses *are* the answer is decided by membership, not by resolving the
+chain. The set of names this reply presents as aliases of the question is the
+question's own name plus every CNAME target reachable from it, and an address
+counts when its owner is in that set, sits in the question's class, and is not
+itself aliased. Nothing else in the answer section belongs to this question.
+
+That is deliberately not a chain walk, and it needs none of the rulings one would
+require. A cycle is harmless because adding to a set is idempotent; a name aliased
+twice contributes both targets; there is no hop limit to pick, since every round
+either adds a name or ends the loop and the only candidates are CNAME targets of
+this answer, bounding it at the number of records. Order does not matter because
+each round rescans the section. The motivating shape works unchanged: a two-step
+Azure chain ending in a private address is a set of one private address.
+
+Three rules that look like details and are not:
+
+- **Only CNAME extends the set.** A DNAME aliases a subtree, not a name — its
+  owner is a proper ancestor of the queried name, and it reaches an answer through
+  the synthesized CNAME RFC 6672 requires alongside it. Letting a DNAME extend the
+  set, or count as a referral, would let an unrelated one decide this question.
+  Without the synthesized CNAME the set does not grow and the ladder settles lower,
+  which is the safe direction.
+- **Only CNAME makes a name non-terminal.** An address at a name that carries a
+  CNAME of its own is not this reply's answer: RFC 1034 §3.6.2 forbids a CNAME
+  owner from holding other data, so a reply doing both is malformed and a client
+  following the alias ends up elsewhere than the address suggests. The test asks
+  about CNAMEs only — a DNAME owner may legitimately carry an address, and
+  excluding those would silently drop a legitimate preference.
+- **Class is part of a record's identity.** A record in a class other than the
+  question's answers a different question; the client matches on (name, class,
+  type) and discards it, so counting it would let a discarded record decide.
+
+One accepted consequence: a reply that pads its answer section with unrelated
+**public** records loses its preference. Only a careless upstream can trigger that,
+and only for its own answer — nobody can enrich another resolver's reply. Note that
+"loses its preference" can mean the *other* group's public view is served, if that
+group wins the tiebreak: for a dual-homed service published with both an internal
+and a public address in one answer, `prefer_private` then has no effect for that
+name. The selected source is logged at debug level, which is where that shows up.
+
+Because "internal" is a property of the whole answer, the ambiguity warning below
+compares only candidates that are internal answers: a mixed reply is not one, so it
+cannot disagree about an internal address. The same restricted address set feeds the
+ranking, the signature comparison and the warning, so they cannot drift apart.
+
+### Which zones are pooled (D5)
+
+The pool is built per zone from the groups serving it, and a nameserver group
+marked *primary* serves the root zone. Two primary groups therefore pool `.`, so
+every A/AAAA query fans out and pays the settle window — not only the split-horizon
+zones D5 has in mind. That is the correct reading of "a zone served by more than one
+resolver", and with classification tied to the queried name such a zone is no less
+safe than any other, but the cost is worth knowing before enabling the policy on a
+peer whose default resolvers are two primary groups.
+
+### Where the implementation refines D4
+
+D4 says a name with two or more private answers is logged as ambiguous. The
+implementation narrows and throttles that:
+
+- The flag (`selection.Result.Ambiguous`) is raised only when the private
+  answers **differ** — two resolvers naming *different* private endpoints for
+  one name. Identical private answers from redundant resolvers are normal HA,
+  not a topology problem, and warning about them would be noise.
+- The selector stays a pure function and does not log; it sets the flag and the
+  pool warns, **at most once per five minutes**. A misconfigured zone is a
+  standing condition an operator has to fix, not a per-query event, and the
+  warning sits on the query path.
+
+The choice itself is deterministic either way, so this only changes what gets
+logged, never what gets answered.
+
+### Deferred: a determinism-preserving early exit
+
+D5 permits an early return only when the outstanding resolvers cannot change the
+outcome, and defines that as "a private answer is in hand *and* every other
+resolver has already responded" — which is the all-answers-in condition. The
+implementation therefore always waits for every resolver or the window, so a
+single slow resolver costs up to the window on every pooled A/AAAA query.
+
+There is a strictly stronger exit condition that still cannot change the result,
+and it is worth recording for a later increment:
+
+> Return as soon as the best candidate holds the **maximum possible score** and
+> every resolver still outstanding sorts to a **higher stable key** than that
+> candidate.
+
+It is exact, not heuristic: the maximum score cannot be beaten, and the tiebreak
+picks the lowest key, so an outstanding resolver with a higher key can at best
+tie and lose. One with a lower key can still win and must be waited for.
+
+Cost: the pool cannot evaluate this itself — it knows neither the policy's
+scoring nor what its maximum is — so `SelectionPolicy` would grow a second
+method along the lines of `Decided(q, candidates, pending) bool`, which every
+policy then has to implement. The only thing lost is the ambiguity flag above,
+since a second private answer may go unseen; that is a diagnostic, not an answer
+path. The gain is bounded by how much slower the slowest resolver is than the
+fastest, so it pays off exactly in the case the window exists for.
+
+### What the grace window does and does not bound (D5)
+
+D5 calls the window "a ceiling on how long the pool waits". It is a ceiling on the
+**added** wait: the clock starts with the first reply a policy could rank, as the
+implementation note in D5 recommends, so the pool is at most one window slower
+than its fastest resolver.
+
+It is deliberately **not** armed by a resolver that failed outright. A zone whose
+first resolver fails fast and whose second is slow therefore waits for the second
+one, bounded only by that resolver's own `UpstreamTimeout` — where today, with
+only the first resolver ever consulted, the client would get an immediate
+SERVFAIL. Arming on a failure instead would cap that wait, but at the price of
+sometimes returning SERVFAIL while discarding the answer the pool exists to
+fetch. Getting the answer wins; the wait stays bounded per resolver, and a
+resolver that keeps failing is deactivated out of the fan-out by the health model
+after `failsTillDeact` attempts.
+
+### Health scope of a pooled zone (D6)
+
+D6 keeps the per-source `deactivate`/`reactivate` model. Two details only became
+visible once the pool existed, both covered by regression tests:
+
+- The zone-level hooks must be derived **once per pool**, not per source. They
+  close over the index `reactivate` needs to undo what `deactivate` did, so
+  per-source pairs let whichever source returns first reactivate through an
+  empty index — leaving the zone deregistered until the next configuration push,
+  depending on which backoff won.
+- They must be scoped to the **pooled zone alone**. A nameserver group may serve
+  further domains, each pooled separately with its own health, so deactivating
+  one zone must not deregister the others. The zone-level hook therefore runs
+  against a synthetic group covering just that zone; per-source status keeps
+  coming from the sources themselves.
+
 ## References
 
 - Proposal & maintainer greenlight: [openzro/openzro#140](https://github.com/openzro/openzro/issues/140).


### PR DESCRIPTION
Part of #140.

## Summary

When a zone is served by more than one nameserver group — split-horizon DNS,
e.g. a Private Link zone answered both by an internal resolver reached over
the mesh and by a public one — openZro today only ever asks the
highest-priority group. The other groups are configured but never consulted,
so the client gets whichever view that one group has, which for a name that
also has an internal address is usually the wrong one.

This adds an opt-in **response selection policy**: when configured, a zone
with more than one resolver group is queried concurrently, and a policy picks
which answer the client gets. Default behavior (`first_success`, the only
policy honored when the field is unset) is byte-for-byte today's path — this
is zero-regression until an operator opts in.

Design doc: [`docs/adr/0023-policy-based-multi-resolver-dns.md`](../blob/HEAD/docs/adr/0023-policy-based-multi-resolver-dns.md),
accepted in #141, with an append-only "Implementation notes" section recording
where the build differs from the accepted decision and why.

## What's new

- `client/internal/dns/selection` — a pure, table-tested selection layer.
  Ships two policies: `first_success` (default) and `prefer_private`, which
  prefers a private/CGNAT answer over a public one, falls back to public when
  none is private, never lets a negative answer beat a positive one, and
  breaks ties deterministically by resolver source.
- `client/internal/dns/pool.go` — `resolverPool`, a single handler per pooled
  zone that fans a query out to every configured group, gathers replies within
  a bounded grace window (~500 ms, armed by the first usable reply, not the
  query), and hands them to the policy. Stays dormant — one handler per group,
  exactly as today — until a ranking policy is configured. Retains openZro's
  existing per-group health model (`deactivate`/`reactivate`), tracked per
  source inside the pool; a pool with every source deactivated behaves exactly
  as the group being absent today.
- Client-side opt-in only: `Config.DNSSelectionPolicy` (persisted config field)
  → `EngineConfig` → `DefaultServer` → `resolverPool`, no package-level state.
  Not part of `ConfigInput` yet — see "Deferred" below.

## Security hardening found during self-review

Two rounds of self-review turned up real correctness gaps in `prefer_private`'s
classification, both fixed and regression-tested before this PR:

1. **Off-name records must not decide the answer.** The first cut classified
   the whole answer section without checking which name a record actually
   belongs to, so an unrelated record for a different owner could promote a
   candidate to "private" while the payload for the queried name was anything.
   Fixed by adding an owner-name check (`tierOffTopic`, ranked above the
   negatives, below anything that's actually about the queried name) — see
   the ADR's "The response ladder" implementation note for the reasoning
   behind every rung.
2. **An answer counts as internal only if every address in it is**, not if it
   merely holds one, and membership in "the answer to this question" is
   decided by the transitive closure of CNAME targets from the queried name —
   not by walking the chain and adjudicating cycles/forks/hop limits. Closes
   the alias-padding variant of the same class of bug (a CNAME for the queried
   name plus an unrelated private record no longer wins).

Framing: these are **correctness fixes** to the stated invariant ("only the
answer to the question is classified"), not new vulnerabilities. The
selection layer only ever chooses which admin-configured group's answer wins;
it does not add a new way for a resolver to lie to the client. A malicious or
misconfigured nameserver group can already win outright today when it's the
only one that answers (no padding needed) — this PR doesn't change that trust
boundary, it makes the pooled path classify correctly within it.

`cgnatPrefix` (100.64.0.0/10) is a local constant: `client/anonymize/anonymize.go`
carries the same range but doesn't export it, so it couldn't be reused as-is.

## Known limitations / accepted tradeoffs

- **HTTPS/SVCB (type 65) bypasses the pool** and is served by the first group
  alone, whose `ipv4hint` may carry the public address — ADR-0023 D5 scopes
  this policy to A/AAAA on purpose.
- **The tiebreak is not total.** Two groups configured with identical server
  lists for one zone yield equal tiebreak keys, so the winner falls back to
  arrival order. Harmless — identical servers are interchangeable — but the
  ambiguity warning won't fire for that case.
- **The private/CGNAT predicate is best-effort**, not authoritative — it
  classifies IP ranges, not resolver identity. A robust, authoritative
  alternative (an explicit "internal zone" tag, `prefer_routed`) is scoped as
  v2 (ADR-0023 D11), needs management/proto/dashboard changes.
- Two primary nameserver groups pool the root zone, so every A/AAAA query
  fans out and pays the grace window — worth knowing before enabling the
  policy on a peer whose defaults are two primary groups.

## Testing

- `go test -race -timeout 5m -count=1 ./client/internal/dns/...` — every test
  this branch adds passes by name under `-race`: the full selection table (40
  subtests across both security rounds), pool/wiring tests, health/zone-hook
  tests, `TestResolveSelectionPolicy`, `TestDNSSelectionPolicySurvivesUpdate`,
  `TestCreateEngineConfig_CarriesDNSSelectionPolicy`.
- `gofmt -s`, `go vet`, `golangci-lint` clean on every touched package.
- **Honesty note on the concurrency tests:** the two zone-hook serialization
  tests pin the new mechanism and can't be run red against the previous code
  (the machinery they test doesn't exist there). The round-2 alias-padding
  regression tests were verified red against round-1 code. The
  `UpdateDNSState` concurrency subtest is a probabilistic net, not a hard one
  — it went red in 3 of 5 `-race` runs at 500 rounds against the old
  read-modify-write pattern; the deterministic subtests are the real
  regression net for that fix.
- Pre-existing `-race` failures in `client/internal/dns` and
  `client/internal/peer` are **not from this branch** — verified identical
  against a `origin/main` baseline worktree.
- **Live smoke test** on a real peer with two nameserver groups for one zone
  (evidence anonymized below — no internal hostnames/addresses):
  - single-group zone: unpooled path unchanged, no pool log line.
  - two-group zone (`host.eu.example.com`, internal `10.0.0.53:53` +
    public `8.8.8.8:53,8.8.4.4:53`): pool built, one handler registered
    instead of two.
  - **private vs. public** (internal `10.0.0.10` / public `203.0.113.10`):
    pool serves the internal answer.
  - **private vs. a different private** (internal `10.0.0.10` / `10.0.9.9`):
    pool serves the internal answer, decided by the source tiebreak (not
    arrival order or group priority); exactly one throttled warning logged
    for the two queries, naming both groups.
  - **private vs. NXDOMAIN**: private answer wins via the base ladder, no
    warning (only one candidate is an internal answer).

## Deferred to a follow-up PR (deliberately not in this one)

- **CLI flag** for the policy — needs a `client/proto` (daemon IPC) field and
  a regenerated `daemon.pb.go`; that commit also adds
  `ConfigInput.DNSSelectionPolicy *string` and strict `apply()` validation.
  `DisableIPv6Discovery` is configured the same way today, so this isn't a new
  pattern.
- Determinism-preserving early exit for the gather window (written up in the
  ADR's implementation notes so it isn't lost).
- Explicit "internal zone" tag and `prefer_routed` (ADR-0023 D11) — the
  authoritative alternative to the best-effort private predicate.
- `docs/adr/README.md` index backfill (stops at 0009) — unrelated to this
  feature, left for its own commit.
