### PR TITLE
fix(management/networks): make the resource name unique in the database

### DIFF
--- a/management/server/http/api/openapi.yml
+++ b/management/server/http/api/openapi.yml
@@ -1643,8 +1643,9 @@ components:
       type: object
       properties:
         name:
-          description: Network resource name
+          description: Network resource name. Unique within the account.
           type: string
+          maxLength: 128
           example: Remote Resource 1
         description:
           description: Network resource description

--- a/management/server/network_resource_concurrency_test.go
+++ b/management/server/network_resource_concurrency_test.go
@@ -34,6 +34,21 @@ import (
 //
 // This is the demonstration half of #143 step 3: the duplicate has to be shown
 // before it is fixed, so the fix lands red to green rather than by argument.
+//
+// The two engines do not fail the same way, and running this on the wrong one
+// would look like proof it does not need fixing. Measured before the unique
+// index existed:
+//
+//	Postgres   FAIL — two rows with the same name. No gap locks; predicate
+//	           locking only exists at SERIALIZABLE, so the shared-lock read
+//	           locks the rows that exist, and there are none.
+//	MySQL      pass — InnoDB's gap locks under REPEATABLE READ hold the
+//	           position the row would occupy and refuse the second insert.
+//	           The loser sees a 1213 deadlock rather than a name conflict.
+//
+// So the red is Postgres-only, and the assertion below is what both engines
+// must satisfy afterwards: exactly one row survives, whichever way the database
+// got there.
 func TestNetworkResource_ConcurrentCreateAcrossReplicas(t *testing.T) {
 	const (
 		accountID    = "resource-race-account"

--- a/management/server/network_resource_concurrency_test.go
+++ b/management/server/network_resource_concurrency_test.go
@@ -1,0 +1,140 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rs/xid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openzro/openzro/management/server/groups"
+	"github.com/openzro/openzro/management/server/networks/resources"
+	resourceTypes "github.com/openzro/openzro/management/server/networks/resources/types"
+	networkTypes "github.com/openzro/openzro/management/server/networks/types"
+	"github.com/openzro/openzro/management/server/permissions"
+	"github.com/openzro/openzro/management/server/store"
+)
+
+// CreateResource rejects a name already taken in the account. It proves that
+// absence with a read (manager.go:116) and then writes on the strength of it,
+// which holds only as long as nothing else can insert the same name in between.
+//
+// AcquireWriteLockByUID makes that true inside one process and false across
+// two, which is the deployment this project ships. Postgres has no gap locks —
+// predicate locking only exists at SERIALIZABLE — so the shared-lock read
+// locks the rows that exist, and there are none. Two replicas can both prove
+// absence and both insert.
+//
+// The window is made deterministic rather than raced for. The name check at
+// manager.go:116 runs *before* the transaction takes the network row
+// exclusively at manager.go:121, so a third transaction holding that row parks
+// both replicas after they have each decided the name is free. Releasing it
+// lets both insert.
+//
+// This is the demonstration half of #143 step 3: the duplicate has to be shown
+// before it is fixed, so the fix lands red to green rather than by argument.
+func TestNetworkResource_ConcurrentCreateAcrossReplicas(t *testing.T) {
+	const (
+		accountID    = "resource-race-account"
+		userID       = "resource-race-user"
+		networkID    = "resource-race-network"
+		resourceName = "contested-name"
+	)
+
+	r := newTwoReplicas(t)
+	ctx := context.Background()
+
+	account := newAccountWithId(ctx, accountID, userID, "", false)
+	require.NoError(t, r.A.Store.SaveAccount(ctx, account))
+	require.NoError(t, r.A.Store.SaveNetwork(ctx, store.LockingStrengthUpdate, &networkTypes.Network{
+		ID:        networkID,
+		AccountID: accountID,
+		Name:      "race-network",
+	}))
+
+	// One resources manager per replica, over that replica's own store, so the
+	// two sides share nothing but the database.
+	managerFor := func(am *DefaultAccountManager) resources.Manager {
+		perms := permissions.NewManager(am.Store)
+		return resources.NewManager(am.Store, perms, groups.NewManager(am.Store, perms, am), am)
+	}
+	resA, resB := managerFor(r.A), managerFor(r.B)
+
+	// Hold the network row so both replicas pile up behind it *after* each has
+	// decided the name is free. Generous on purpose: the name check is a single
+	// indexed lookup, so both are through it long before this releases, and
+	// releasing early is the failure mode that would make this pass for the
+	// wrong reason.
+	blockerReady := make(chan struct{})
+	blockerDone := make(chan error, 1)
+	go func() {
+		blockerDone <- r.A.Store.ExecuteInTransaction(ctx, func(tx store.Store) error {
+			if _, err := tx.GetNetworkByID(ctx, store.LockingStrengthUpdate, accountID, networkID); err != nil {
+				return err
+			}
+			close(blockerReady)
+			time.Sleep(2 * time.Second)
+			return nil
+		})
+	}()
+	<-blockerReady
+
+	b := newBarrier()
+	create := func(mgr resources.Manager) <-chan error {
+		errCh := make(chan error, 1)
+		go func() {
+			b.wait(t)
+			_, err := mgr.CreateResource(ctx, userID, &resourceTypes.NetworkResource{
+				ID:        xid.New().String(),
+				AccountID: accountID,
+				NetworkID: networkID,
+				Name:      resourceName,
+				Type:      resourceTypes.NetworkResourceType("domain"),
+				Address:   "example.internal",
+				Enabled:   true,
+			})
+			errCh <- err
+		}()
+		return errCh
+	}
+	errA, errB := create(resA), create(resB)
+
+	join := func(name string, ch <-chan error) error {
+		t.Helper()
+		select {
+		case err := <-ch:
+			return err
+		case <-time.After(30 * time.Second):
+			t.Fatalf("replica %s never returned from CreateResource", name)
+			return nil
+		}
+	}
+	// Both sides are joined before anything is asserted, so a failure on one
+	// cannot leave the other running into the next assertion.
+	resultA, resultB := join("A", errA), join("B", errB)
+	require.NoError(t, <-blockerDone)
+
+	accepted := 0
+	for _, err := range []error{resultA, resultB} {
+		if err == nil {
+			accepted++
+		}
+	}
+
+	// Measured from committed state through the other replica's store, not from
+	// what either side believes it did.
+	stored, err := r.B.Store.GetNetworkResourcesByNetID(ctx, store.LockingStrengthNone, accountID, networkID)
+	require.NoError(t, err)
+
+	named := 0
+	for _, res := range stored {
+		if res.Name == resourceName {
+			named++
+		}
+	}
+
+	require.Equal(t, 1, named,
+		"the account holds %d resources named %q; CreateResource accepted %d of 2 concurrent creates (A=%v, B=%v)",
+		named, resourceName, accepted, resultA, resultB)
+}

--- a/management/server/network_resource_concurrency_test.go
+++ b/management/server/network_resource_concurrency_test.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,6 +16,7 @@ import (
 	networkTypes "github.com/openzro/openzro/management/server/networks/types"
 	"github.com/openzro/openzro/management/server/permissions"
 	"github.com/openzro/openzro/management/server/store"
+	"github.com/openzro/openzro/management/server/types"
 )
 
 // CreateResource rejects a name already taken in the account. It proves that
@@ -93,7 +96,15 @@ func TestNetworkResource_ConcurrentCreateAcrossReplicas(t *testing.T) {
 			return nil
 		})
 	}()
