### PR TITLE
fix(client): present the client certificate on the PKCE token exchange

### DIFF
--- a/client/internal/auth/pkce_flow.go
+++ b/client/internal/auth/pkce_flow.go
@@ -31,6 +31,10 @@ const (
 	queryError                = "error"
 	queryErrorDesc            = "error_description"
 	defaultPKCETimeoutSeconds = 300
+
+	// tokenExchangeTimeout bounds the back-channel token request, matching the
+	// budget the device flow gives its own HTTP client.
+	tokenExchangeTimeout = 10 * time.Second
 )
 
 // PKCEAuthorizationFlow implements the OAuthFlow interface for
@@ -40,6 +44,10 @@ type PKCEAuthorizationFlow struct {
 	state          string
 	codeVerifier   string
 	oAuthConfig    *oauth2.Config
+	// tokenHTTPClient carries the client certificate on the back-channel token
+	// exchange. It is nil when the profile configures no certificate, which
+	// leaves the oauth2 default client in place.
+	tokenHTTPClient *http.Client
 }
 
 // NewPKCEAuthorizationFlow returns new PKCE authorization code flow.
@@ -70,9 +78,38 @@ func NewPKCEAuthorizationFlow(config internal.PKCEAuthProviderConfig) (*PKCEAuth
 	}
 
 	return &PKCEAuthorizationFlow{
-		providerConfig: config,
-		oAuthConfig:    cfg,
+		providerConfig:  config,
+		oAuthConfig:     cfg,
+		tokenHTTPClient: newTokenExchangeClient(config.ClientCertPair),
 	}, nil
