### PR TITLE
fix(management/dns_zones): order the account lock against the shared read on save

### DIFF
--- a/management/server/dns_zones.go
+++ b/management/server/dns_zones.go
@@ -95,7 +95,15 @@ func (am *DefaultAccountManager) CreateDNSZone(ctx context.Context, accountID, u
 		if err != nil {
 			return err
 		}
-		if err := validateDNSZone(ctx, tx, accountID, zone, dnsDomain, true); err != nil {
+		// Unchanged ordering on purpose: this path still reads the account
+		// row before it writes it, so it still carries the deadlock #143
+		// describes. Fixing it needs a serialization point that survives the
+		// isolation-level difference between Postgres and MySQL, which is
+		// tracked separately — see the note on the pull request.
+		if err := validateDNSZone(ctx, tx, accountID, zone, true); err != nil {
+			return err
+		}
+		if err := validateDNSZonePeerOverlap(zone, dnsDomain); err != nil {
 			return err
 		}
 		// A new zone has no records yet (records arrive via
@@ -141,10 +149,23 @@ func (am *DefaultAccountManager) SaveDNSZone(ctx context.Context, accountID, use
 	var saved *types.DNSZone
 	var updateAccountPeers bool
 	err := am.Store.ExecuteInTransaction(ctx, func(tx store.Store) error {
-		dnsDomain, err := am.resolvePeerDNSDomainTx(ctx, tx, accountID)
-		if err != nil {
-			return err
-		}
+		// Zone and group reads come before the exclusive account lock, and the
+		// account read comes after it. Two constraints meet here:
+		//
+		//   - The record mutations in this file take the zone row first and
+		//     the account row second (DeleteDNSRecord: GetDNSZoneByID at
+		//     LockingStrengthUpdate, then IncrementNetworkSerial). Locking the
+		//     account up front would invert that and trade one deadlock for
+		//     another — the mistake #148 caught on DeletePeer.
+		//   - resolvePeerDNSDomainTx reads the account row under a SHARED
+		//     lock. Doing that before IncrementNetworkSerial makes this
+		//     transaction upgrade shared to exclusive on the same row, which
+		//     deadlocks against any other account-scoped write doing the same.
+		//
+		// So: zone and group reads, then the exclusive account lock, then the
+		// shared read it now safely covers. Nothing here depends on seeing a
+		// concurrent writer's rows — the domain is immutable on save, so no
+		// overlap can be introduced by this path.
 		existing, err := tx.GetDNSZoneByID(ctx, store.LockingStrengthUpdate, accountID, zoneToSave.ID)
 		if err != nil {
 			if errors.Is(err, store.ErrDNSZoneNotFound) {
@@ -166,14 +187,21 @@ func (am *DefaultAccountManager) SaveDNSZone(ctx context.Context, accountID, use
 		// is on disk regardless of what the caller passed.
 		zoneToSave.Records = existing.Records
 
-		if err := validateDNSZone(ctx, tx, accountID, zoneToSave, dnsDomain, false); err != nil {
+		if err := validateDNSZone(ctx, tx, accountID, zoneToSave, false); err != nil {
 			return err
 		}
 		updateAccountPeers, err = areDNSZoneChangesAffectPeers(ctx, tx, accountID, zoneToSave, existing)
 		if err != nil {
 			return err
 		}
-		if err := tx.IncrementNetworkSerial(ctx, store.LockingStrengthUpdate, accountID); err != nil {
+		if err = tx.IncrementNetworkSerial(ctx, store.LockingStrengthUpdate, accountID); err != nil {
+			return err
+		}
+		dnsDomain, err := am.resolvePeerDNSDomainTx(ctx, tx, accountID)
+		if err != nil {
+			return err
+		}
+		if err := validateDNSZonePeerOverlap(zoneToSave, dnsDomain); err != nil {
 			return err
 		}
 		if err := tx.SaveDNSZone(ctx, store.LockingStrengthUpdate, zoneToSave); err != nil {
@@ -490,13 +518,31 @@ func (am *DefaultAccountManager) resolvePeerDNSDomainTx(ctx context.Context, tx 
 	return am.GetDNSDomain(settings), nil
 }
 
-// validateDNSZone enforces ADR-0022 D5 invariants: FQDN syntax,
-// bidirectional peer-DNS overlap rejection, ≥1 distribution group
+// validateDNSZonePeerOverlap rejects a zone whose domain collides with the
+// peer DNS namespace. The peer zone is rooted at peerDNSDomain and its apex
+// carries one A record per peer, so a label-aligned suffix in either direction
+// is a collision.
+//
+// Split out of validateDNSZone because resolving peerDNSDomain reads the
+// account row under a shared lock, and SaveDNSZone has to defer that read
+// until after it holds the row exclusively. Call it with a normalized domain:
+// validateDNSZone lowercases and strips the trailing dot, and must run first.
+func validateDNSZonePeerOverlap(zone *types.DNSZone, peerDNSDomain string) error {
+	if peerDNSDomain != "" && dnsZoneOverlap(zone.Domain, peerDNSDomain) {
+		return status.Errorf(status.InvalidArgument,
+			"dns zone domain %q overlaps with the peer DNS domain %q; pick a non-overlapping namespace",
+			zone.Domain, peerDNSDomain)
+	}
+	return nil
+}
+
+// validateDNSZone enforces the ADR-0022 D5 invariants that need no account
+// read: FQDN syntax, >=1 distribution group
 // (deduplicated), group existence in the account, cross-zone overlap
 // rejection against OTHER user-managed zones in the same account
 // (excluding the zone being saved). Called inside the same
 // transaction as the upsert so reads are consistent with the write.
-func validateDNSZone(ctx context.Context, tx store.Store, accountID string, zone *types.DNSZone, peerDNSDomain string, isCreate bool) error {
+func validateDNSZone(ctx context.Context, tx store.Store, accountID string, zone *types.DNSZone, isCreate bool) error {
 	zone.Domain = strings.TrimSuffix(strings.ToLower(zone.Domain), ".")
 	if zone.Domain == "" {
 		return status.Errorf(status.InvalidArgument, "dns zone domain is required")
@@ -506,15 +552,6 @@ func validateDNSZone(ctx context.Context, tx store.Store, accountID string, zone
 	}
 	if l := len(zone.Name); l < 1 || l > 255 {
 		return status.Errorf(status.InvalidArgument, "dns zone name length must be in [1, 255]")
-	}
-
-	// Bidirectional peer-DNS overlap. The peer zone is rooted at
-	// `peerDNSDomain` and the apex carries one A record per peer.
-	// Reject if either domain is a label-aligned suffix of the other.
-	if peerDNSDomain != "" && dnsZoneOverlap(zone.Domain, peerDNSDomain) {
-		return status.Errorf(status.InvalidArgument,
-			"dns zone domain %q overlaps with the peer DNS domain %q; pick a non-overlapping namespace",
-			zone.Domain, peerDNSDomain)
 	}
 
 	// Cross-zone overlap rejection against OTHER user-managed zones

--- a/management/server/dns_zones_concurrency_test.go
+++ b/management/server/dns_zones_concurrency_test.go
@@ -1,0 +1,72 @@
+package server
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openzro/openzro/management/server/store"
+	"github.com/openzro/openzro/management/server/types"
+)
+
+// SaveDNSZone writes the account row (IncrementNetworkSerial) and also reads it
+// under a shared lock, to resolve the peer DNS domain the overlap check needs.
+// Taking the shared lock first and upgrading later deadlocks as soon as a
+// second account-scoped write overlaps: both transactions hold the shared lock,
+// both then ask for the exclusive one, and the database kills one of them
+// (Postgres SQLSTATE 40P01), which reaches the API caller as a 500.
+//
+// Same defect and same shape as the one fixed for DeletePeer in #146; see
+// peer_delete_concurrency_test.go. The competing goroutine stands in for any
+// other account-scoped write reaching the database at the same time, and holds
+// its shared lock across the window in which the mutation needs the exclusive
+// one, so the ordering violation is deterministic rather than a race the test
+// would only sometimes lose.
+//
+// CreateDNSZone carries the same defect and is deliberately not covered here —
+// see the pull request for why it is held back.
+func TestDNSZones_SaveConcurrentAccountWrite_NoDeadlock(t *testing.T) {
+	t.Setenv("OPENZRO_STORE_ENGINE", string(types.PostgresStoreEngine))
+
+	// holdShared has to outlast the mutation's own walk to the exclusive lock.
+	const holdShared = 2 * time.Second
+
+	am, zoneID := initDNSZoneTestAccountWithZone(t)
+	ctx := context.Background()
+
+	zone, err := am.GetDNSZone(ctx, dnsZoneTestAccountID, dnsZoneTestUserID, zoneID)
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	var competingErr, saveErr error
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		competingErr = am.Store.ExecuteInTransaction(ctx, func(tx store.Store) error {
+			if _, err := tx.GetAccountSettings(ctx, store.LockingStrengthShare, dnsZoneTestAccountID); err != nil {
+				return err
+			}
+			time.Sleep(holdShared)
+			return tx.IncrementNetworkSerial(ctx, store.LockingStrengthUpdate, dnsZoneTestAccountID)
+		})
+	}()
+
+	// Let the competing transaction take its shared lock first.
+	time.Sleep(200 * time.Millisecond)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		zone.Name = "renamed-zone"
+		_, saveErr = am.SaveDNSZone(ctx, dnsZoneTestAccountID, dnsZoneTestUserID, zone)
+	}()
+
+	wg.Wait()
+
+	require.NoError(t, saveErr, "SaveDNSZone must queue behind a concurrent account write, not deadlock")
+	require.NoError(t, competingErr, "the concurrent account write must not be the deadlock victim either")
+}


### PR DESCRIPTION
First of #143. Covers **`SaveDNSZone` only** — `CreateDNSZone` was in this PR
and has been pulled back out; see below.

`group.go` (6 transactions) and `group_scim.go` (3) follow separately.

## Problem

`SaveDNSZone` resolves the peer DNS domain through `resolvePeerDNSDomainTx`,
which reads the account row under a **shared** lock (`dns_zones.go:486` →
`GetAccountSettings(…LockingStrengthShare…)`), and later writes that same row
via `IncrementNetworkSerial`.

Shared first, exclusive after, is an upgrade. Two account-scoped writes
overlapping both hold the shared lock, both then ask for the exclusive one, and
the database kills one of them — Postgres `SQLSTATE 40P01`, surfacing to the
caller as HTTP 500. Same defect #146 fixed for `DeletePeer`.

## Why not simply lock the account first

This file already has an established row order in the other direction. The
record mutations take the zone row and then the account row:

```go
// DeleteDNSRecord
zone, err := tx.GetDNSZoneByID(ctx, store.LockingStrengthUpdate, accountID, zoneID)  // :423
...
tx.IncrementNetworkSerial(ctx, store.LockingStrengthUpdate, accountID)               // :452
```

An account-first zone mutation would invert that and open a fresh cycle —
precisely what #148 caught after the first attempt at #146.

## Fix

Split the validation so both constraints hold at once: everything needing no
account read runs first, then the exclusive lock, then the shared read it now
covers.

| step | touches |
| --- | --- |
| `GetDNSZoneByID` (Update) | zone row |
| `validateDNSZone` | syntax, sibling-zone overlap, distribution groups — **no account row** |
| `areDNSZoneChangesAffectPeers` | groups, peers |
| `IncrementNetworkSerial` | **exclusive** on the account row |
| `resolvePeerDNSDomainTx` | **shared** on the account row, now covered |
| `validateDNSZonePeerOverlap` | split out so it can run once the domain is resolved |

Nothing here depends on observing a concurrent writer's rows: the zone domain
is immutable on save, so a save cannot introduce an overlap.

## Why `CreateDNSZone` was pulled out

It carries the same defect, but the same reordering there removes a
serialization the deadlock was providing by accident. The cross-zone overlap
check reads siblings with `FOR SHARE`, which locks the rows that exist and not
the row another replica is inserting — so two overlapping creates could both
read "no conflict". Today they still cannot both commit, because both upgrade
the account row and the database kills one. ADR-0022 D5 holds as a side effect
of the very deadlock being fixed.

The obvious repair — re-read the siblings after the exclusive lock, without
taking row locks — holds on Postgres and **not** on MySQL. The store never sets
an isolation level (`sql_store.go:1714` begins without options; the MySQL DSN
at `:1256` sets none), so InnoDB runs REPEATABLE READ and that re-read comes
from the transaction snapshot. On a supported backend the change would turn a
loud 500 into a silently persisted invalid state, which is the worse failure.

Tracked in #157. `CreateDNSZone` comes back on top of it, with the narrow
`id, domain` read the re-check wants rather than `GetAccountDNSZones`, which
preloads every record and distribution group of every zone.

## Behaviour change worth knowing about

A zone colliding with **both** the peer DNS namespace and an existing sibling
zone now reports the sibling collision rather than the peer one, because that
check moved after. Both are 400s naming the offending domain; only the message
differs, and only in the both-at-once case.

## Tests

The regression test holds the shared lock across the window in which the save
needs the exclusive one, so the violation is deterministic rather than a race
the test would only sometimes lose.

| | on `main` | with the fix |
| --- | --- | --- |
| `TestDNSZones_SaveConcurrentAccountWrite_NoDeadlock` | **FAIL** — `deadlock detected (SQLSTATE 40P01)` | pass |

Postgres only; sqlite serializes on a single connection and cannot exhibit the
cycle. Same shape as `peer_delete_concurrency_test.go`.

```
go test ./management/server/ -run TestDNSZone -race -count=2   pass
go test ./management/server/ -race                             ok
gofmt -s, go vet, go build ./management/...                    clean
```

## License

`management/` is AGPLv3 upstream. Diagnosis and fix come from this tree plus
observed Postgres and MySQL locking behavior. No upstream patch consulted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