-	<-blockerReady
+	select {
+	case <-blockerReady:
+	case err := <-blockerDone:
+		// The blocker failed before it could signal. Without this the test
+		// would sit on blockerReady until the package timeout, naming nothing.
+		t.Fatalf("blocking transaction failed before taking the network row: %v", err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("blocking transaction never took the network row")
+	}
 
 	b := newBarrier()
 	create := func(mgr resources.Manager) <-chan error {
@@ -152,4 +163,19 @@ func TestNetworkResource_ConcurrentCreateAcrossReplicas(t *testing.T) {
 	require.Equal(t, 1, named,
 		"the account holds %d resources named %q; CreateResource accepted %d of 2 concurrent creates (A=%v, B=%v)",
 		named, resourceName, accepted, resultA, resultB)
+	require.Equal(t, 1, accepted, "exactly one create must be accepted")
+
+	// The loser's error is engine-specific, so assert it where it is
+	// deterministic. On Postgres the insert reaches the unique index and the
+	// store maps the violation to the same answer the pre-check gives. On
+	// MySQL the gap lock fires first and the loser sees a 1213 deadlock
+	// instead — see the note at the top of this file.
+	if types.Engine(strings.ToLower(os.Getenv("OPENZRO_STORE_ENGINE"))) == types.PostgresStoreEngine {
+		loser := resultA
+		if loser == nil {
+			loser = resultB
+		}
+		require.ErrorContains(t, loser, "already exists",
+			"the losing create must be reported as a taken name, not an internal error")
+	}
 }

--- a/management/server/networks/resources/manager.go
+++ b/management/server/networks/resources/manager.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
+	"unicode/utf8"
 
 	"github.com/openzro/openzro/management/server/account"
 	"github.com/openzro/openzro/management/server/activity"
@@ -59,23 +59,17 @@ func NewManager(store store.Store, permissionsManager permissions.Manager, group
 // (activity_exporters, flow_exports).
 const MaxResourceNameLength = 128
 
-// isUniqueConstraintError reports whether err is the database refusing a
-// duplicate. Mirrors the helper in the server package, which cannot be imported
-// from here.
-func isUniqueConstraintError(err error) bool {
-	msg := err.Error()
-	return strings.Contains(msg, "(SQLSTATE 23505)") ||
-		strings.Contains(msg, "Error 1062 (23000)") ||
-		strings.Contains(msg, "UNIQUE constraint failed")
-}
-
 // validateResourceName rejects a name the unique index could not hold, so the
 // caller gets a validation error naming the limit rather than a database error
 // from the write.
 func validateResourceName(name string) error {
-	if len(name) > MaxResourceNameLength {
+	// Counted in runes, not bytes: the column is varchar(128), which both
+	// engines size in characters. len() would reject a 100-character name
+	// carrying accents that the database would have accepted, and the message
+	// would be wrong about what it counted.
+	if n := utf8.RuneCountInString(name); n > MaxResourceNameLength {
 		return status.Errorf(status.InvalidArgument,
-			"resource name is %d characters; the maximum is %d", len(name), MaxResourceNameLength)
+			"resource name is %d characters; the maximum is %d", n, MaxResourceNameLength)
 	}
 	return nil
 }
@@ -161,15 +155,11 @@ func (m *managerImpl) CreateResource(ctx context.Context, userID string, resourc
 
 		err = transaction.SaveNetworkResource(ctx, store.LockingStrengthUpdate, resource)
 		if err != nil {
-			// The unique index is what actually holds this invariant across
-			// replicas; the name check earlier only fails fast on the common
-			// case. Report the loser of a genuine race the same way, rather
-			// than letting a constraint violation surface as an internal
-			// error.
-			if isUniqueConstraintError(err) {
-				return status.Errorf(status.InvalidArgument, "resource with name %s already exists", resource.Name)
-			}
-			return fmt.Errorf("failed to save network resource: %w", err)
+			// The store classifies a unique-index violation for us and returns
+			// the same error the name check above produces, so the loser of a
+			// cross-replica race is reported as a taken name rather than an
+			// internal fault. Passed through unwrapped so the type survives.
+			return err
 		}
 
 		event := func() {
@@ -283,15 +273,11 @@ func (m *managerImpl) UpdateResource(ctx context.Context, userID string, resourc
 
 		err = transaction.SaveNetworkResource(ctx, store.LockingStrengthUpdate, resource)
 		if err != nil {
-			// The unique index is what actually holds this invariant across
-			// replicas; the name check earlier only fails fast on the common
-			// case. Report the loser of a genuine race the same way, rather
-			// than letting a constraint violation surface as an internal
-			// error.
-			if isUniqueConstraintError(err) {
-				return status.Errorf(status.InvalidArgument, "resource with name %s already exists", resource.Name)
-			}
-			return fmt.Errorf("failed to save network resource: %w", err)
+			// The store classifies a unique-index violation for us and returns
+			// the same error the name check above produces, so the loser of a
+			// cross-replica race is reported as a taken name rather than an
+			// internal fault. Passed through unwrapped so the type survives.
+			return err
 		}
 
 		events, err := m.updateResourceGroups(ctx, transaction, userID, resource, oldResource)

--- a/management/server/networks/resources/manager.go
+++ b/management/server/networks/resources/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/openzro/openzro/management/server/account"
 	"github.com/openzro/openzro/management/server/activity"
@@ -57,6 +58,16 @@ func NewManager(store store.Store, permissionsManager permissions.Manager, group
 // 128 follows the sizes already used for name columns elsewhere in the tree
 // (activity_exporters, flow_exports).
 const MaxResourceNameLength = 128
+
+// isUniqueConstraintError reports whether err is the database refusing a
+// duplicate. Mirrors the helper in the server package, which cannot be imported
+// from here.
+func isUniqueConstraintError(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "(SQLSTATE 23505)") ||
+		strings.Contains(msg, "Error 1062 (23000)") ||
+		strings.Contains(msg, "UNIQUE constraint failed")
+}
 
 // validateResourceName rejects a name the unique index could not hold, so the
 // caller gets a validation error naming the limit rather than a database error
@@ -150,6 +161,14 @@ func (m *managerImpl) CreateResource(ctx context.Context, userID string, resourc
 
 		err = transaction.SaveNetworkResource(ctx, store.LockingStrengthUpdate, resource)
 		if err != nil {
+			// The unique index is what actually holds this invariant across
+			// replicas; the name check earlier only fails fast on the common
+			// case. Report the loser of a genuine race the same way, rather
+			// than letting a constraint violation surface as an internal
+			// error.
+			if isUniqueConstraintError(err) {
+				return status.Errorf(status.InvalidArgument, "resource with name %s already exists", resource.Name)
+			}
 			return fmt.Errorf("failed to save network resource: %w", err)
 		}
 
@@ -264,6 +283,14 @@ func (m *managerImpl) UpdateResource(ctx context.Context, userID string, resourc
 
 		err = transaction.SaveNetworkResource(ctx, store.LockingStrengthUpdate, resource)
 		if err != nil {
+			// The unique index is what actually holds this invariant across
+			// replicas; the name check earlier only fails fast on the common
+			// case. Report the loser of a genuine race the same way, rather
+			// than letting a constraint violation surface as an internal
+			// error.
+			if isUniqueConstraintError(err) {
+				return status.Errorf(status.InvalidArgument, "resource with name %s already exists", resource.Name)
+			}
 			return fmt.Errorf("failed to save network resource: %w", err)
 		}
 

--- a/management/server/networks/resources/manager.go
+++ b/management/server/networks/resources/manager.go
@@ -48,6 +48,27 @@ func NewManager(store store.Store, permissionsManager permissions.Manager, group
 	}
 }
 
+// MaxResourceNameLength bounds the resource name. The limit exists so the
+// column can carry a unique index: without a size the MySQL driver maps the
+// field to longtext, which InnoDB cannot index without a prefix length, and a
+// prefix index would collide two different names sharing their first bytes —
+// trading one correctness bug for another.
+//
+// 128 follows the sizes already used for name columns elsewhere in the tree
+// (activity_exporters, flow_exports).
+const MaxResourceNameLength = 128
+
+// validateResourceName rejects a name the unique index could not hold, so the
+// caller gets a validation error naming the limit rather than a database error
+// from the write.
+func validateResourceName(name string) error {
+	if len(name) > MaxResourceNameLength {
+		return status.Errorf(status.InvalidArgument,
+			"resource name is %d characters; the maximum is %d", len(name), MaxResourceNameLength)
+	}
+	return nil
+}
+
 func (m *managerImpl) GetAllResourcesInNetwork(ctx context.Context, accountID, userID, networkID string) ([]*types.NetworkResource, error) {
 	ok, err := m.permissionsManager.ValidateUserPermissions(ctx, accountID, userID, modules.Networks, operations.Read)
 	if err != nil {
@@ -112,6 +133,10 @@ func (m *managerImpl) CreateResource(ctx context.Context, userID string, resourc
 	defer unlock()
 
 	var eventsToStore []func()
+	if err := validateResourceName(resource.Name); err != nil {
+		return nil, err
+	}
+
 	err = m.store.ExecuteInTransaction(ctx, func(transaction store.Store) error {
 		_, err = transaction.GetNetworkResourceByName(ctx, store.LockingStrengthShare, resource.AccountID, resource.Name)
 		if err == nil {
@@ -193,6 +218,10 @@ func (m *managerImpl) UpdateResource(ctx context.Context, userID string, resourc
 	}
 	if !ok {
 		return nil, status.NewPermissionDeniedError()
+	}
+
+	if err := validateResourceName(resource.Name); err != nil {
+		return nil, err
 	}
 
 	resourceType, domain, prefix, err := types.GetResourceType(resource.Address)

--- a/management/server/networks/resources/types/resource.go
+++ b/management/server/networks/resources/types/resource.go
@@ -33,7 +33,7 @@ type NetworkResource struct {
 	ID          string `gorm:"primaryKey"`
 	NetworkID   string `gorm:"index"`
 	AccountID   string `gorm:"index"`
-	Name        string
+	Name        string `gorm:"size:128"`
 	Description string
 	Type        NetworkResourceType
 	Address     string   `gorm:"-"`

--- a/management/server/status/error.go
+++ b/management/server/status/error.go
@@ -164,6 +164,15 @@ func NewGroupNotFoundError(groupID string) error {
 	return Errorf(NotFound, "group: %s not found", groupID)
 }
 
+// NewResourceNameAlreadyExistsError creates a new Error for a network resource
+// name already taken in the account. Returned both by the manager's own check
+// and by the store when the unique index refuses the write, so the loser of a
+// cross-replica race gets the same answer as someone who simply picked a name
+// that was already in use.
+func NewResourceNameAlreadyExistsError(name string) error {
+	return Errorf(InvalidArgument, "resource with name %s already exists", name)
+}
+
 // NewPostureChecksNotFoundError creates a new Error with NotFound type for a missing posture checks
 func NewPostureChecksNotFoundError(postureChecksID string) error {
 	return Errorf(NotFound, "posture checks: %s not found", postureChecksID)

--- a/management/server/store/sql_store.go
+++ b/management/server/store/sql_store.go
@@ -2753,10 +2753,27 @@ func (s *SqlStore) SaveNetworkResource(ctx context.Context, lockStrength Locking
 	result := s.db.Clauses(clause.Locking{Strength: string(lockStrength)}).Save(resource)
 	if result.Error != nil {
 		log.WithContext(ctx).Errorf("failed to save network resource to store: %v", result.Error)
+		// idx_network_resources_account_name is what holds the per-account
+		// name invariant across replicas, so a violation here is the loser of
+		// a real race, not an internal fault. Classified here because this is
+		// the only layer that sees the driver error — callers get a generic
+		// message, by design, so the driver text does not reach the API.
+		if isUniqueConstraintViolation(result.Error) {
+			return status.NewResourceNameAlreadyExistsError(resource.Name)
+		}
 		return status.Errorf(status.Internal, "failed to save network resource to store")
 	}
 
 	return nil
+}
+
+// isUniqueConstraintViolation reports whether err is the database refusing a
+// duplicate, across the three engines this store supports.
+func isUniqueConstraintViolation(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "(SQLSTATE 23505)") || // postgres
+		strings.Contains(msg, "Error 1062 (23000)") || // mysql
+		strings.Contains(msg, "UNIQUE constraint failed") // sqlite
 }
 
 func (s *SqlStore) DeleteNetworkResource(ctx context.Context, lockStrength LockingStrength, accountID, resourceID string) error {

--- a/management/server/store/sql_store.go
+++ b/management/server/store/sql_store.go
@@ -2758,6 +2758,14 @@ func (s *SqlStore) SaveNetworkResource(ctx context.Context, lockStrength Locking
 		// a real race, not an internal fault. Classified here because this is
 		// the only layer that sees the driver error — callers get a generic
 		// message, by design, so the driver text does not reach the API.
+		//
+		// This attributes any unique violation on this table to the name,
+		// which is true while that index and the primary key are the only
+		// ones. If a second unique index is ever added to network_resources,
+		// this has to start distinguishing them — the three engines each name
+		// the offending constraint differently (Postgres and MySQL give the
+		// index name, SQLite gives the columns), so it would mean per-engine
+		// parsing rather than one more string match.
 		if isUniqueConstraintViolation(result.Error) {
 			return status.NewResourceNameAlreadyExistsError(resource.Name)
 		}

--- a/management/server/store/store.go
+++ b/management/server/store/store.go
@@ -398,6 +398,19 @@ func getMigrationsPostAuto(ctx context.Context) []migrationFunc {
 		func(db *gorm.DB) error {
 			return migration.CreateIndexIfNotExists[nbpeer.Peer](ctx, db, "idx_account_dnslabel", "account_id", "dns_label")
 		},
+		// Resource names are unique per account, and were only ever enforced
+		// by a read-then-write in the resources manager. That holds inside one
+		// process and not across replicas, where two can both find the name
+		// free and both insert. The database is the only place the guarantee
+		// survives — see #143.
+		//
+		// This fails on a database that already carries a duplicate from that
+		// race. That is deliberate: the operator has to see that it happened
+		// and choose which row survives. Picking a winner here would hide it.
+		func(db *gorm.DB) error {
+			return migration.CreateIndexIfNotExists[resourceTypes.NetworkResource](ctx, db,
+				"idx_network_resources_account_name", "account_id", "name")
+		},
 	}
 }
 


### PR DESCRIPTION
First red-to-green of step 3 in #143, on the harness merged in #158.

`resources.name` was picked because it is the one of the six phantom-prone
invariants that is genuinely unconditional — both create (`manager.go:116`) and
update (`manager.go:226`) reject a taken name, the update excluding itself by
ID. The other five are not: `posture_checks.name` skips the check on update,
`group.name` only applies to API-issued groups, `account.domain` is a
three-part predicate, and `dns_zones`/`route` are semantic overlaps no index
expresses.

## The demonstration comes first

`CreateResource` proves a name is free with a read and then writes on the
strength of it. `AcquireWriteLockByUID` makes that true inside one process and
false across two — the deployment this project ships.

The window is deterministic, not raced for: the name check runs *before* the
transaction takes the network row exclusively (`manager.go:121`), so a third
transaction holding that row parks both replicas after each has decided the
name is free. The count is read from committed state, without locks, through
the *other* replica's store, after both goroutines are joined.

| control | result |
| --- | --- |
| two replicas | **FAIL** — the account holds 2 resources named `contested-name`, both creates accepted |
| one replica | pass — the process-local mutex still covers the old case, so it is the second replica exposing this and not a broken scenario |

## The engines disagree, and that turned out to matter

Measured before the index existed:

| engine | without the index |
| --- | --- |
| Postgres | **FAIL** — two rows. No gap locks; predicate locking only exists at SERIALIZABLE, so the shared-lock read locks the rows that exist, and there are none |
| MySQL | **pass** — InnoDB's gap locks under REPEATABLE READ hold the position the row would occupy and refuse the second insert |

This is the first measured confirmation of the reading in #157, which until now
rested on engine documentation: MySQL is protecting these invariants by
accident, and Postgres never protected them at all. It is also why moving MySQL
to READ COMMITTED has to wait for invariants like this one to become explicit —
it would take away a protection MySQL genuinely has.

The test comment records this, so nobody runs it on MySQL alone, sees green, and
concludes the invariant is fine.

## The fix

Three commits: the red test, the column size it needs, then the index.

**`gorm:"size:128"` on `NetworkResource.Name`.** Not cosmetic — the field had no
size, and measured on a migrated schema the MySQL driver maps it to `longtext`:

```
account_id  varchar     (sized because of its index tag)
name        longtext
```

InnoDB cannot index `longtext` without a prefix length, and a prefix index would
treat two different names sharing their first bytes as equal — trading one
correctness bug for another. 128 follows the size already used for name columns
in `activity_exporters` and `flow_exports`.

**Validated in the manager, on create and update**, so a name over the limit is
a validation error naming the limit rather than a truncation at the driver.

**`idx_network_resources_account_name`**, unique on `(account_id, name)`, with a
violation reported as `resource with name %s already exists` — the same answer
the pre-check gives — on all three engines (`23505`, `1062`,
`UNIQUE constraint failed`).

## Three things to know before deploying

1. **The migration fails on a database already carrying a duplicate** from this
   race. Deliberate. The operator has to see it happened and choose which row
   survives; picking a winner here would hide it.
2. **Case semantics are inherited, not introduced.** The column collates
   `utf8mb4_0900_ai_ci` on MySQL (case- and accent-insensitive) and uses the
   database default on Postgres (case-sensitive), so the index treats `Foo` and
   `foo` exactly as the existing `WHERE name = ?` already does on each engine.
   Unifying that would be a product decision, not a concurrency fix.
3. **MySQL can still return a 1213 deadlock** in this scenario rather than the
   mapped conflict, because the gap lock fires before the insert reaches the
   index. Left alone: retrying or remapping deadlocks belongs to #157 or to a
   transaction policy, not here.

## Scope

No `not null` on the name. Making it mandatory at the database level is a
separate decision from making it unique.

```
two replicas, Postgres and MySQL          pass
./management/server/networks/...          pass
./management/server/ -race                ok 205s
gofmt -s, go vet, go build ./management/  clean
```

Refs #143 (step 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
