### PR TITLE
fix(management/updatechannel): send under the read lock so close cannot race

### DIFF
--- a/management/server/updatechannel.go
+++ b/management/server/updatechannel.go
@@ -131,9 +131,7 @@ func (p *PeersUpdateManager) SendUpdate(ctx context.Context, peerID string, upda
 	start := time.Now()
 	var found, dropped bool
 
-	p.channelsMux.RLock()
-	channel, isLocal := p.peerChannels[peerID]
-	p.channelsMux.RUnlock()
+	var queued int
 
 	defer func() {
 		if p.metrics != nil {
@@ -141,19 +139,44 @@ func (p *PeersUpdateManager) SendUpdate(ctx context.Context, peerID string, upda
 		}
 	}()
 
+	// The lookup and the send are one critical section on purpose. Every
+	// close of a peer channel — CloseChannel, CloseChannels, and
+	// CreateChannel replacing a channel on reconnect — happens under the
+	// write lock, so holding the read lock across the send is what makes
+	// send-on-closed-channel impossible here. Reading the channel out and
+	// releasing first, as this used to do, leaves a window a few
+	// instructions wide in which a close lands and the send panics,
+	// taking the process down: this runs on the broadcast fan-out
+	// goroutine (see UpdateAccountPeers) where nothing recovers.
+	//
+	// Safe to hold the lock only because the send is non-blocking — the
+	// default branch below is load-bearing, not a convenience. Anything
+	// that can block stays out: no logging, no metrics, no cluster I/O.
+	p.channelsMux.RLock()
+	channel, isLocal := p.peerChannels[peerID]
 	if isLocal {
 		found = true
 		select {
 		case channel <- update:
-			log.WithContext(ctx).Debugf("update was sent to channel for peer %s", peerID)
 		default:
+			dropped = true
+			// Captured under the lock: after releasing, the channel may
+			// be closed or replaced and the number would be misleading.
+			queued = len(channel)
+		}
+	}
+	p.channelsMux.RUnlock()
+
+	if isLocal {
+		if dropped {
 			// A drop here means the peer will miss this update entirely —
 			// the next snapshot will reconcile state, but until then the
 			// peer's view is stale. Log loudly so operators can see this
 			// and either investigate the slow consumer or raise
 			// OPENZRO_PEER_UPDATE_CHANNEL_BUFFER_SIZE.
-			dropped = true
-			log.WithContext(ctx).Errorf("dropped update for peer %s: channel full (%d/%d)", peerID, len(channel), channelBufferSize)
+			log.WithContext(ctx).Errorf("dropped update for peer %s: channel full (%d/%d)", peerID, queued, channelBufferSize)
+		} else {
+			log.WithContext(ctx).Debugf("update was sent to channel for peer %s", peerID)
 		}
 		return
 	}
@@ -241,19 +264,37 @@ func (p *PeersUpdateManager) forwardClusterEvents(peerID string, channel chan *U
 			log.Errorf("cluster forward for peer %s: bad proto: %v", peerID, err)
 			continue
 		}
-		// We re-check that the channel still exists and is the one we
-		// were spawned for. If a CloseChannel raced with a delivery, we
-		// drop instead of panicking on send-on-closed-channel.
+		// Re-check that the channel still exists and is the one we were
+		// spawned for, then send — both under the same read lock. The
+		// check used to release the lock before the send, which narrowed
+		// the window without closing it: a CloseChannel landing in
+		// between still closed the channel under us and the send panicked.
+		// Closers hold the write lock, so keeping it for the send is what
+		// actually makes that impossible.
+		//
+		// As in SendUpdate, this is only safe because the send is
+		// non-blocking; nothing that can block belongs in here.
+		var dropped bool
+		var queued int
+
 		p.channelsMux.RLock()
 		current, ok := p.peerChannels[peerID]
+		stale := !ok || current != channel
+		if !stale {
+			select {
+			case channel <- &UpdateMessage{Update: sync}:
+			default:
+				dropped = true
+				queued = len(channel)
+			}
+		}
 		p.channelsMux.RUnlock()
-		if !ok || current != channel {
+
+		if stale {
 			return
 		}
-		select {
-		case channel <- &UpdateMessage{Update: sync}:
-		default:
-			log.Errorf("dropped cluster-forwarded update for peer %s: channel full (%d/%d)", peerID, len(channel), channelBufferSize)
+		if dropped {
+			log.Errorf("dropped cluster-forwarded update for peer %s: channel full (%d/%d)", peerID, queued, channelBufferSize)
 		}
 	}
 }

--- a/management/server/updatechannel_race_test.go
+++ b/management/server/updatechannel_race_test.go
@@ -1,0 +1,238 @@
+package server
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	gproto "google.golang.org/protobuf/proto"
+
+	"github.com/openzro/openzro/cluster"
+	"github.com/openzro/openzro/management/proto"
+)
+
+// The manager hands a channel to the Sync stream and closes it to signal
+// teardown, while updates are sent into it from elsewhere — the account
+// broadcast, the token refresher, the cluster forwarder. Sending and
+// closing are therefore concurrent by design, and only the channels mutex
+// can order them.
+//
+// Both tests below drive the manager through its public surface only.
+// Reaching into peerChannels (as some existing tests do) would add
+// unsynchronized access of its own and make any race report ambiguous
+// about whose fault it is.
+//
+// The assertion vehicle is the race detector, not a panic. The window
+// between releasing the lock and touching the channel is a few
+// instructions wide, so waiting for an actual send-on-closed panic would
+// need far more iterations and still be luck; -race reports the
+// unsynchronized close/send pair on the first overlap.
+
+const raceTestPeerID = "peer-race"
+
+// drainUntilClosed consumes a channel the way the Sync stream does, so
+// senders keep finding room and the drop path stays off the hot loop.
+// It returns when the manager closes the channel.
+func drainUntilClosed(wg *sync.WaitGroup, ch chan *UpdateMessage) {
+	defer wg.Done()
+	for range ch { //nolint:revive // draining is the point
+	}
+}
+
+// TestPeersUpdateManager_SendUpdateRacesClose covers the local send path
+// against every way a channel gets closed.
+func TestPeersUpdateManager_SendUpdateRacesClose(t *testing.T) {
+	// cycle closes the peer's current channel and leaves a fresh one in
+	// place, so the next iteration has something to race against.
+	cases := []struct {
+		name  string
+		cycle func(p *PeersUpdateManager, ctx context.Context, reopen func())
+	}{
+		{
+			name: "CloseChannel",
+			cycle: func(p *PeersUpdateManager, ctx context.Context, reopen func()) {
+				p.CloseChannel(ctx, raceTestPeerID)
+				reopen()
+			},
+		},
+		{
+			name: "CloseChannels",
+			cycle: func(p *PeersUpdateManager, ctx context.Context, reopen func()) {
+				p.CloseChannels(ctx, []string{raceTestPeerID})
+				reopen()
+			},
+		},
+		{
+			// CreateChannel closes whatever channel the peer already had
+			// before installing the new one — the reconnect path, and the
+			// least obvious of the three closers.
+			name: "CreateChannel replacing an existing channel",
+			cycle: func(_ *PeersUpdateManager, _ context.Context, reopen func()) {
+				reopen()
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			const (
+				senders    = 8
+				iterations = 300
+			)
+
+			ctx := context.Background()
+			p := NewPeersUpdateManager(nil)
+
+			var drains sync.WaitGroup
+			reopen := func() {
+				ch := p.CreateChannel(ctx, raceTestPeerID)
+				drains.Add(1)
+				go drainUntilClosed(&drains, ch)
+			}
+			reopen()
+
+			stop := make(chan struct{})
+			var senderWG sync.WaitGroup
+			for i := 0; i < senders; i++ {
+				senderWG.Add(1)
+				go func() {
+					defer senderWG.Done()
+					for {
+						select {
+						case <-stop:
+							return
+						default:
+							p.SendUpdate(ctx, raceTestPeerID, &UpdateMessage{
+								Update: &proto.SyncResponse{},
+							})
+						}
+					}
+				}()
+			}
+
+			for i := 0; i < iterations; i++ {
+				tc.cycle(p, ctx, reopen)
+			}
+
+			close(stop)
+			senderWG.Wait()
+			p.CloseChannel(ctx, raceTestPeerID)
+			drains.Wait()
+		})
+	}
+}
+
+// fakeCoordinator is an in-process cluster.Coordinator good enough to
+// drive forwardClusterEvents. Publish hands the payload to every live
+// subscriber without blocking, matching the at-most-once contract the
+// real backends document.
+type fakeCoordinator struct {
+	mu   sync.Mutex
+	subs map[string][]chan cluster.Event
+}
+
+func newFakeCoordinator() *fakeCoordinator {
+	return &fakeCoordinator{subs: make(map[string][]chan cluster.Event)}
+}
+
+func (f *fakeCoordinator) Lock(_ context.Context, _ string) (func(), error) {
+	return func() {}, nil
+}
+
+func (f *fakeCoordinator) Publish(_ context.Context, topic string, payload []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, ch := range f.subs[topic] {
+		select {
+		case ch <- cluster.Event{Topic: topic, Payload: payload}:
+		default:
+		}
+	}
+	return nil
+}
+
+func (f *fakeCoordinator) Subscribe(ctx context.Context, topic string) (<-chan cluster.Event, error) {
+	ch := make(chan cluster.Event, 64)
+
+	f.mu.Lock()
+	f.subs[topic] = append(f.subs[topic], ch)
+	f.mu.Unlock()
+
+	go func() {
+		<-ctx.Done()
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		remaining := f.subs[topic][:0]
+		for _, existing := range f.subs[topic] {
+			if existing != ch {
+				remaining = append(remaining, existing)
+			}
+		}
+		f.subs[topic] = remaining
+		close(ch)
+	}()
+
+	return ch, nil
+}
+
+func (f *fakeCoordinator) Close() error { return nil }
+
+// TestPeersUpdateManager_ClusterForwardRacesClose covers the HA path.
+//
+// forwardClusterEvents is a second sender into the same channel, and it
+// already carries a guard that re-reads peerChannels before sending —
+// but it drops the read lock before touching the channel, so the guard
+// narrows the window instead of closing it. Publishing straight to the
+// peer's topic is what another management instance does, so this drives
+// that sender without touching manager internals.
+func TestPeersUpdateManager_ClusterForwardRacesClose(t *testing.T) {
+	const iterations = 300
+
+	ctx := context.Background()
+	coord := newFakeCoordinator()
+	p := NewPeersUpdateManagerWithCluster(nil, coord)
+	t.Cleanup(p.Stop)
+
+	payload, err := gproto.Marshal(&proto.SyncResponse{})
+	if err != nil {
+		t.Fatalf("marshal sync response: %v", err)
+	}
+	topic := peerUpdateTopicPrefix + raceTestPeerID
+
+	var drains sync.WaitGroup
+	reopen := func() {
+		ch := p.CreateChannel(ctx, raceTestPeerID)
+		drains.Add(1)
+		go drainUntilClosed(&drains, ch)
+	}
+	reopen()
+
+	stop := make(chan struct{})
+	var publishers sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		publishers.Add(1)
+		go func() {
+			defer publishers.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					if err := coord.Publish(ctx, topic, payload); err != nil {
+						return
+					}
+				}
+			}
+		}()
+	}
+
+	for i := 0; i < iterations; i++ {
+		p.CloseChannel(ctx, raceTestPeerID)
+		reopen()
+	}
+
+	close(stop)
+	publishers.Wait()
+	p.CloseChannel(ctx, raceTestPeerID)
+	drains.Wait()
+}


