### PR TITLE
ci(release): let an AUR outage degrade the release instead of failing it

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1144,6 +1144,18 @@ jobs:
     # sha256sums for the PKGBUILD).
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs: [release]
+    # AUR is a third-party service we do not control, and it is the only
+    # publication target in this pipeline that is not ours. When it is down —
+    # as it was for v0.53.1-alpha.87, mid-maintenance — this job fails and
+    # takes the whole release run red with it, even though the GitHub Release,
+    # ghcr.io, pkg.openzro.io, the macOS PKG and the Windows MSI all published
+    # correctly from earlier jobs.
+    #
+    # A red release that actually shipped everything teaches people to skim
+    # past red. Degrade instead: the job still runs and its failure is still
+    # visible on the job itself, it just no longer fails the run. Arch users
+    # get the package on the next release, or on a rerun once AUR is back.
+    continue-on-error: true
     environment: production
 
     steps:
@@ -1257,6 +1269,18 @@ jobs:
     runs-on: ubuntu-22.04
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     needs: [release_ui]
+    # AUR is a third-party service we do not control, and it is the only
+    # publication target in this pipeline that is not ours. When it is down —
+    # as it was for v0.53.1-alpha.87, mid-maintenance — this job fails and
+    # takes the whole release run red with it, even though the GitHub Release,
+    # ghcr.io, pkg.openzro.io, the macOS PKG and the Windows MSI all published
+    # correctly from earlier jobs.
+    #
+    # A red release that actually shipped everything teaches people to skim
+    # past red. Degrade instead: the job still runs and its failure is still
+    # visible on the job itself, it just no longer fails the run. Arch users
+    # get the package on the next release, or on a rerun once AUR is back.
+    continue-on-error: true
     environment: production
 
     steps:


### PR DESCRIPTION
## Problem

AUR is the only publication target in this pipeline we do not own, and when it
goes down it fails the whole release run.

Not hypothetical — `v0.53.1-alpha.87` finished **9 green, 2 red**:

```
Cloning into '.aur-clone'...
The AUR is down due to maintenance. We will be back soon.
fatal: Could not read from remote repository.
```

Meanwhile the GitHub Release (67 assets), ghcr.io (6 images), pkg.openzro.io,
the signed and notarized macOS PKG and the Windows MSI had all published
correctly, from jobs that run *before* this one. The release was complete for
every channel except Arch, and the run reported failure.

Same shape as the cascade #136 fixed for `release_pkg`, and the same cost: a
red run that actually shipped everything teaches people to skim past red,
which is how a genuine failure gets missed. We spent a chunk of this week
proving three separate reds were not what they looked like.

Worth being precise about the AUR's state, since it frames how likely this is
to recur. It was not a random maintenance window: adoptions were disabled on
[2026-07-30](https://lists.archlinux.org/archives/list/aur-general@lists.archlinux.org/message/DRDEU3JUSC72CB265XHXPFA3DFSLXPBP/)
and SSH/git push on
[2026-08-01](https://lists.archlinux.org/archives/list/aur-general@lists.archlinux.org/message/YPJ3FQYJTJXXY3RUXCYLMHUKHLIUNVFF/),
in response to the "Atomic Arch" malicious-takeover campaign — the third wave
since June. `aurweb` 6.5.0 restored both on
[2026-08-11](https://lists.archlinux.org/archives/list/aur-general@lists.archlinux.org/thread/P5C7GZ4C3OJIH4EXJ62JAF6X6PY2BCQ4/),
with adoption now going through review.

alpha.87 was tagged on 2026-08-10 — inside that push freeze. So the failure was
not bad luck with a maintenance window, it was a ten-day incident response we
had no visibility into, and alpha.88 succeeded because the freeze had lifted.

That cuts both ways and is worth saying plainly: **the specific outage is
over**, so this is not urgent. The case for the change is the pattern, not the
incident — three security responses in three months on a service we do not
control and cannot page, publishing last in a pipeline where everything ahead
of it is ours.

## Change

Mark both AUR jobs `continue-on-error`. They still run, and a failure is still
visible on the job itself with its log — it just no longer decides the outcome
of a release that succeeded everywhere we control.

Arch picks the package up on the next release, or on a rerun once AUR is
reachable. That is exactly what happened here: alpha.87 never got its AUR
push, and alpha.88 carried it (`openzro-bin 0.53.1.alpha.88-1`).

## The cost, stated plainly

A real breakage of *our* AUR publishing — a bad PKGBUILD, an expired SSH key —
now goes quiet in the run summary instead of shouting. That is a genuine
downside, not a free win.

The cleaner shape is a separate workflow triggered by `release: published`,
where an AUR failure is red in its own right without touching the release run.
That is a larger change; tracked separately rather than smuggled in here.

## Verification

The workflow still parses and the job graph is unchanged: 11 jobs,
`publish_aur` needs `[release]`, `publish_aur_ui` needs `[release_ui]`, both
now carrying `continue-on-error: true`. Nothing else in the file moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
