### PR TITLE
fix(management/posture): make the check name unique in the database

### DIFF
--- a/management/server/http/api/openapi.yml
+++ b/management/server/http/api/openapi.yml
@@ -1182,6 +1182,7 @@ components:
         name:
           description: Posture check unique name identifier
           type: string
+          maxLength: 128
           example: Default
         description:
           description: Posture check friendly description

--- a/management/server/http/api/openapi.yml
+++ b/management/server/http/api/openapi.yml
@@ -1464,8 +1464,9 @@ components:
       type: object
       properties:
         name:
-          description: Posture check name identifier
+          description: Posture check name identifier. Unique within the account.
           type: string
+          maxLength: 128
           example: Default
         description:
           description: Posture check friendly description

--- a/management/server/posture/checks.go
+++ b/management/server/posture/checks.go
@@ -40,8 +40,14 @@ type Checks struct {
 	// ID of the posture checks
 	ID string `gorm:"primaryKey"`
 
-	// Name of the posture checks
-	Name string
+	// Name of the posture checks. Unique within the account — enforced by
+	// idx_posture_checks_account_name, not only by the manager's check.
+	//
+	// The size is what lets that index exist: without it the MySQL driver maps
+	// the field to longtext, which InnoDB cannot index without a prefix
+	// length, and a prefix index would treat two different names sharing their
+	// first bytes as equal.
+	Name string `gorm:"size:128"`
 
 	// Description of the posture checks visible in the UI
 	Description string

--- a/management/server/posture_check_concurrency_test.go
+++ b/management/server/posture_check_concurrency_test.go
@@ -1,0 +1,141 @@
+package server
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openzro/openzro/management/server/posture"
+	"github.com/openzro/openzro/management/server/store"
+	"github.com/openzro/openzro/management/server/types"
+)
+
+// SavePostureChecks rejects a name already taken in the account. It proves that
+// absence with a read (posture_checks.go:213) and then writes on the strength
+// of it, which holds only as long as nothing else can insert the same name in
+// between.
+//
+// AcquireWriteLockByUID makes that true inside one process and false across
+// two, which is the deployment this project ships. Postgres has no gap locks —
+// predicate locking only exists at SERIALIZABLE — so the shared-lock read locks
+// the rows that exist, and there are none.
+//
+// Unlike the resource-name case (#159), the create path takes no exclusive lock
+// at all: it validates and saves, with no IncrementNetworkSerial to serialize
+// on. That absence is what makes the invariant vulnerable, and it is also what
+// makes it awkward to demonstrate — there is no row a third transaction can
+// hold to park both replicas inside the window, the way #159 used the network
+// row.
+//
+// Worth knowing before copying this pattern to the next invariant: the barrier
+// aligns the two *calls*, not the two transactions. Each side then runs
+// permission validation — several round trips — before opening its
+// transaction, and on a cold connection pool that offsets one replica past the
+// other's entire transaction. The first version of this test passed for
+// exactly that reason. The warm-up below removes the offset; without it, a
+// green run means nothing.
+//
+// The engines do not fail this the same way, and running it on MySQL alone
+// would look like proof the invariant is fine:
+//
+//	Postgres   two rows with the same name
+//	MySQL      the second insert is refused by InnoDB's gap locks under
+//	           REPEATABLE READ, and the loser sees a 1213 deadlock
+//
+// The assertion below is what both must satisfy: exactly one row survives.
+func TestPostureChecks_ConcurrentCreateAcrossReplicas(t *testing.T) {
+	const (
+		accountID = "posture-race-account"
+		userID    = "posture-race-user"
+		checkName = "contested-posture-check"
+	)
+
+	r := newTwoReplicas(t)
+	ctx := context.Background()
+
+	account := newAccountWithId(ctx, accountID, userID, "", false)
+	require.NoError(t, r.A.Store.SaveAccount(ctx, account))
+
+	// Warm each replica first. The barrier aligns the two calls, but each then
+	// runs permission validation — several round trips — before opening its
+	// transaction, and a cold connection pool on one side offsets it past the
+	// other's whole transaction. Without this the two never overlap and the
+	// test passes for the wrong reason.
+	for i, am := range []*DefaultAccountManager{r.A, r.B} {
+		_, err := am.SavePostureChecks(ctx, accountID, userID, &posture.Checks{
+			Name:   "warmup-" + string(rune('a'+i)),
+			Checks: posture.ChecksDefinition{NBVersionCheck: &posture.NBVersionCheck{MinVersion: "0.26.0"}},
+		}, true)
+		require.NoError(t, err)
+	}
+
+	b := newBarrier()
+	create := func(am *DefaultAccountManager) <-chan error {
+		errCh := make(chan error, 1)
+		go func() {
+			b.wait(t)
+			_, err := am.SavePostureChecks(ctx, accountID, userID, &posture.Checks{
+				Name: checkName,
+				Checks: posture.ChecksDefinition{
+					NBVersionCheck: &posture.NBVersionCheck{MinVersion: "0.26.0"},
+				},
+			}, true)
+			errCh <- err
+		}()
+		return errCh
+	}
+	errA, errB := create(r.A), create(r.B)
+
+	join := func(name string, ch <-chan error) error {
+		t.Helper()
+		select {
+		case err := <-ch:
+			return err
+		case <-time.After(30 * time.Second):
+			t.Fatalf("replica %s never returned from SavePostureChecks", name)
+			return nil
+		}
+	}
+	// Both sides are joined before anything is asserted, so a failure on one
+	// cannot leave the other running into the next assertion.
+	resultA, resultB := join("A", errA), join("B", errB)
+
+	accepted := 0
+	for _, err := range []error{resultA, resultB} {
+		if err == nil {
+			accepted++
+		}
+	}
+
+	// Measured from committed state through the other replica's store, not from
+	// what either side believes it did.
+	stored, err := r.B.Store.GetAccountPostureChecks(ctx, store.LockingStrengthNone, accountID)
+	require.NoError(t, err)
+
+	named := 0
+	for _, check := range stored {
+		if check.Name == checkName {
+			named++
+		}
+	}
+
+	require.Equal(t, 1, named,
+		"the account holds %d posture checks named %q; SavePostureChecks accepted %d of 2 concurrent creates (A=%v, B=%v)",
+		named, checkName, accepted, resultA, resultB)
+	require.Equal(t, 1, accepted, "exactly one create must be accepted")
+
+	// The loser's error is engine-specific; assert it where it is
+	// deterministic. See the note at the top of this file.
+	if types.Engine(strings.ToLower(os.Getenv("OPENZRO_STORE_ENGINE"))) == types.PostgresStoreEngine {
+		loser := resultA
+		if loser == nil {
+			loser = resultB
+		}
+		require.ErrorContains(t, loser, "already exists",
+			"the losing create must be reported as a taken name, not an internal error")
+	}
+}