+}
+
+// newTokenExchangeClient returns the HTTP client the token exchange has to use
+// when the profile carries a client certificate.
+//
+// PKCE has two legs against the IdP: the browser drives the authorize leg and
+// presents its own certificate, while the token leg is a back-channel POST made
+// by the client itself. A gate that requires a client certificate on every path
+// rejects that POST unless the certificate is attached here too.
+//
+// The transport is cloned from http.DefaultTransport so proxy settings, the
+// system root pool and the default dial timeouts survive; only the client
+// certificate is added. It returns nil when no certificate is configured.
+func newTokenExchangeClient(cert *tls.Certificate) *http.Client {
+	if cert == nil {
+		return nil
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{
+		MinVersion:   tls.VersionTLS12,
+		Certificates: []tls.Certificate{*cert},
+	}
+
+	return &http.Client{
+		Timeout:   tokenExchangeTimeout,
+		Transport: transport,
+	}
 }
 
 // GetClientID returns the provider client id
@@ -155,18 +192,6 @@ func (p *PKCEAuthorizationFlow) WaitToken(ctx context.Context, _ AuthFlowInfo) (
 func (p *PKCEAuthorizationFlow) startServer(server *http.Server, tokenChan chan<- *oauth2.Token, errChan chan<- error) {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
-		cert := p.providerConfig.ClientCertPair
-		if cert != nil {
-			tr := &http.Transport{
-				TLSClientConfig: &tls.Config{
-					Certificates: []tls.Certificate{*cert},
-				},
-			}
-			sslClient := &http.Client{Transport: tr}
-			ctx := context.WithValue(req.Context(), oauth2.HTTPClient, sslClient)
-			req = req.WithContext(ctx)
-		}
-
 		token, err := p.handleRequest(req)
 		if err != nil {
 			renderPKCEFlowTmpl(w, err)
@@ -202,8 +227,13 @@ func (p *PKCEAuthorizationFlow) handleRequest(req *http.Request) (*oauth2.Token,
 		return nil, fmt.Errorf("missing code")
 	}
 
+	ctx := req.Context()
+	if p.tokenHTTPClient != nil {
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, p.tokenHTTPClient)
+	}
+
 	return p.oAuthConfig.Exchange(
-		req.Context(),
+		ctx,
 		code,
 		oauth2.SetAuthURLParam("code_verifier", p.codeVerifier),
 	)

--- a/client/internal/auth/pkce_flow_test.go
+++ b/client/internal/auth/pkce_flow_test.go
@@ -2,7 +2,19 @@ package auth
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -68,4 +80,128 @@ func TestPromptLogin(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestTokenExchangeClientCert covers the back-channel leg of the PKCE flow.
+// The browser presents its own certificate on the authorize leg, so a gate that
+// requires a client certificate on every path only rejects the token POST the
+// client makes itself — the leg exercised here.
+func TestTokenExchangeClientCert(t *testing.T) {
+	t.Run("certificate configured", func(t *testing.T) {
+		clientCert := generateTestClientCert(t)
+
+		var (
+			mu   sync.Mutex
+			seen []*x509.Certificate
+		)
+		srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			seen = r.TLS.PeerCertificates
+			mu.Unlock()
+
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"test-access-token","token_type":"Bearer"}`))
+		}))
+		srv.TLS = &tls.Config{ClientAuth: tls.RequireAnyClientCert, MinVersion: tls.VersionTLS12}
+		srv.StartTLS()
+		defer srv.Close()
+
+		flow := newTestPKCEFlow(t, srv.URL, &clientCert)
+
+		transport, ok := flow.tokenHTTPClient.Transport.(*http.Transport)
+		require.True(t, ok, "token exchange transport should be an *http.Transport")
+		// the default transport's proxy resolution has to survive the clone,
+		// gated deployments commonly sit behind one
+		require.NotNil(t, transport.Proxy)
+		require.Equal(t, []tls.Certificate{clientCert}, transport.TLSClientConfig.Certificates)
+
+		// only the trust anchor is test-specific; the throwaway server is not in
+		// the system pool the production transport uses
+		pool := x509.NewCertPool()
+		pool.AddCert(srv.Certificate())
+		transport.TLSClientConfig.RootCAs = pool
+
+		token, err := flow.handleRequest(callbackRequest(t, flow))
+		require.NoError(t, err)
+		require.Equal(t, "test-access-token", token.AccessToken)
+
+		mu.Lock()
+		defer mu.Unlock()
+		require.Len(t, seen, 1, "the token exchange did not present a client certificate")
+		require.Equal(t, clientCert.Leaf.Raw, seen[0].Raw)
+	})
+
+	t.Run("no certificate configured", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"test-access-token","token_type":"Bearer"}`))
+		}))
+		defer srv.Close()
+
+		flow := newTestPKCEFlow(t, srv.URL, nil)
+		require.Nil(t, flow.tokenHTTPClient, "no certificate configured must leave the oauth2 default client in place")
+
+		token, err := flow.handleRequest(callbackRequest(t, flow))
+		require.NoError(t, err)
+		require.Equal(t, "test-access-token", token.AccessToken)
+	})
+}
+
+// newTestPKCEFlow returns a flow pointed at tokenEndpoint that has already
+// issued its state and code verifier.
+func newTestPKCEFlow(t *testing.T, tokenEndpoint string, cert *tls.Certificate) *PKCEAuthorizationFlow {
+	t.Helper()
+
+	flow, err := NewPKCEAuthorizationFlow(internal.PKCEAuthProviderConfig{
+		ClientID:              "test-client-id",
+		Audience:              "test-audience",
+		TokenEndpoint:         tokenEndpoint,
+		AuthorizationEndpoint: "https://test-auth-endpoint.com/authorize",
+		Scope:                 "openid email profile",
+		RedirectURLs:          []string{"http://127.0.0.1:33992/"},
+		ClientCertPair:        cert,
+	})
+	require.NoError(t, err)
+
+	_, err = flow.RequestAuthInfo(context.Background())
+	require.NoError(t, err)
+
+	return flow
+}
+
+// callbackRequest builds the redirect the IdP sends back to the local callback
+// server once the browser has completed the authorize leg.
+func callbackRequest(t *testing.T, flow *PKCEAuthorizationFlow) *http.Request {
+	t.Helper()
+
+	query := url.Values{}
+	query.Set(queryState, flow.state)
+	query.Set(queryCode, "test-authorization-code")
+
+	return httptest.NewRequest(http.MethodGet, "/?"+query.Encode(), nil)
+}
+
+// generateTestClientCert returns a throwaway self-signed client certificate.
+func generateTestClientCert(t *testing.T) tls.Certificate {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "openzro-test-client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	leaf, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	return tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key, Leaf: leaf}
 }

--- a/client/internal/profilemanager/config.go
+++ b/client/internal/profilemanager/config.go
@@ -485,15 +485,7 @@ func (config *Config) apply(input ConfigInput) (updated bool, err error) {
 		updated = true
 	}
 