### PR DESCRIPTION
Closes #144.

## Problem

Both senders into a peer's update channel read the channel out of the
map, released the channels lock, and only then sent on it:

```go
p.channelsMux.RLock()
channel, isLocal := p.peerChannels[peerID]
p.channelsMux.RUnlock()        // lock released
...
case channel <- update:        // send happens unlocked
```

Every close of a peer channel takes the **write** lock — `CloseChannel`,
`CloseChannels`, and `CreateChannel` replacing a channel when a peer
reconnects. So between the release and the send a close can land, and
the send panics with `send on closed channel`.

That is not a dropped update. `SendUpdate` runs on the account broadcast
fan-out goroutine (`UpdateAccountPeers`, `peer.go:1449`) and nothing
recovers there: the gRPC interceptors only attach a request id, and a
panic in a bare goroutine is not reachable by an interceptor anyway.
**It takes the replica down.**

Reachability is ordinary operation, not an exotic interleaving: any
broadcast (policy, group, DNS, peer add/delete) overlapping any peer
disconnect or reconnect.

`forwardClusterEvents` already carried a guard for exactly this,
re-reading `peerChannels` before sending and dropping if the channel had
been replaced — but it released the read lock before the send, so the
guard narrowed the window instead of closing it.

## Fix

Keep the read lock across the send, in both senders. Closers need the
write lock, so send and close are now ordered by the same mutex and the
panic is impossible by construction rather than unlikely.