--- a/management/server/posture_check_concurrency_test.go
+++ b/management/server/posture_check_concurrency_test.go
@@ -139,3 +139,59 @@ func TestPostureChecks_ConcurrentCreateAcrossReplicas(t *testing.T) {
 			"the losing create must be reported as a taken name, not an internal error")
 	}
 }
+
+// TestPostureChecks_UpdateToTakenNameIsRejected pins the behaviour change that
+// comes with idx_posture_checks_account_name.
+//
+// Before it, validatePostureChecks returned early for anything carrying an ID:
+// it confirmed the row existed and skipped the duplicate-name check entirely,
+// so renaming a posture check onto another one's name was accepted. That was a
+// gap rather than a decision — the OpenAPI has described the field as "Posture
+// check unique name identifier" since it was introduced, with no exception for
+// update, and the early return arrived with the refactor to store methods.
+//
+// This is the assertion that makes the documented contract true, and it is a
+// deliberate behaviour change: a rename that used to be accepted now returns a
+// validation error.
+func TestPostureChecks_UpdateToTakenNameIsRejected(t *testing.T) {
+	const (
+		accountID = "posture-rename-account"
+		userID    = "posture-rename-user"
+		takenName = "already-taken"
+	)
+
+	r := newTwoReplicas(t)
+	ctx := context.Background()
+
+	account := newAccountWithId(ctx, accountID, userID, "", false)
+	require.NoError(t, r.A.Store.SaveAccount(ctx, account))
+
+	newCheck := func(name string) *posture.Checks {
+		return &posture.Checks{
+			Name:   name,
+			Checks: posture.ChecksDefinition{NBVersionCheck: &posture.NBVersionCheck{MinVersion: "0.26.0"}},
+		}
+	}
+
+	_, err := r.A.SavePostureChecks(ctx, accountID, userID, newCheck(takenName), true)
+	require.NoError(t, err)
+
+	other, err := r.A.SavePostureChecks(ctx, accountID, userID, newCheck("some-other-name"), true)
+	require.NoError(t, err)
+
+	other.Name = takenName
+	_, err = r.A.SavePostureChecks(ctx, accountID, userID, other, false)
+	require.ErrorContains(t, err, "already exists",
+		"renaming a posture check onto a name already in use must be rejected")
+
+	// And the rename left nothing behind: still one row under that name.
+	stored, err := r.B.Store.GetAccountPostureChecks(ctx, store.LockingStrengthNone, accountID)
+	require.NoError(t, err)
+	named := 0
+	for _, check := range stored {
+		if check.Name == takenName {
+			named++
+		}
+	}
+	require.Equal(t, 1, named, "the rejected rename must not have written a second row named %q", takenName)
+}