-	if config.ClientCertPath != "" && config.ClientCertKeyPath != "" {
-		cert, err := tls.LoadX509KeyPair(config.ClientCertPath, config.ClientCertKeyPath)
-		if err != nil {
-			log.Error("Failed to load mTLS cert/key pair: ", err)
-		} else {
-			config.ClientCertKeyPair = &cert
-			log.Info("Loaded client mTLS cert/key pair")
-		}
-	}
+	config.loadClientCertPair()
 
 	if input.DNSLabels != nil && !slices.Equal(config.DNSLabels, input.DNSLabels) {
 		log.Infof("updating DNS labels [ %s ] (old value: [ %s ])",
@@ -510,6 +502,28 @@ func (config *Config) apply(input ConfigInput) (updated bool, err error) {
 	}
 
 	return updated, nil
+}
+
+// loadClientCertPair loads the configured client mTLS certificate/key pair into
+// ClientCertKeyPair. The pair is not serialized with the profile, so every
+// loader has to call this — the PKCE flow reads the certificate it presents on
+// the token exchange from here.
+//
+// It is a no-op when either path is unset, and a load failure is logged and
+// leaves the pair nil, so deployments without an mTLS gate are unaffected.
+func (config *Config) loadClientCertPair() {
+	if config.ClientCertPath == "" || config.ClientCertKeyPath == "" {
+		return
+	}
+
+	cert, err := tls.LoadX509KeyPair(config.ClientCertPath, config.ClientCertKeyPath)
+	if err != nil {
+		log.Errorf("failed to load client mTLS cert/key pair: %v", err)
+		return
+	}
+
+	config.ClientCertKeyPair = &cert
+	log.Info("Loaded client mTLS cert/key pair")
 }
 
 // parseURL parses and validates a service URL
@@ -618,6 +632,7 @@ func GetConfig(configPath string) (*Config, error) {
 	if _, err := util.ReadJson(configPath, config); err != nil {
 		return nil, fmt.Errorf("failed to read config file %s: %w", configPath, err)
 	}
+	config.loadClientCertPair()
 
 	return config, nil
 }

--- a/client/internal/profilemanager/config_test.go
+++ b/client/internal/profilemanager/config_test.go
@@ -2,10 +2,18 @@ package profilemanager
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
 	"errors"
+	"math/big"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -228,4 +236,99 @@ func TestUpdateOldManagementURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGetConfigLoadsClientCertKeyPair guards the daemon's profile load path.
+// ClientCertKeyPair is a `json:"-"` field, so every path that hands a Config to
+// the PKCE flow has to load the pair from disk — otherwise the back-channel
+// token exchange goes out without a client certificate and an mTLS gate rejects
+// it.
+func TestGetConfigLoadsClientCertKeyPair(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := writeTestCertPair(t, dir)
+
+	tt := []struct {
+		name       string
+		certPath   string
+		keyPath    string
+		expectPair bool
+	}{
+		{
+			name:       "cert and key configured",
+			certPath:   certPath,
+			keyPath:    keyPath,
+			expectPair: true,
+		},
+		{
+			name: "no mTLS configured",
+		},
+		{
+			name:     "cert without key",
+			certPath: certPath,
+		},
+		{
+			name:    "key without cert",
+			keyPath: keyPath,
+		},
+		{
+			name:     "pair missing on disk",
+			certPath: filepath.Join(dir, "absent.crt"),
+			keyPath:  filepath.Join(dir, "absent.key"),
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			configPath := filepath.Join(t.TempDir(), "config.json")
+			require.NoError(t, WriteOutConfig(configPath, &Config{
+				ClientCertPath:    tc.certPath,
+				ClientCertKeyPath: tc.keyPath,
+			}))
+
+			config, err := GetConfig(configPath)
+			require.NoError(t, err)
+
+			if !tc.expectPair {
+				assert.Nil(t, config.ClientCertKeyPair)
+				return
+			}
+
+			require.NotNil(t, config.ClientCertKeyPair)
+			assert.NotEmpty(t, config.ClientCertKeyPair.Certificate)
+		})
+	}
+}
+
+// writeTestCertPair writes a throwaway self-signed client certificate and its
+// private key into dir and returns the two paths.
+func writeTestCertPair(t *testing.T, dir string) (certPath, keyPath string) {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "openzro-test-client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	require.NoError(t, err)
+
+	certPath = filepath.Join(dir, "client.crt")
+	keyPath = filepath.Join(dir, "client.key")
+
+	require.NoError(t, os.WriteFile(certPath,
+		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600))
+	require.NoError(t, os.WriteFile(keyPath,
+		pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0o600))
+
+	return certPath, keyPath
 }


