### PR TITLE
test(client/server): stop TestServer_Up racing its own auto-connect

### DIFF
--- a/client/server/server_test.go
+++ b/client/server/server_test.go
@@ -151,8 +151,19 @@ func TestServer_Up(t *testing.T) {
 
 	profName := "default"
 
+	// Start() kicks off `go connectWithRetryRuns` unless auto-connect is
+	// disabled, and that goroutine moves the status off Idle. Up refuses
+	// to run when the status is not Idle, so leaving auto-connect on made
+	// this test a race between the goroutine and the Up call below, with
+	// no synchronization between them: whichever got there first decided
+	// the outcome. Disabling auto-connect removes the second connection
+	// attempt entirely, which is what this test wants anyway — it is
+	// asserting how Up behaves against an unreachable management URL, not
+	// how the daemon auto-connects.
+	disableAutoConnect := true
 	ic := profilemanager.ConfigInput{
-		ConfigPath: filepath.Join(tempDir, profName+".json"),
+		ConfigPath:         filepath.Join(tempDir, profName+".json"),
+		DisableAutoConnect: &disableAutoConnect,
 	}
 
 	_, err = profilemanager.UpdateOrCreateConfig(ic)


### PR DESCRIPTION
## Problem

`TestServer_Up` races its own daemon.

`Start()` ends in `go s.connectWithRetryRuns(...)` unless auto-connect is
disabled, and that goroutine moves the status off `Idle`. `Up` refuses to
run unless the status is `Idle` (`client/server/server.go:745`):

```go
if status != internal.StatusIdle {
    return nil, fmt.Errorf("up already in progress: current status %s", status)
}
```

The test calls `Start()` and then `Up()` with **nothing synchronizing
the two**. Between them sit a `url.Parse`, a struct assignment, a
`context.WithTimeout` and a request literal — microseconds. Whichever
side wins decides the result:

- goroutine has not flipped the status yet → `Up` reaches the dial and
  fails with the expected `context deadline exceeded` → **pass**
- goroutine got there first → `Up` returns the guard error → **fail**

Nothing makes one outcome more correct than the other. The test has
always been a coin toss that happened to land green.

## Why now

The bias is per-platform and it moves. On the current Windows runner the
goroutine wins consistently, so the test fails there while Linux and
Darwin pass — verified that the Linux job does run this package
(`ok github.com/openzro/openzro/client/server`) rather than skipping it.

It is sensitive enough that an unrelated change under `management/server`
flips it deterministically. #148 touches only `updatechannel.go`, which
this test binary links (via `server_test.go`'s imports) but never
executes on this path — the test points at an invalid URL, so management
is never contacted. Controlled comparison, same base commit
(`1e7551be`), same runner, same day:

|                 | Windows samples | result                    |
| --------------- | --------------- | ------------------------- |
| `main`, no diff | 3               | 3 pass                    |
| #148 branch     | 3               | 3 fail, identical message |

So #148 is the trigger, not the defect. This PR fixes the defect.

## Fix

Disable auto-connect in the test profile. That removes the second
connection attempt entirely, which is what the test wants anyway: it
asserts how `Up` behaves against an unreachable management URL, not how
the daemon auto-connects on start.

## Verification

Made the losing side deterministic rather than trusting CI round-trips.
With a 50ms sleep after `Start()` — handing the goroutine the win — the
test reproduces the Windows failure on Linux, byte for byte:

```
"up already in progress: current status Connecting" does not contain "context deadline exceeded"
```

With auto-connect disabled it passes with that sleep still in place. The
sleep is not part of the commit.

Afterwards `TestServer_Up` takes 1.00s on every one of 5 runs — it
reaches the dial and times out — where a failure returned in 0.00s and a
lucky pass in 1.01s.

- full `client/server` package: pass
- `gofmt -s`, `go vet`: clean

## Scope

`TestServer_SubcribeEvents` starts the daemon the same way, but asserts
only that `SubscribeEvents` returns no error, so it does not depend on
the status guard. Left alone.

Not addressed here: why the Windows scheduler biases this particular
race the way it does. Chasing that only matters while trying to live
with the race; once the test no longer has one, the answer stops
mattering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- `main` <!-- branch-stack -->
  - \#149 :point\_left:
    - \#148
