### PR TITLE
test(management/scheduler): stop the scheduler tests racing themselves

### DIFF
--- a/management/server/scheduler_test.go
+++ b/management/server/scheduler_test.go
@@ -12,6 +12,21 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// schedulerJobIDs returns the scheduled job IDs under the scheduler's own
+// mutex. The assertions below used to read DefaultScheduler.jobs directly,
+// which races the scheduler goroutine deleting from that same map as jobs
+// finish or are cancelled.
+func schedulerJobIDs(s *DefaultScheduler) []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ids := make([]string, 0, len(s.jobs))
+	for id := range s.jobs {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
 func TestScheduler_Performance(t *testing.T) {
 	scheduler := NewDefaultScheduler()
 	n := 500
@@ -38,7 +53,7 @@ func TestScheduler_Performance(t *testing.T) {
 		t.Fatal("timed out while waiting for test to finish")
 		return
 	}
-	assert.Len(t, scheduler.jobs, 0)
+	assert.Len(t, schedulerJobIDs(scheduler), 0)
 }
 
 func TestScheduler_Cancel(t *testing.T) {
@@ -46,7 +61,6 @@ func TestScheduler_Cancel(t *testing.T) {
 	jobID2 := "test-scheduler-job-2"
 	scheduler := NewDefaultScheduler()
 	tChan := make(chan struct{})
-	p := []string{jobID1, jobID2}
 	scheduletime := 2 * time.Millisecond
 	sleepTime := 4 * time.Millisecond
 	if runtime.GOOS == "windows" {
@@ -55,9 +69,7 @@ func TestScheduler_Cancel(t *testing.T) {
 	}
 
 	scheduler.Schedule(context.Background(), scheduletime, jobID1, func() (nextRunIn time.Duration, reschedule bool) {
-		tt := p[0]
 		<-tChan
-		t.Logf("job %s", tt)
 		return scheduletime, true
 	})
 	scheduler.Schedule(context.Background(), scheduletime, jobID2, func() (nextRunIn time.Duration, reschedule bool) {
@@ -66,13 +78,12 @@ func TestScheduler_Cancel(t *testing.T) {
 	defer scheduler.Cancel(context.Background(), []string{jobID2})
 
 	time.Sleep(sleepTime)
-	assert.Len(t, scheduler.jobs, 2)
+	assert.Len(t, schedulerJobIDs(scheduler), 2)
 	scheduler.Cancel(context.Background(), []string{jobID1})
 	close(tChan)
-	p = []string{}
 	time.Sleep(sleepTime)
-	assert.Len(t, scheduler.jobs, 1)
-	assert.NotNil(t, scheduler.jobs[jobID2])
+	assert.Len(t, schedulerJobIDs(scheduler), 1)
+	assert.Contains(t, schedulerJobIDs(scheduler), jobID2)
 }
 
 func TestScheduler_CancelAll(t *testing.T) {
@@ -80,7 +91,6 @@ func TestScheduler_CancelAll(t *testing.T) {
 	jobID2 := "test-scheduler-job-2"
 	scheduler := NewDefaultScheduler()
 	tChan := make(chan struct{})
-	p := []string{jobID1, jobID2}
 	scheduletime := 2 * time.Millisecond
 	sleepTime := 4 * time.Millisecond
 	if runtime.GOOS == "windows" {
@@ -89,9 +99,7 @@ func TestScheduler_CancelAll(t *testing.T) {
 	}
 
 	scheduler.Schedule(context.Background(), scheduletime, jobID1, func() (nextRunIn time.Duration, reschedule bool) {
-		tt := p[0]
 		<-tChan
-		t.Logf("job %s", tt)
 		return scheduletime, true
 	})
 	scheduler.Schedule(context.Background(), scheduletime, jobID2, func() (nextRunIn time.Duration, reschedule bool) {
@@ -99,12 +107,11 @@ func TestScheduler_CancelAll(t *testing.T) {
 	})
 
 	time.Sleep(sleepTime)
-	assert.Len(t, scheduler.jobs, 2)
+	assert.Len(t, schedulerJobIDs(scheduler), 2)
 	scheduler.CancelAll(context.Background())
 	close(tChan)
-	p = []string{}
 	time.Sleep(sleepTime)
-	assert.Len(t, scheduler.jobs, 0)
+	assert.Len(t, schedulerJobIDs(scheduler), 0)
 }
 
 func TestScheduler_Schedule(t *testing.T) {

--- a/management/server/scheduler_test.go
+++ b/management/server/scheduler_test.go
@@ -15,7 +15,7 @@ import (
 // schedulerJobIDs returns the scheduled job IDs under the scheduler's own
 // mutex. The assertions below used to read DefaultScheduler.jobs directly,
 // which races the scheduler goroutine deleting from that same map as jobs
-// finish or are cancelled.
+// finish or are canceled.
 func schedulerJobIDs(s *DefaultScheduler) []string {
 	s.mu.Lock()
 	defer s.mu.Unlock()


### PR DESCRIPTION
Closes #145.

## Problem

`TestScheduler_Performance`, `_Cancel` and `_CancelAll` fail the race
detector on a clean checkout, so `make test` — which runs with `-race` — has
been red for everyone regardless of what they changed.

Both races are in the test code. `scheduler.go` is not implicated: the reports
name `scheduler_test.go` on both sides of every pair.

**Reading the job map without its mutex.** The assertions read
`DefaultScheduler.jobs` directly while the scheduler goroutine deletes from
that same map as jobs finish or are cancelled (`scheduler.go:139`). The map
already has a mutex; the tests just were not taking it.

**Mutating a slice under the running job.** `p` existed only to be read inside
the closure and logged:

```go
p := []string{jobID1, jobID2}
...
    tt := p[0]
    <-tChan
    t.Logf("job %s", tt)
...
close(tChan)
p = []string{}          // races the read above
```

Nothing asserts anything about it.

## Fix

Read the job IDs through a helper that takes the scheduler's own lock, and
delete `p` along with the read and the log it fed.

Dropping the log removes a second hazard on the way out: `t.Logf` from a
background goroutine panics if the test has already finished, which this only
survives today because the test sleeps afterwards.

Net: 21 lines added, 14 removed — the tests end up smaller than they were.

## Verification

```
go test ./management/server/ -race            ok 202s, no skips
go test -run TestScheduler -race -count=5     pass
go vet, gofmt -s                              clean
```

The first line is the one that matters: the full package now passes with
`-race` and **no `-skip`**, which it has not done for as long as this issue
has been open.

## Deliberately out of scope

The `time.Sleep(sleepTime)` synchronization stays. Replacing it with real
signalling would be an improvement, but it is not what was broken and the
suite is green without touching it.

`scheduler.go` is untouched. If fixing the tests had surfaced a genuine race
in the scheduler it would have earned its own issue; it did not.

## Why this one first

A permanently red `-race` suite trains everyone to ignore race output — which
is how #144, a real send-on-closed-channel panic that took down a management
replica, survived in the tree. With this green, red means something again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