--- a/management/server/posture_check_concurrency_test.go
+++ b/management/server/posture_check_concurrency_test.go
@@ -140,7 +140,7 @@ func TestPostureChecks_ConcurrentCreateAcrossReplicas(t *testing.T) {
 	}
 }
 
-// TestPostureChecks_UpdateToTakenNameIsRejected pins the behaviour change that
+// TestPostureChecks_UpdateToTakenNameIsRejected pins the behavior change that
 // comes with idx_posture_checks_account_name.
 //
 // Before it, validatePostureChecks returned early for anything carrying an ID:
@@ -151,7 +151,7 @@ func TestPostureChecks_ConcurrentCreateAcrossReplicas(t *testing.T) {
 // update, and the early return arrived with the refactor to store methods.
 //
 // This is the assertion that makes the documented contract true, and it is a
-// deliberate behaviour change: a rename that used to be accepted now returns a
+// deliberate behavior change: a rename that used to be accepted now returns a
 // validation error.
 func TestPostureChecks_UpdateToTakenNameIsRejected(t *testing.T) {
 	const (

--- a/management/server/posture_checks.go
+++ b/management/server/posture_checks.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"unicode/utf8"
 
 	"github.com/rs/xid"
 	"golang.org/x/exp/maps"
@@ -195,10 +196,22 @@ func arePostureCheckChangesAffectPeers(ctx context.Context, transaction store.St
 	return false, nil
 }
 
+// MaxPostureCheckNameLength bounds the posture check name so the column can
+// carry a unique index; see the note on posture.Checks.Name. 128 follows the
+// size used for name columns elsewhere in the tree.
+const MaxPostureCheckNameLength = 128
+
 // validatePostureChecks validates the posture checks.
 func validatePostureChecks(ctx context.Context, transaction store.Store, accountID string, postureChecks *posture.Checks) error {
 	if err := postureChecks.Validate(); err != nil {
 		return status.Errorf(status.InvalidArgument, "%s", err.Error())
+	}
+
+	// Counted in runes: the column is varchar(128), which both engines size in
+	// characters, so len() would reject an accented name the database accepts.
+	if n := utf8.RuneCountInString(postureChecks.Name); n > MaxPostureCheckNameLength {
+		return status.Errorf(status.InvalidArgument,
+			"posture check name is %d characters; the maximum is %d", n, MaxPostureCheckNameLength)
 	}
 
 	// If the posture check already has an ID, verify its existence in the store.

--- a/management/server/posture_schedule_loader_test.go
+++ b/management/server/posture_schedule_loader_test.go
@@ -44,6 +44,7 @@ func TestScheduleLoader_AccountsWithActiveSchedules(t *testing.T) {
 	seed := []*posture.Checks{
 		{
 			ID:        "pc-1",
+			Name:      "pc-1-name",
 			AccountID: accountSched1,
 			Checks: posture.ChecksDefinition{
 				ScheduleCheck: &posture.ScheduleCheck{
@@ -56,6 +57,7 @@ func TestScheduleLoader_AccountsWithActiveSchedules(t *testing.T) {
 			// Second schedule-bearing check for the SAME account —
 			// must not produce a duplicate account ID.
 			ID:        "pc-2",
+			Name:      "pc-2-name",
 			AccountID: accountSched1,
 			Checks: posture.ChecksDefinition{
 				ScheduleCheck: &posture.ScheduleCheck{
@@ -66,6 +68,7 @@ func TestScheduleLoader_AccountsWithActiveSchedules(t *testing.T) {
 		},
 		{
 			ID:        "pc-3",
+			Name:      "pc-3-name",
 			AccountID: accountSched2,
 			Checks: posture.ChecksDefinition{
 				ScheduleCheck: &posture.ScheduleCheck{
@@ -77,6 +80,7 @@ func TestScheduleLoader_AccountsWithActiveSchedules(t *testing.T) {
 		{
 			// No ScheduleCheck → account must NOT appear.
 			ID:        "pc-4",
+			Name:      "pc-4-name",
 			AccountID: accountNoSched,
 			Checks: posture.ChecksDefinition{
 				NBVersionCheck: &posture.NBVersionCheck{MinVersion: "0.31.0"},
@@ -117,6 +121,7 @@ func TestScheduleLoader_LoadActiveSchedules(t *testing.T) {
 	seedAccount(t, st, accountID)
 	require.NoError(t, st.SavePostureChecks(ctx, store.LockingStrengthUpdate, &posture.Checks{
 		ID:        "pc-sched",
+		Name:      "pc-sched-name",
 		AccountID: accountID,
 		Checks: posture.ChecksDefinition{
 			ScheduleCheck: &posture.ScheduleCheck{
@@ -127,6 +132,7 @@ func TestScheduleLoader_LoadActiveSchedules(t *testing.T) {
 	}))
 	require.NoError(t, st.SavePostureChecks(ctx, store.LockingStrengthUpdate, &posture.Checks{
 		ID:        "pc-nbver",
+		Name:      "pc-nbver-name",
 		AccountID: accountID,
 		Checks: posture.ChecksDefinition{
 			NBVersionCheck: &posture.NBVersionCheck{MinVersion: "0.31.0"},

--- a/management/server/status/error.go
+++ b/management/server/status/error.go
@@ -164,6 +164,15 @@ func NewGroupNotFoundError(groupID string) error {
 	return Errorf(NotFound, "group: %s not found", groupID)
 }
 
+// NewPostureCheckNameAlreadyExistsError creates a new Error for a posture check
+// name already taken in the account. Returned both by the manager's own check
+// and by the store when the unique index refuses the write, so the loser of a
+// cross-replica race gets the same answer as someone who simply picked a name
+// that was already in use.
+func NewPostureCheckNameAlreadyExistsError(name string) error {
+	return Errorf(InvalidArgument, "posture checks with name %s already exists", name)
+}
+
 // NewResourceNameAlreadyExistsError creates a new Error for a network resource
 // name already taken in the account. Returned both by the manager's own check
 // and by the store when the unique index refuses the write, so the loser of a

--- a/management/server/store/sql_store.go
+++ b/management/server/store/sql_store.go
@@ -2085,6 +2085,14 @@ func (s *SqlStore) SavePostureChecks(ctx context.Context, lockStrength LockingSt
 	result := s.db.Clauses(clause.Locking{Strength: string(lockStrength)}).Save(postureCheck)
 	if result.Error != nil {
 		log.WithContext(ctx).Errorf("failed to save posture checks to store: %s", result.Error)
+		// Same reasoning as SaveNetworkResource: idx_posture_checks_account_name
+		// is what holds the per-account name invariant across replicas, and
+		// this is the only layer that sees the driver error. Attributing any
+		// unique violation on this table to the name holds while that index and
+		// the primary key are the only ones.
+		if isUniqueConstraintViolation(result.Error) {
+			return status.NewPostureCheckNameAlreadyExistsError(postureCheck.Name)
+		}
 		return status.Errorf(status.Internal, "failed to save posture checks to store")
 	}
 

--- a/management/server/store/sql_store_test.go
+++ b/management/server/store/sql_store_test.go
@@ -1688,6 +1688,7 @@ func TestSqlStore_SavePostureChecks(t *testing.T) {
 
 	postureChecks := &posture.Checks{
 		ID:        "posture-checks-id",
+		Name:      "posture-checks-id-name",
 		AccountID: accountID,
 		Checks: posture.ChecksDefinition{
 			NBVersionCheck: &posture.NBVersionCheck{
@@ -1741,6 +1742,7 @@ func TestSqlStore_GetAllPostureChecks(t *testing.T) {
 	seed := []*posture.Checks{
 		{
 			ID:        "pc-acctA-schedule",
+			Name:      "pc-acctA-schedule-name",
 			AccountID: accountA,
 			Checks: posture.ChecksDefinition{
 				ScheduleCheck: &posture.ScheduleCheck{
@@ -1751,6 +1753,7 @@ func TestSqlStore_GetAllPostureChecks(t *testing.T) {
 		},
 		{
 			ID:        "pc-acctA-nbversion",
+			Name:      "pc-acctA-nbversion-name",
 			AccountID: accountA,
 			Checks: posture.ChecksDefinition{
 				NBVersionCheck: &posture.NBVersionCheck{MinVersion: "0.31.0"},
@@ -1758,6 +1761,7 @@ func TestSqlStore_GetAllPostureChecks(t *testing.T) {
 		},
 		{
 			ID:        "pc-acctB-schedule",
+			Name:      "pc-acctB-schedule-name",
 			AccountID: accountB,
 			Checks: posture.ChecksDefinition{
 				ScheduleCheck: &posture.ScheduleCheck{

--- a/management/server/store/store.go
+++ b/management/server/store/store.go
@@ -416,7 +416,7 @@ func getMigrationsPostAuto(ctx context.Context) []migrationFunc {
 		// enforced on create, and only by a read-then-write that holds inside
 		// one process. This makes the documented contract true, including on
 		// update — see the pull request, which calls that out as a deliberate
-		// behaviour change rather than a side effect.
+		// behavior change rather than a side effect.
 		//
 		// Fails on a database already carrying a duplicate, by design: the
 		// operator has to see it and choose which row survives.

--- a/management/server/store/store.go
+++ b/management/server/store/store.go
@@ -418,8 +418,14 @@ func getMigrationsPostAuto(ctx context.Context) []migrationFunc {
 		// update — see the pull request, which calls that out as a deliberate
 		// behavior change rather than a side effect.
 		//
-		// Fails on a database already carrying a duplicate, by design: the
+		// Fails on a database already carrying duplicate names, by design: the
 		// operator has to see it and choose which row survives.
+		//
+		// Duplicates only. A single empty name passes — this index constrains
+		// duplication, not emptiness, and there is no NOT NULL or CHECK here.
+		// What keeps names non-empty is Validate() on the way in
+		// (posture/checks.go:373). Duplicate empty strings do collide, which
+		// is what the fixtures in this tree were producing.
 		func(db *gorm.DB) error {
 			return migration.CreateIndexIfNotExists[posture.Checks](ctx, db,
 				"idx_posture_checks_account_name", "account_id", "name")

--- a/management/server/store/store.go
+++ b/management/server/store/store.go
@@ -411,6 +411,19 @@ func getMigrationsPostAuto(ctx context.Context) []migrationFunc {
 			return migration.CreateIndexIfNotExists[resourceTypes.NetworkResource](ctx, db,
 				"idx_network_resources_account_name", "account_id", "name")
 		},
+		// Posture check names are documented as unique per account
+		// ("Posture check unique name identifier", openapi.yml) but were only
+		// enforced on create, and only by a read-then-write that holds inside
+		// one process. This makes the documented contract true, including on
+		// update — see the pull request, which calls that out as a deliberate
+		// behaviour change rather than a side effect.
+		//
+		// Fails on a database already carrying a duplicate, by design: the
+		// operator has to see it and choose which row survives.
+		func(db *gorm.DB) error {
+			return migration.CreateIndexIfNotExists[posture.Checks](ctx, db,
+				"idx_posture_checks_account_name", "account_id", "name")
+		},
 	}
 }
 


### PR DESCRIPTION
Second of the six in #143 step 3, after `networks/resources.name` (#159). Same
shape, one difference that matters: this one carries a **deliberate behavior
change**, called out below.

## The race

`SavePostureChecks` proves a name is free with a read
(`posture_checks.go:213`) and then writes on the strength of it.
`AcquireWriteLockByUID` makes that true inside one process and false across
two.

Unlike #159, the create path takes no exclusive lock at all — validate, then
save, with no `IncrementNetworkSerial`. That absence is what makes the
invariant vulnerable, and it is also what made it awkward to demonstrate: there
is no row a third transaction can hold to park both replicas inside the window.

**The first version of this test passed**, and the reason is recorded in the
test because the next invariant will meet it too: the barrier aligns the two
*calls*, not the two transactions. Each side then runs permission validation —
several round trips — before opening its transaction, and on a cold connection
pool that offsets one replica past the other's entire transaction. A warm-up
call per replica removes the offset. Without it a green run means nothing.

| control | result |
| --- | --- |
| two replicas, Postgres | **FAIL 3/3** — two posture checks named `contested-posture-check`, both creates accepted |
| one replica | pass 3/3 |

Engine asymmetry as in #159: Postgres persists the duplicate, MySQL refuses the
second insert through InnoDB's gap locks under REPEATABLE READ and hands the
loser a 1213.

## The behavior change, stated plainly

`validatePostureChecks` returns early for anything carrying an ID — it confirms
the row exists and **skips the duplicate-name check** — so renaming a posture
check onto another one's name has been accepted.

That reads as a gap rather than a decision: `openapi.yml` has described the
field as *"Posture check unique name identifier"* since it was introduced, with
no exception for update, and the early return arrived with the refactor to
store methods. So this makes the documented contract true, including on update.

A rename that used to succeed now returns a validation error. There is a test
for exactly that, and its log shows the rejection coming from the index, not
from the manager — the early return is still there.

If that is not wanted, the alternative is to serialize creates only and leave
colliding renames alone, which preserves a behavior the OpenAPI contradicts.

## The fix

`gorm:"size:128"` on `posture.Checks.Name`, validated in runes (the column is
`varchar(128)`, which both engines size in characters, so `len()` would reject
an accented name the database accepts), `maxLength: 128` in `openapi.yml`, and
`idx_posture_checks_account_name` unique on `(account_id, name)` with the
violation classified in the store.

## Two things to know before deploying

1. **The migration fails if the database already holds duplicate posture check
   names in one account** — including duplicate empty strings. Deliberate: the
   application should not be able to create that state today — `Validate`
   rejects an empty name and the only non-test caller of the store is the
   manager, which validates first — so the migration should expose the
   inconsistency for an operator to resolve rather than renaming or dropping
   rows on its own.

   To be precise about what it does *not* do: a single empty name passes. The
   index constrains duplication, not emptiness, and carries no `NOT NULL` or
   `CHECK`. Emptiness is held by `Validate()` on the way in, not by the
   database. (The commit message overstates this as "empty or duplicate"; this
   is the accurate version.)
2. **Case semantics are inherited, not introduced.** The column collates
   `utf8mb4_0900_ai_ci` on MySQL and uses the database default on Postgres, so
   the index treats `Foo` and `foo` exactly as the existing check already does
   on each engine.

That first point is not hypothetical. Fixtures in
`posture_schedule_loader_test.go` and `store/sql_store_test.go` wrote posture
checks straight to the store with no name, so an account held two rows at
`name = ''` and the index refused the second. They now carry names — adjusting the index to tolerate them would
have protected a weaker invariant than the real one because of a test shortcut.

```
create, two replicas, Postgres   3/3 red without the index, green with
create, one replica              3/3 green
update onto a taken name         green — rejected by the index
two replicas on MySQL            pass
./management/server/ -race       ok 210s
./management/server/posture/...  pass
gofmt -s, go vet, go build       clean
```

Refs #143 (step 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

