### PR TITLE
fix(management/peer): resolve account row deadlock on concurrent peer delete

### DIFF
--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -444,34 +444,42 @@ func (am *DefaultAccountManager) DeletePeer(ctx context.Context, accountID, peer
 	var eventsToStore []func()
 
 	err = am.Store.ExecuteInTransaction(ctx, func(transaction store.Store) error {
-		// Take the exclusive lock on the account row up front. This
-		// transaction is going to write that row anyway, and several of
-		// the reads below (isPeerInActiveGroup, and the settings/network
-		// lookups in deletePeers) take a SHARED lock on the very same
-		// row. Acquiring the shared lock first and upgrading later
-		// deadlocks as soon as a second account-scoped write overlaps:
-		// both transactions hold the shared lock, both then ask for the
-		// exclusive one, and the database kills one of them (Postgres
-		// SQLSTATE 40P01), which reaches the API caller as a 500.
+		peer, err = transaction.GetPeerByID(ctx, store.LockingStrengthUpdate, accountID, peerID)
+		if err != nil {
+			return err
+		}
+
+		// Touches network_routers, not the account row.
+		if err = am.validatePeerDelete(ctx, transaction, accountID, peerID); err != nil {
+			return err
+		}
+
+		// Take the exclusive lock on the account row here, before the
+		// first shared read of it. This transaction is going to write
+		// that row anyway, and the reads that follow (isPeerInActiveGroup
+		// and the settings/network lookups in deletePeers) take a SHARED
+		// lock on the very same row. Acquiring the shared lock first and
+		// upgrading later deadlocks as soon as a second account-scoped
+		// write overlaps: both transactions hold the shared lock, both
+		// then ask for the exclusive one, and the database kills one of
+		// them (Postgres SQLSTATE 40P01), which reaches the API caller as
+		// a 500.
 		//
 		// AcquireWriteLockByUID above does not prevent this — it is a
 		// process-local mutex, so with more than one management replica
 		// the overlapping transaction simply runs elsewhere. The account
 		// row itself is the only lock every replica shares.
 		//
+		// It has to stay *after* GetPeerByID: peer-scoped writes reach
+		// the two rows peer-first (UpdatePeer locks the peer, then reads
+		// account settings under a shared lock). Hoisting this to the top
+		// of the transaction would invert that and trade one deadlock for
+		// another.
+		//
 		// Ordering only: the serial is incremented inside the same
 		// transaction as before, so a later validation failure still
 		// rolls it back.
 		if err = transaction.IncrementNetworkSerial(ctx, store.LockingStrengthUpdate, accountID); err != nil {
-			return err
-		}
-
-		peer, err = transaction.GetPeerByID(ctx, store.LockingStrengthUpdate, accountID, peerID)
-		if err != nil {
-			return err
-		}
-
-		if err = am.validatePeerDelete(ctx, transaction, accountID, peerID); err != nil {
 			return err
 		}
 

--- a/management/server/peer.go
+++ b/management/server/peer.go
@@ -444,6 +444,28 @@ func (am *DefaultAccountManager) DeletePeer(ctx context.Context, accountID, peer
 	var eventsToStore []func()
 
 	err = am.Store.ExecuteInTransaction(ctx, func(transaction store.Store) error {
+		// Take the exclusive lock on the account row up front. This
+		// transaction is going to write that row anyway, and several of
+		// the reads below (isPeerInActiveGroup, and the settings/network
+		// lookups in deletePeers) take a SHARED lock on the very same
+		// row. Acquiring the shared lock first and upgrading later
+		// deadlocks as soon as a second account-scoped write overlaps:
+		// both transactions hold the shared lock, both then ask for the
+		// exclusive one, and the database kills one of them (Postgres
+		// SQLSTATE 40P01), which reaches the API caller as a 500.
+		//
+		// AcquireWriteLockByUID above does not prevent this — it is a
+		// process-local mutex, so with more than one management replica
+		// the overlapping transaction simply runs elsewhere. The account
+		// row itself is the only lock every replica shares.
+		//
+		// Ordering only: the serial is incremented inside the same
+		// transaction as before, so a later validation failure still
+		// rolls it back.
+		if err = transaction.IncrementNetworkSerial(ctx, store.LockingStrengthUpdate, accountID); err != nil {
+			return err
+		}
+
 		peer, err = transaction.GetPeerByID(ctx, store.LockingStrengthUpdate, accountID, peerID)
 		if err != nil {
 			return err
@@ -455,10 +477,6 @@ func (am *DefaultAccountManager) DeletePeer(ctx context.Context, accountID, peer
 
 		updateAccountPeers, err = isPeerInActiveGroup(ctx, transaction, accountID, peerID)
 		if err != nil {
-			return err
-		}
-
-		if err = transaction.IncrementNetworkSerial(ctx, store.LockingStrengthUpdate, accountID); err != nil {
 			return err
 		}
 

--- a/management/server/peer_delete_concurrency_test.go
+++ b/management/server/peer_delete_concurrency_test.go
@@ -1,0 +1,104 @@
+package server
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	nbpeer "github.com/openzro/openzro/management/server/peer"
+	"github.com/openzro/openzro/management/server/store"
+	"github.com/openzro/openzro/management/server/types"
+)
+
+// TestDeletePeer_ConcurrentAccountWrite_NoDeadlock guards the lock
+// ordering inside DeletePeer's transaction.
+//
+// The account row is the hot spot: DeletePeer ends up updating it
+// (IncrementNetworkSerial), and several reads on the way there take a
+// shared lock on that very same row. Taking the shared lock first and
+// upgrading to exclusive later is a deadlock waiting to happen — two
+// transactions can both hold the shared lock and then both ask for the
+// exclusive one. Postgres breaks the cycle by killing one of them with
+// SQLSTATE 40P01, which surfaces to the API caller as a 500.
+//
+// This is not hypothetical: the dashboard's bulk delete fires one
+// DELETE /api/peers/{id} per selected peer in parallel, and
+// AcquireWriteLockByUID only serializes within a single process, so
+// with more than one management replica those transactions overlap.
+//
+// The second goroutine here stands in for any other account-scoped
+// write reaching the database at the same time. It deliberately holds
+// the shared lock across the window in which DeletePeer needs the
+// exclusive one, so the ordering violation is deterministic rather
+// than a race the test would only lose sometimes.
+func TestDeletePeer_ConcurrentAccountWrite_NoDeadlock(t *testing.T) {
+	t.Setenv("OPENZRO_STORE_ENGINE", string(types.PostgresStoreEngine))
+
+	manager, err := createManager(t)
+	require.NoError(t, err)
+
+	const (
+		accountID = "test_account"
+		adminUser = "account_creator"
+		peerID    = "peer1"
+	)
+
+	ctx := context.Background()
+	account := newAccountWithId(ctx, accountID, adminUser, "", false)
+	account.Peers = map[string]*nbpeer.Peer{
+		peerID: {
+			ID:        peerID,
+			AccountID: accountID,
+			IP:        net.IP{1, 1, 1, 1},
+			DNSLabel:  peerID + ".test",
+		},
+	}
+	account.Groups["group1"] = &types.Group{
+		ID:        "group1",
+		AccountID: accountID,
+		Name:      "Group1",
+		Peers:     []string{peerID},
+	}
+	require.NoError(t, manager.Store.SaveAccount(ctx, account))
+
+	// holdShared is how long the competing transaction keeps its shared
+	// lock on the account row. It has to outlast DeletePeer's own walk
+	// to the exclusive lock, which is a handful of indexed queries.
+	const holdShared = 2 * time.Second
+
+	var wg sync.WaitGroup
+	var competingErr, deleteErr error
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		competingErr = manager.Store.ExecuteInTransaction(ctx, func(tx store.Store) error {
+			if _, err := tx.GetAccountSettings(ctx, store.LockingStrengthShare, accountID); err != nil {
+				return err
+			}
+			time.Sleep(holdShared)
+			return tx.IncrementNetworkSerial(ctx, store.LockingStrengthUpdate, accountID)
+		})
+	}()
+
+	// Let the competing transaction take its shared lock first.
+	time.Sleep(200 * time.Millisecond)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		deleteErr = manager.DeletePeer(ctx, accountID, peerID, adminUser)
+	}()
+
+	wg.Wait()
+
+	require.NoError(t, deleteErr, "DeletePeer must queue behind a concurrent account write, not deadlock")
+	require.NoError(t, competingErr, "the concurrent account write must not be the deadlock victim either")
+
+	_, err = manager.GetPeer(ctx, accountID, peerID, adminUser)
+	require.Error(t, err, "peer should be gone after a successful delete")
+}

--- a/management/server/peer_delete_concurrency_test.go
+++ b/management/server/peer_delete_concurrency_test.go
@@ -102,3 +102,94 @@ func TestDeletePeer_ConcurrentAccountWrite_NoDeadlock(t *testing.T) {
 	_, err = manager.GetPeer(ctx, accountID, peerID, adminUser)
 	require.Error(t, err, "peer should be gone after a successful delete")
 }
+
+// TestDeletePeer_ConcurrentPeerWrite_NoDeadlock guards the other half of
+// the ordering: DeletePeer must still take the peer row before the
+// account row.
+//
+// Peer-scoped writes reach the two rows in that order — UpdatePeer locks
+// the peer with GetPeerByID and only then reads account settings under a
+// shared lock. A DeletePeer that grabbed the account row first would
+// invert this and produce a fresh cycle: one transaction holding the
+// account row and waiting on the peer, the other holding the peer and
+// waiting on the account.
+//
+// The competing goroutine mirrors UpdatePeer's order and holds the peer
+// lock across the window, so the inversion is deterministic. Together
+// with TestDeletePeer_ConcurrentAccountWrite_NoDeadlock this pins
+// DeletePeer to exactly one position: peer first, account before any
+// shared read of it.
+func TestDeletePeer_ConcurrentPeerWrite_NoDeadlock(t *testing.T) {
+	t.Setenv("OPENZRO_STORE_ENGINE", string(types.PostgresStoreEngine))
+
+	manager, err := createManager(t)
+	require.NoError(t, err)
+
+	const (
+		accountID = "test_account"
+		adminUser = "account_creator"
+		peerID    = "peer1"
+	)
+
+	ctx := context.Background()
+	account := newAccountWithId(ctx, accountID, adminUser, "", false)
+	account.Peers = map[string]*nbpeer.Peer{
+		peerID: {
+			ID:        peerID,
+			AccountID: accountID,
+			IP:        net.IP{1, 1, 1, 1},
+			DNSLabel:  peerID + ".test",
+		},
+	}
+	account.Groups["group1"] = &types.Group{
+		ID:        "group1",
+		AccountID: accountID,
+		Name:      "Group1",
+		Peers:     []string{peerID},
+	}
+	require.NoError(t, manager.Store.SaveAccount(ctx, account))
+
+	const holdPeer = 2 * time.Second
+
+	var wg sync.WaitGroup
+	var competingErr, deleteErr error
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		// Same order as UpdatePeer: peer row first, account row after.
+		//
+		// The peer row is held under a SHARED lock on purpose. DeletePeer
+		// resolves the account with a shared read of that row before it
+		// opens its transaction; an exclusive lock here would simply park
+		// DeletePeer on that pre-transaction read, so it would never hold
+		// the account row while waiting for the peer and no cycle could
+		// form. A shared lock lets that read through and leaves the
+		// ordering itself as the only thing under test.
+		competingErr = manager.Store.ExecuteInTransaction(ctx, func(tx store.Store) error {
+			if _, err := tx.GetPeerByID(ctx, store.LockingStrengthShare, accountID, peerID); err != nil {
+				return err
+			}
+			time.Sleep(holdPeer)
+			_, err := tx.GetAccountSettings(ctx, store.LockingStrengthShare, accountID)
+			return err
+		})
+	}()
+
+	// Let the competing transaction take the peer lock first.
+	time.Sleep(200 * time.Millisecond)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		deleteErr = manager.DeletePeer(ctx, accountID, peerID, adminUser)
+	}()
+
+	wg.Wait()
+
+	require.NoError(t, deleteErr, "DeletePeer must queue behind a concurrent peer write, not deadlock")
+	require.NoError(t, competingErr, "the concurrent peer write must not be the deadlock victim either")
+
+	_, err = manager.GetPeer(ctx, accountID, peerID, adminUser)
+	require.Error(t, err, "peer should be gone after a successful delete")
+}


### PR DESCRIPTION
## Problem

Deleting several peers at once from the dashboard answers HTTP 500.

The dashboard has no bulk-delete endpoint: it fires one
`DELETE /api/peers/{id}` per selected peer in parallel. `DeletePeer`
guards the account with `AcquireWriteLockByUID`, which is a
process-local mutex — with more than one management replica those
requests land on different processes and their transactions overlap on
the same account row.

That overlap is fatal because the transaction reaches the account row
twice, in the wrong order:

1. `isPeerInActiveGroup` → `areGroupChangesAffectPeers` reads
   `GetAccountDNSSettings` / `GetAccountSettings` under
   `LockingStrengthShare` → `SELECT … FROM accounts … FOR SHARE`
2. `IncrementNetworkSerial` → `UPDATE accounts SET network_serial = …`
   on that same row

Two transactions both take the shared lock (compatible with each
other), then both request the exclusive one. Postgres breaks the cycle:

```
ERROR: deadlock detected (SQLSTATE 40P01)
```

`ExecuteInTransaction` returns it unmapped, `status.FromError` does not
recognise it, and `util.WriteError` falls through to
`http.StatusInternalServerError`. The user sees a 500 toast.

The path only reaches the shared reads when the peer belongs to a
group — which is always, because of the `All` group. That is why it
takes two concurrent deletes and not one.

## Fix

Move `IncrementNetworkSerial` so the exclusive lock on the account row
is taken before the first shared read of it.

Position matters in both directions, and this is the only spot that
satisfies both constraints:

- **after** `GetPeerByID`, because peer-scoped writes reach the two rows
  peer-first (`UpdatePeer` locks the peer, then reads account settings
  under a shared lock). Hoisting it to the top of the transaction trades
  the original deadlock for a new one.
- **before** `isPeerInActiveGroup`, which is where the first shared read
  of the account row happens.

`validatePeerDelete` sits between them and reads `network_routers`
only, so it disturbs neither.

Ordering only — the increment stays inside the same transaction, so a
later validation failure still rolls it back, and the serial read back
in `deletePeers` still sees the incremented value.

## Tests

Two regression tests pin the position from both sides. Each holds a
lock across the window in which `DeletePeer` needs the other one, so
the ordering violation is deterministic rather than a race the test
would only sometimes lose.

|                          | main | account-first | this PR |
| ------------------------ | ---- | ------------- | ------- |
| `ConcurrentAccountWrite` | FAIL | PASS          | PASS    |
| `ConcurrentPeerWrite`    | PASS | FAIL          | PASS    |

They run against Postgres — sqlite serializes on a single connection
and cannot exhibit the cycle.

One detail worth keeping in mind for anyone writing similar tests: the
competing transaction in `ConcurrentPeerWrite` holds the peer row under
a **shared** lock on purpose. `DeletePeer` resolves the account with a
shared read of that row *before* opening its transaction, so an
exclusive lock there simply parks it on that pre-transaction read — it
never holds the account row while waiting for the peer, no cycle forms,
and the test passes against every ordering.

## Verification

- `gofmt -s`, `go vet ./management/server/…`: clean
- both new tests, `-race -count=3`: pass
- `DeletePeer|UpdatePeer|AddPeer|Ephemeral|DeleteUser`, `-race`: pass
- full `management/server` package, `-race`: passes except
  `TestScheduler_Performance` / `TestScheduler_Cancel` /
  `TestScheduler_CancelAll`, which fail identically on a pristine `main`
  worktree (verified) and are unrelated — see #145

## Scope

This fixes `DeletePeer` only. The same shared-then-exclusive inversion
exists in the other write paths that call `IncrementNetworkSerial`
(`policy.go`, `route.go`, `dns.go`, `dns_zones.go`,
`posture_checks.go`, `nameserver.go`) — tracked in #143, one
reviewed change each rather than a sweep.

A bulk-delete endpoint would remove the parallel-request pattern
entirely and cut N round-trips to one, but it does not fix the
underlying deadlock class (two admins editing the same account still
collide), so it is a separate discussion.

## License

`management/` is AGPLv3 upstream. The diagnosis comes from this tree
plus observed Postgres locking behaviour, reproduced in
`peer_delete_concurrency_test.go`. No upstream patch was consulted, and
no upstream diff was translated or adapted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
