### PR TITLE
ci(codespell): pin the action to a commit instead of the v2 tag

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,7 +17,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: codespell
-        uses: codespell-project/actions-codespell@v2
+        # Pinned to a commit rather than the floating v2 tag. At v2.2 — where
+        # v2 currently points — requirements.txt asks for
+        # codespell[toml]>=2.2.4 and the Dockerfile installs it unpinned, so
+        # every run resolves to whatever is newest on PyPI. That is how this
+        # job went red with no commit behind it: 2.4.1 in August, 2.4.3 later,
+        # and the newer dictionary folds pre-selected into preselected.
+        # This commit pins codespell==2.4.2 under --require-hashes and the
+        # python base image by digest, so a dictionary release can no longer
+        # arrive unannounced. Bumping it is a deliberate, reviewable act.
+        uses: codespell-project/actions-codespell@3c04c03694eb927ff908b8b5abfe9c58b239b0ae # codespell 2.4.2
         with:
           # ignore_words_list collects:
           #   - upstream NetBird false positives carried over (erro, clienta,

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v4
       - name: codespell
         # Pinned to a commit rather than the floating v2 tag. At v2.2 — where
-        # v2 currently points — requirements.txt asks for
+        # v2 pointed when this was investigated — requirements.txt asks for
         # codespell[toml]>=2.2.4 and the Dockerfile installs it unpinned, so
         # every run resolves to whatever is newest on PyPI. That is how this
         # job went red with no commit behind it: 2.4.1 in August, 2.4.3 later,


### PR DESCRIPTION
Follow-up to #151, which cleared the symptom. This removes the mechanism.

## What actually happened

`codespell-project/actions-codespell@v2` resolves to `v2.2`, whose
`requirements.txt` asks for `codespell[toml]>=2.2.4` and whose `Dockerfile`
runs a plain `pip install`. The image is rebuilt on every run, so pip resolves
that range to whatever is newest on PyPI at that moment:

| run | date | codespell | result |
| --- | --- | --- | --- |
| [31412191396](https://github.com/openzro/openzro/actions/runs/31412191396) | 2026-08-10 | 2.4.1 | green |
| [33277967565](https://github.com/openzro/openzro/actions/runs/33277967565) | 2026-08-30 | 2.4.3 | red |

Same tree, same tag, different dictionary. It cost an external contributor's
PR (#150) a red check it had nothing to do with, and a few hours to prove that.

The important detail: **the version range lives inside the action**, so pinning
the tag to a release would not have helped. The version has to be pinned where
it is chosen.

## Fix

Pin to `3c04c03`, where `requirements.txt` carries `codespell[toml]==2.4.2`
installed under `--require-hashes`, and the python base image is pinned by
digest.

That also SHA-pins a third-party action, which is the usual supply-chain
guidance for actions we do not control — a floating tag can be re-pointed at
any time, and by anyone who gains write access upstream.

## This does not make #151 redundant

2.4.2 flags `pre-selected` too — the entry landed between 2.4.1 and 2.4.2, not
in 2.4.3 as #151's description said. So the ignore entries are needed at the
pinned version as well; the two changes are complementary, not alternatives.

## Verification

codespell 2.4.2 locally, with the workflow's own ignore list, over the tracked
files the action actually scans: clean.

Worth recording, since it tripped me up while diagnosing this: the action
leaves hidden paths alone (`check_hidden` defaults to off), so `.github/**` is
never scanned. Running codespell locally over the whole tree reports hits the
job will never produce.

## The trade

Dictionary improvements now arrive only when someone bumps the pin. That is
deliberate: a surprise red on an unrelated pull request costs more than a late
dictionary entry, and bumping becomes a reviewable act instead of an ambush.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