This works only because the send is non-blocking. The `select`'s
`default` branch is load-bearing, not a convenience, and the comments
say so — removing it later would turn this into a deadlock.

Everything that can block stays outside the critical section:

- the drop log (`Errorf`, and it runs precisely when channels are full —
  logging under the lock would stretch a nanosecond critical section
  into I/O exactly when the system is already struggling)
- the success debug log
- the cluster `Publish`, which is network I/O

The queue depth quoted in the drop message is captured inside the lock:
afterwards the channel may already be closed or replaced and the number
would mislead.

**This preserves existing best-effort/drop-on-full semantics; it only
orders send vs close under the same mutex.**

Two behaviours confirmed unchanged:

- Updates already buffered when a channel closes are still delivered —
  `handleUpdates` (`grpcserver.go:278`) only observes `open=false` after
  draining the buffer.
- Cluster fan-out stays best-effort, per the `Coordinator` contract.

## Tests

Both drive the manager through its public surface only. Existing tests
reach into `peerChannels` directly (`peer_test.go:978` swaps the whole
map without holding the lock); a race test doing that would add
unsynchronized access of its own and make the report ambiguous about
whose fault it is.

| test                                                               | on `cf74ae13` (test only)                                   | with the fix |
| ------------------------------------------------------------------ | ----------------------------------------------------------- | ------------ |
| `SendUpdateRacesClose/CloseChannel`                                | **panic: send on closed channel** at `updatechannel.go:147` | pass         |
| `SendUpdateRacesClose/CloseChannels`                               | race `close` vs `send`                                      | pass         |
| `SendUpdateRacesClose/CreateChannel replacing an existing channel` | race `close` vs `send`                                      | pass         |
| `ClusterForwardRacesClose`                                         | race at `updatechannel.go:254`, inside the old guard        | pass         |
| `TestGroupAccountPeersUpdate` (pre-existing reproducer)            | race                                                        | pass         |