### PR DESCRIPTION
## Describe your changes

`openzro up` on a certificate-holding desktop fails to log in through an mTLS
gate that requires a client certificate on every path:

```
waiting for browser login failed: PKCE authorization flow failed:
oauth2: cannot fetch token: 403 Forbidden
```

PKCE has two legs against the IdP. The **authorize** leg is driven by the user's
browser, which presents its own imported certificate — so a sign-in form loads
and an authorization code comes back. The **token** leg is a back-channel POST
the client makes itself, and that one went out with no client certificate, so
the gate rejected it.

**Root cause.** The certificate the PKCE flow presents comes from
`profilemanager.Config.ClientCertKeyPair`, a `json:"-"` field that only exists
in memory once something loads it from `ClientCertPath`/`ClientCertKeyPath`.
That load lived inside `(*Config).apply`, which the foreground paths (`login`
without a daemon, `up`) go through — hence the `Loaded client mTLS cert/key
pair` line in the log. Every *daemon* path (startup, `Login`, `SwitchProfile`,
the `GetConfig` IPC) instead loads the profile with `profilemanager.GetConfig`,
which read the JSON straight into a `Config` and returned. `ClientCertKeyPair`
stayed nil there, `PKCEAuthProviderConfig.ClientCertPair` stayed nil with it,
and `pkce_flow.go` skipped the certificate-bearing HTTP client entirely.

Three commits:

1. **`test(client/profilemanager)`** — a regression test that fails on `main`:
   `GetConfig` on a profile carrying both certificate paths must return a loaded
   pair, and must leave it nil for every configuration that is not a complete,
   readable pair.
2. **`fix(client/profilemanager)`** — pull the load out of `apply` into
   `loadClientCertPair()` and call it from `GetConfig` too, so there is one load
   path rather than two that can drift.
3. **`fix(client/auth)`** — the certificate was attached to the token exchange
   inside the callback mux handler, on a bare `&http.Transport{}`. That drops
   everything `http.DefaultTransport` carries — proxy resolution above all,
   which the gated deployments needing this certificate are the most likely to
   want — and left the exchange without a request timeout. Build the client once
   in the constructor from a clone of the default transport, adding only the
   certificate, and attach it in `handleRequest` next to the `Exchange` it
   belongs to.

### Verification

Against a FortiGate access proxy with `client-cert enable` /
`empty-cert-action block`, POSTing a dummy code at the Keycloak token endpoint:

| Request | Result |
|---|---|
| no client certificate | **403** `ZTNA certificate is empty` — the daemon's exact failure |
| with the client certificate | **400** `invalid_grant: Code not valid` |

The 400 is the decisive one: the request reached Keycloak, so the gate accepted
the certificate. The gate and the certificate were both correct; only the
daemon's token client omitted it.

The unit tests reproduce that matrix in-process: the new
`TestTokenExchangeClientCert` runs the exchange against a test token endpoint
configured with `tls.RequireAnyClientCert` and asserts the certificate the
server saw. Reverting the `handleRequest` change turns it into
`tls: bad certificate` at the handshake.

End-to-end confirmation needs a fresh SSO round trip — peer login expiry is 24h
and `openzro up` on a still-valid session never re-exercises the token leg, so
the peer has to be re-enrolled (or the session left to expire) first.

### Scope / non-goals

- **Device flow is untouched.** It cannot present a client certificate, and this
  change is scoped to PKCE.
- **No new CLI flag.** Certificate configuration stays profile-driven
  (`ClientCertPath` / `ClientCertKeyPath`).
- **No behavior change when the paths are unset** — a nil pair still yields a
  nil client and the oauth2 default is used, as before.
- **No discovery fetch to fix.** The PKCE endpoints come from management over
  gRPC (`GetPKCEAuthorizationFlow`); the client never fetches
  `.well-known/openid-configuration` from the gated host.

## Issue ticket number and link

n/a

## Stack

<!-- branch-stack -->

### Checklist
- [x] Is it a bug fix
- [ ] Is a typo/documentation fix
- [ ] Is a feature enhancement
- [ ] It is a refactor
- [x] Created tests that fail without the change (if possible)
- [ ] Extended the README / documentation, if necessary
- [x] All commits in this PR are signed off with `git commit -s` (DCO)