The intended assertion vehicle was the race detector — the window is a
few instructions wide, so waiting for a panic should have been luck. It
was not: the local test panics on the first run at 300 iterations.

Verification:

- new tests, `-race -count=5`: pass
- `TestGroupAccountPeersUpdate`, `-race -count=5`: pass
- full `management/server`, `-race`: `ok 209s` — with
  `TestScheduler_Performance` / `_Cancel` / `_CancelAll` skipped, which
  fail identically on a pristine `main` and are tracked in #145
- `gofmt -s`, `go vet`: clean

## Scope

Nothing else changes: buffer sizes, drop semantics, the cluster
protocol, and `grpcserver` are untouched, and the lock stays global
rather than becoming per-peer.

One adjacent finding is deliberately **not** here: `CreateChannel` calls
`coordinator.Subscribe()` — broker network I/O — while holding the write
lock, so in HA every peer connect blocks every `SendUpdate` in the
process for a round-trip. It predates this PR and is orders of magnitude
larger than the read-side cost added here. Tracked in #147.

## Notes on cost

The read-side critical section gets slightly longer. Read locks do not
exclude each other, so the broadcast fan-out does not serialize; a
waiting closer is what pays. No number is claimed — `CountSendUpdateDuration`
already reports this and is where to look if a regression shows up.

## License

`management/` is AGPLv3 upstream. The diagnosis and fix come from this
tree plus the race detector, reproduced in `updatechannel_race_test.go`.
No upstream patch was consulted, and no upstream diff was translated or
adapted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- `main` <!-- branch-stack -->
  - \#149
    - \#148 :point\_left:
