### PR TITLE
fix(management/account): enforce one primary account per private domain

### DIFF
--- a/management/server/account.go
+++ b/management/server/account.go
@@ -209,12 +209,19 @@ var primaryDomainWinnerBackoff = []time.Duration{
 // primary, retrying briefly while it becomes visible.
 //
 // This is not a retry policy and should not grow into one — that belongs to
-// #157. It resolves one known race, at one call site: the database has already
-// picked a winner for idx_accounts_primary_private_domain, and on MySQL the
-// loser is told so through a gap-lock deadlock raised before the winner has
-// finished committing. There is nothing to decide, only something to wait for,
-// and without the wait the loser's login fails for a conflict that has already
-// been resolved in its favor by joining.
+// #157. It resolves one known race: the database has already picked a winner
+// for idx_accounts_primary_private_domain, and on MySQL the loser can be told
+// so through a gap-lock deadlock raised before the winner has finished
+// committing. There is nothing to decide, only something to wait for, and
+// without the wait the loser's login fails for a conflict that has already
+// been resolved in its favor.
+//
+// Both login paths use it, and must: signup joins the winner it returns, while
+// the existing-login path only needs to know the domain has an owner before
+// writing itself non-primary. Waiting in one and not the other would leave the
+// UPDATE path — where gap locks are most likely — failing on a winner that
+// exists but has not yet committed. UpdateToPrimaryAccount deliberately does
+// not wait: an explicit promotion that lost should be refused, not retried.
 //
 // Gives up on the caller's context, and returns the lookup error when no
 // winner appears within the budget so the caller can report the original
@@ -1354,7 +1361,13 @@ func (am *DefaultAccountManager) updateAccountDomainAttributesIfNotUpToDate(ctx 
 		// simply is not the primary one, which is exactly what the caller
 		// would have written had the lookup seen the winner (#143).
 		if lostPrimaryDomainRace(err) {
-			winnerID, lookupErr := am.Store.GetAccountIDByPrivateDomain(ctx, store.LockingStrengthNone, newDomain)
+			// The same wait the signup path uses, for the same reason. This is
+			// an UPDATE moving a row into the index range, which is where
+			// InnoDB gap locks are most likely to raise 1213 — and 1213 is the
+			// one shape that reports before the winner has committed, so an
+			// immediate lookup can miss a winner that exists and turn this
+			// into a failed login.
+			winnerID, lookupErr := am.waitForPrimaryDomainWinner(ctx, newDomain)
 			if lookupErr != nil {
 				log.WithContext(ctx).Errorf("primary domain conflict for %s but no primary account found: %v", newDomain, lookupErr)
 				return err

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -845,9 +845,13 @@ func (am *DefaultAccountManager) newAccount(ctx context.Context, userID, domain 
 			log.WithContext(ctx).Warnf("an account with ID already exists, retrying...")
 			continue
 		case statusErr.Type() == status.NotFound:
-			newAccount := newAccountWithId(ctx, accountId, userID, domain, am.disableDefaultPolicy)
-			am.StoreEvent(ctx, userID, newAccount.Id, accountId, activity.AccountCreated, nil)
-			return newAccount, nil
+			// No AccountCreated event here. This only builds the account; the
+			// callers store it, and one of them can now lose the account to
+			// idx_accounts_primary_private_domain and join somebody else's
+			// instead. Announcing the creation at construction time would put
+			// account.create in the audit trail for an account ID that never
+			// reached the database.
+			return newAccountWithId(ctx, accountId, userID, domain, am.disableDefaultPolicy), nil
 		default:
 			return nil, err
 		}
@@ -1450,6 +1454,10 @@ func (am *DefaultAccountManager) addNewPrivateAccount(ctx context.Context, domai
 		log.WithContext(ctx).Infof("account for domain %s was created concurrently; joining %s", lowerDomain, winnerID)
 		return am.addNewUserToDomainAccount(ctx, winnerID, userAuth)
 	}
+
+	// Announced only now: the account is in the database, so the audit trail
+	// describes something that exists.
+	am.StoreEvent(ctx, userAuth.UserId, newAccount.Id, newAccount.Id, activity.AccountCreated, nil)
 
 	err = am.addAccountIDToIDPAppMeta(ctx, userAuth.UserId, newAccount.Id)
 	if err != nil {

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -195,6 +195,75 @@ func (am *DefaultAccountManager) SetFlowPolicyIndex(idx FlowPolicyIndex) {
 	am.flowPolicyIndex = idx
 }
 
+// primaryDomainWinnerBackoff is how long the signup path waits for the account
+// that won a contested domain to become visible. Total under a second.
+var primaryDomainWinnerBackoff = []time.Duration{
+	10 * time.Millisecond,
+	25 * time.Millisecond,
+	50 * time.Millisecond,
+	100 * time.Millisecond,
+	200 * time.Millisecond,
+}
+
+// waitForPrimaryDomainWinner looks up the account that claimed domain as
+// primary, retrying briefly while it becomes visible.
+//
+// This is not a retry policy and should not grow into one — that belongs to
+// #157. It resolves one known race, at one call site: the database has already
+// picked a winner for idx_accounts_primary_private_domain, and on MySQL the
+// loser is told so through a gap-lock deadlock raised before the winner has
+// finished committing. There is nothing to decide, only something to wait for,
+// and without the wait the loser's login fails for a conflict that has already
+// been resolved in its favor by joining.
+//
+// Gives up on the caller's context, and returns the lookup error when no
+// winner appears within the budget so the caller can report the original
+// failure instead.
+func (am *DefaultAccountManager) waitForPrimaryDomainWinner(ctx context.Context, domain string) (string, error) {
+	var err error
+	for attempt := 0; ; attempt++ {
+		var winnerID string
+		winnerID, err = am.Store.GetAccountIDByPrivateDomain(ctx, store.LockingStrengthNone, domain)
+		if err == nil {
+			return winnerID, nil
+		}
+		if attempt >= len(primaryDomainWinnerBackoff) {
+			return "", err
+		}
+		select {
+		case <-time.After(primaryDomainWinnerBackoff[attempt]):
+		case <-ctx.Done():
+			return "", ctx.Err()
+		}
+	}
+}
+
+// lostPrimaryDomainRace reports whether err is how a database tells us another
+// account claimed this private domain first.
+//
+// Two shapes, because the engines refuse the second write at different moments.
+// Postgres has no gap locks, so the insert reaches
+// idx_accounts_primary_private_domain and comes back as a unique violation,
+// which the store classifies. MySQL under REPEATABLE READ takes a gap lock on
+// the position the row would occupy, so the two writers deadlock before either
+// insert lands and the loser sees 1213 instead — the same race, reported
+// earlier.
+//
+// Neither error is the answer on its own: what decides is the lookup the caller
+// does next. If no account holds the domain, the caller propagates the original
+// error rather than inventing a winner.
+func lostPrimaryDomainRace(err error) bool {
+	if err == nil {
+		return false
+	}
+	if s, ok := status.FromError(err); ok && s.Type() == status.AlreadyExists {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "Error 1213 (40001)") || // mysql
+		strings.Contains(msg, "SQLSTATE 40P01") // postgres
+}
+
 func isUniqueConstraintError(err error) bool {
 	switch {
 	case strings.Contains(err.Error(), "(SQLSTATE 23505)"),
@@ -1273,7 +1342,25 @@ func (am *DefaultAccountManager) updateAccountDomainAttributesIfNotUpToDate(ctx 
 		newCategoty = userAuth.DomainCategory
 	}
 
-	return am.Store.UpdateAccountDomainAttributes(ctx, accountID, newDomain, newCategoty, primaryDomain)
+	err = am.Store.UpdateAccountDomainAttributes(ctx, accountID, newDomain, newCategoty, primaryDomain)
+	if err != nil {
+		// Another account claimed the domain as primary while this login was
+		// deciding it could. The user stays where they are — this account
+		// simply is not the primary one, which is exactly what the caller
+		// would have written had the lookup seen the winner (#143).
+		if lostPrimaryDomainRace(err) {
+			winnerID, lookupErr := am.Store.GetAccountIDByPrivateDomain(ctx, store.LockingStrengthNone, newDomain)
+			if lookupErr != nil {
+				log.WithContext(ctx).Errorf("primary domain conflict for %s but no primary account found: %v", newDomain, lookupErr)
+				return err
+			}
+			log.WithContext(ctx).Infof("domain %s became primary on account %s concurrently; keeping %s non-primary", newDomain, winnerID, accountID)
+			return am.Store.UpdateAccountDomainAttributes(ctx, accountID, newDomain, newCategoty, false)
+		}
+		return err
+	}
+
+	return nil
 }
 
 // handleExistingUserAccount handles existing User accounts and update its domain attributes.
@@ -1321,9 +1408,29 @@ func (am *DefaultAccountManager) addNewPrivateAccount(ctx context.Context, domai
 	newAccount.DomainCategory = userAuth.DomainCategory
 	newAccount.IsDomainPrimaryAccount = true
 
-	err = am.Store.SaveAccount(ctx, newAccount)
-	if err != nil {
-		return "", err
+	// Another replica can claim this domain between the lookup that sent us
+	// here and this write. getPrivateDomainWithGlobalLock cannot prevent it —
+	// its lock is a mutex inside one process — so the database decides, and
+	// losing is a normal outcome of two people from the same organization
+	// signing in at once. It must not surface as a failed login (#143).
+	// CreateAccount, not SaveAccount: the latter's upsert absorbs the index
+	// violation on MySQL and reports success without writing anything. See the
+	// note on CreateAccount.
+	if err = am.Store.CreateAccount(ctx, newAccount); err != nil {
+		if !lostPrimaryDomainRace(err) {
+			return "", err
+		}
+
+		winnerID, waitErr := am.waitForPrimaryDomainWinner(ctx, lowerDomain)
+		if waitErr != nil {
+			// A conflict with no winner to join is not the race we expect.
+			// Report the original failure rather than inventing an outcome.
+			log.WithContext(ctx).Errorf("primary domain conflict for %s but no primary account appeared: %v", lowerDomain, waitErr)
+			return "", err
+		}
+
+		log.WithContext(ctx).Infof("account for domain %s was created concurrently; joining %s", lowerDomain, winnerID)
+		return am.addNewUserToDomainAccount(ctx, winnerID, userAuth)
 	}
 
 	err = am.addAccountIDToIDPAppMeta(ctx, userAuth.UserId, newAccount.Id)
@@ -2198,14 +2305,28 @@ func (am *DefaultAccountManager) UpdateToPrimaryAccount(ctx context.Context, acc
 			return status.Errorf(status.Internal, "cannot update account to primary")
 		}
 
-		account.IsDomainPrimaryAccount = true
-
-		if err := transaction.SaveAccount(ctx, account); err != nil {
+		// A narrow attribute update rather than SaveAccount: only the flag
+		// changes here, and SaveAccount's upsert would absorb the index
+		// violation on MySQL instead of reporting it.
+		if err := transaction.UpdateAccountDomainAttributes(ctx, accountId,
+			account.Domain, account.DomainCategory, true); err != nil {
+			// Losing the race here means the same thing the pre-check above
+			// reports: another account is already primary for this domain.
+			// Deliberately no retry — unlike the login paths, this is an
+			// explicit promotion, and refusing it is the correct answer
+			// rather than something to work around (#143).
+			if lostPrimaryDomainRace(err) {
+				log.WithContext(ctx).WithFields(log.Fields{
+					"accountId": accountId,
+				}).Infof("cannot update account to primary: another account claimed domain %s concurrently", account.Domain)
+				return err
+			}
 			log.WithContext(ctx).WithFields(log.Fields{
 				"accountId": accountId,
 			}).Errorf("failed to update account to primary: %v", err)
 			return status.Errorf(status.Internal, "failed to update account to primary")
 		}
+		account.IsDomainPrimaryAccount = true
 
 		return nil
 	})

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -244,10 +244,15 @@ func (am *DefaultAccountManager) waitForPrimaryDomainWinner(ctx context.Context,
 // Two shapes, because the engines refuse the second write at different moments.
 // Postgres has no gap locks, so the insert reaches
 // idx_accounts_primary_private_domain and comes back as a unique violation,
-// which the store classifies. MySQL under REPEATABLE READ takes a gap lock on
-// the position the row would occupy, so the two writers deadlock before either
-// insert lands and the loser sees 1213 instead — the same race, reported
-// earlier.
+// which the store classifies into a typed AlreadyExists. MySQL under
+// REPEATABLE READ takes a gap lock on the position the row would occupy, so
+// the two writers deadlock before either insert lands and the loser sees 1213
+// instead — the same race, reported earlier.
+//
+// Deliberately narrow. Postgres deadlocks (SQLSTATE 40P01) are not read here:
+// nothing on this path produces one, and a deadlock raised by unrelated work
+// in the same transaction would otherwise be reclassified as having lost this
+// race — silently joining another account instead of surfacing it.
 //
 // Neither error is the answer on its own: what decides is the lookup the caller
 // does next. If no account holds the domain, the caller propagates the original
@@ -259,9 +264,9 @@ func lostPrimaryDomainRace(err error) bool {
 	if s, ok := status.FromError(err); ok && s.Type() == status.AlreadyExists {
 		return true
 	}
-	msg := err.Error()
-	return strings.Contains(msg, "Error 1213 (40001)") || // mysql
-		strings.Contains(msg, "SQLSTATE 40P01") // postgres
+	// MySQL raises the deadlock before the insert reaches the index, so there
+	// is no typed error to match on.
+	return strings.Contains(err.Error(), "Error 1213 (40001)")
 }
 
 func isUniqueConstraintError(err error) bool {

--- a/management/server/account_created_event_test.go
+++ b/management/server/account_created_event_test.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openzro/openzro/management/server/activity"
+	nbcontext "github.com/openzro/openzro/management/server/context"
+	"github.com/openzro/openzro/management/server/types"
+)
+
+// account.create must describe an account that exists.
+//
+// newAccount used to emit it at construction time, which was close enough to
+// true while the save that followed could not really fail. It can now: the
+// loser of a contested private domain is refused by
+// idx_accounts_primary_private_domain and joins the winner's account instead,
+// so the event would name an account ID that never reached the database — a
+// false record in the audit trail, and in whatever SIEM the activity store
+// feeds.
+//
+// The two halves belong together. On its own, the absence check would pass
+// just as well with events switched off entirely, which is exactly the kind of
+// vacuous assertion this repository has been bitten by; the second half proves
+// events do flow through this setup.
+func TestAccountCreatedEventFollowsTheStore(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("building an account announces nothing", func(t *testing.T) {
+		am, err := createManager(t)
+		require.NoError(t, err)
+
+		account, err := am.newAccount(ctx, "user-not-stored", "unstored.example")
+		require.NoError(t, err)
+
+		// StoreEvent is asynchronous, so absence has to hold over an interval
+		// rather than at one instant.
+		require.Never(t, func() bool {
+			events, getErr := am.eventStore.Get(ctx, account.Id, 0, 100, false)
+			return getErr == nil && len(events) > 0
+		}, 500*time.Millisecond, 50*time.Millisecond,
+			"an account that was never stored must not appear in the audit trail")
+	})
+
+	t.Run("storing one announces it", func(t *testing.T) {
+		am, err := createManager(t)
+		require.NoError(t, err)
+
+		accountID, _, err := am.GetAccountIDFromUserAuth(ctx, nbcontext.UserAuth{
+			UserId:         "user-stored",
+			Domain:         "stored.example",
+			DomainCategory: types.PrivateCategory,
+		})
+		require.NoError(t, err)
+
+		require.Eventually(t, func() bool {
+			events, getErr := am.eventStore.Get(ctx, accountID, 0, 100, false)
+			if getErr != nil {
+				return false
+			}
+			for _, e := range events {
+				if e.Activity == activity.AccountCreated && e.TargetID == accountID {
+					return true
+				}
+			}
+			return false
+		}, 5*time.Second, 50*time.Millisecond,
+			"a stored account must be announced")
+	})
+}

--- a/management/server/account_domain_concurrency_test.go
+++ b/management/server/account_domain_concurrency_test.go
@@ -192,13 +192,44 @@ func TestAccountDomain_ConcurrentExistingLoginAcrossReplicas(t *testing.T) {
 	require.NoError(t, resultA, "an existing user's login must not fail because it lost the primary-domain race")
 	require.NoError(t, resultB, "an existing user's login must not fail because it lost the primary-domain race")
 
-	accounts := r.B.Store.GetAllAccounts(ctx)
+	// Measured from committed state through the other replica's store.
+	seeded := map[string]*types.Account{}
 	primary := 0
-	for _, acc := range accounts {
-		if acc.Domain == domain && acc.IsDomainPrimaryAccount && acc.DomainCategory == types.PrivateCategory {
+	for _, acc := range r.B.Store.GetAllAccounts(ctx) {
+		if strings.EqualFold(acc.Domain, domain) && acc.IsDomainPrimaryAccount && acc.DomainCategory == types.PrivateCategory {
 			primary++
+		}
+		if acc.Id == "existing-account-a" || acc.Id == "existing-account-b" {
+			seeded[acc.Id] = acc
 		}
 	}
 	require.Equal(t, 1, primary,
 		"the domain %q is primary on %d accounts; exactly one may hold it", domain, primary)
+
+	// The count alone would be satisfied by outcomes this path must not
+	// produce: an account losing its domain, a user being moved, or the loser
+	// left unclassified. Unlike signup, nobody joins anybody here — each user
+	// stays where it was and only the primary flag is decided.
+	require.Len(t, seeded, 2, "both seeded accounts must still exist")
+
+	loser := 0
+	for id, acc := range seeded {
+		require.True(t, strings.EqualFold(domain, acc.Domain), "account %s lost the domain", id)
+		require.Equal(t, types.PrivateCategory, acc.DomainCategory,
+			"account %s was left unclassified; the login is what classifies it", id)
+		if !acc.IsDomainPrimaryAccount {
+			loser++
+		}
+	}
+	require.Equal(t, 1, loser, "exactly one of the two accounts must have been written non-primary")
+
+	for userID, accountID := range map[string]string{
+		"existing-user-a": "existing-account-a",
+		"existing-user-b": "existing-account-b",
+	} {
+		user, err := r.B.Store.GetUserByUserID(ctx, store.LockingStrengthNone, userID)
+		require.NoError(t, err)
+		require.Equal(t, accountID, user.AccountID,
+			"%s was moved out of its own account; losing the domain race must not relocate a user", userID)
+	}
 }

--- a/management/server/account_domain_concurrency_test.go
+++ b/management/server/account_domain_concurrency_test.go
@@ -1,0 +1,180 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	nbcontext "github.com/openzro/openzro/management/server/context"
+	"github.com/openzro/openzro/management/server/types"
+)
+
+// The first user of a corporate domain creates the account that every later
+// user of that domain joins. Exactly one account may hold the domain as
+// primary — GetAccountIDByPrivateDomain matches on
+// `domain = ? AND is_domain_primary_account = true AND domain_category =
+// 'private'`, and the rest of onboarding assumes it finds at most one.
+//
+// That is proven by a read and then written on: getPrivateDomainWithGlobalLock
+// looks the domain up, takes AcquireGlobalLock when it finds nothing, looks
+// again, and only then does addNewPrivateAccount create the account with
+// IsDomainPrimaryAccount = true. The second lookup exists precisely because of
+// "simultaneous requests" — but AcquireGlobalLock is s.globalAccountLock, a
+// mutex inside one process. With a second replica it serializes nothing.
+//
+// This is the most reachable of the six invariants in #143 step 3: it does not
+// need an administrator doing something unusual, only two people from the same
+// company signing in for the first time at the same moment, on different
+// replicas. What they get is two primary accounts for one domain, and from
+// then on which one a user lands in depends on which row the lookup returns.
+//
+// The engines differ as in #159 and #160: Postgres persists both, MySQL's gap
+// locks under REPEATABLE READ refuse the second insert. The assertion is what
+// both must satisfy — one account, and both users inside it.
+func TestAccountDomain_ConcurrentFirstLoginAcrossReplicas(t *testing.T) {
+	const domain = "contested-company.example"
+
+	r := newTwoReplicas(t)
+	ctx := context.Background()
+
+	login := func(am *DefaultAccountManager, userID string) <-chan error {
+		errCh := make(chan error, 1)
+		go func() {
+			b := userAuthFor(userID, domain)
+			b.UserId = userID
+			_, _, err := am.GetAccountIDFromUserAuth(ctx, b)
+			errCh <- err
+		}()
+		return errCh
+	}
+
+	// Warm each replica first: the barrier aligns the calls, not the moment
+	// each reaches the database, and a cold pool offsets one past the other.
+	// See the note in posture_check_concurrency_test.go.
+	for i, am := range []*DefaultAccountManager{r.A, r.B} {
+		_, _, err := am.GetAccountIDFromUserAuth(ctx, userAuthFor("warmup-user-"+string(rune('a'+i)), "warmup-"+string(rune('a'+i))+".example"))
+		require.NoError(t, err)
+	}
+
+	errA, errB := login(r.A, "user-a"), login(r.B, "user-b")
+
+	join := func(name string, ch <-chan error) error {
+		t.Helper()
+		select {
+		case err := <-ch:
+			return err
+		case <-time.After(30 * time.Second):
+			t.Fatalf("replica %s never returned from GetAccountIDFromUserAuth", name)
+			return nil
+		}
+	}
+	resultA, resultB := join("A", errA), join("B", errB)
+
+	// Neither user may be turned away: losing the race is not a login failure.
+	require.NoError(t, resultA, "first login on replica A must succeed")
+	require.NoError(t, resultB, "first login on replica B must succeed")
+
+	// Measured from committed state through the other replica's store.
+	accounts := r.B.Store.GetAllAccounts(ctx)
+	primary := 0
+	for _, acc := range accounts {
+		if acc.Domain == domain && acc.IsDomainPrimaryAccount && acc.DomainCategory == types.PrivateCategory {
+			primary++
+		}
+	}
+	require.Equal(t, 1, primary,
+		"the domain %q is primary on %d accounts; exactly one may hold it", domain, primary)
+}
+
+// userAuthFor builds the claims a first login carries for a private domain.
+func userAuthFor(userID, domain string) nbcontext.UserAuth {
+	return nbcontext.UserAuth{
+		UserId:         userID,
+		Domain:         domain,
+		DomainCategory: types.PrivateCategory,
+	}
+}
+
+// TestAccountDomain_ConcurrentExistingLoginAcrossReplicas covers the second
+// login path into the same invariant, and the one that is easiest to miss.
+//
+// handleExistingUserAccount decides
+// `primaryDomain := domainAccountID == "" || userAccountID == domainAccountID`
+// and hands that to UpdateAccountDomainAttributes, which writes domain,
+// domain_category and is_domain_primary_account in a single statement. So a
+// user who already has an account claims the domain as primary whenever the
+// lookup found none — and that lookup is the same one protected by
+// AcquireGlobalLock, a mutex inside one process.
+//
+// The situation this models is real: a domain that was previously
+// unclassified, so several users signed up with accounts of their own, and is
+// later classified as private. The next logins race to claim it.
+//
+// Losing that race must not fail the login. The user whose account does not
+// win should simply end up non-primary, which is what the code already does
+// when the lookup does find a primary.
+func TestAccountDomain_ConcurrentExistingLoginAcrossReplicas(t *testing.T) {
+	const domain = "reclassified-company.example"
+
+	r := newTwoReplicas(t)
+	ctx := context.Background()
+
+	// Two users who already have accounts on that domain, neither primary —
+	// the state a previously unclassified domain leaves behind.
+	for _, seed := range []struct{ accountID, userID string }{
+		{"existing-account-a", "existing-user-a"},
+		{"existing-account-b", "existing-user-b"},
+	} {
+		account := newAccountWithId(ctx, seed.accountID, seed.userID, domain, false)
+		// Previously unclassified: the category is what the login will update,
+		// and updateAccountDomainAttributesIfNotUpToDate returns early when the
+		// account already matches the claims.
+		account.DomainCategory = ""
+		account.IsDomainPrimaryAccount = false
+		require.NoError(t, r.A.Store.SaveAccount(ctx, account))
+	}
+
+	login := func(am *DefaultAccountManager, userID string) <-chan error {
+		errCh := make(chan error, 1)
+		go func() {
+			_, _, err := am.GetAccountIDFromUserAuth(ctx, userAuthFor(userID, domain))
+			errCh <- err
+		}()
+		return errCh
+	}
+
+	for i, am := range []*DefaultAccountManager{r.A, r.B} {
+		_, _, err := am.GetAccountIDFromUserAuth(ctx,
+			userAuthFor("warm-existing-"+string(rune('a'+i)), "warm-existing-"+string(rune('a'+i))+".example"))
+		require.NoError(t, err)
+	}
+
+	errA, errB := login(r.A, "existing-user-a"), login(r.B, "existing-user-b")
+
+	join := func(name string, ch <-chan error) error {
+		t.Helper()
+		select {
+		case err := <-ch:
+			return err
+		case <-time.After(30 * time.Second):
+			t.Fatalf("replica %s never returned from GetAccountIDFromUserAuth", name)
+			return nil
+		}
+	}
+	resultA, resultB := join("A", errA), join("B", errB)
+
+	require.NoError(t, resultA, "an existing user's login must not fail because it lost the primary-domain race")
+	require.NoError(t, resultB, "an existing user's login must not fail because it lost the primary-domain race")
+
+	accounts := r.B.Store.GetAllAccounts(ctx)
+	primary := 0
+	for _, acc := range accounts {
+		if acc.Domain == domain && acc.IsDomainPrimaryAccount && acc.DomainCategory == types.PrivateCategory {
+			primary++
+		}
+	}
+	require.Equal(t, 1, primary,
+		"the domain %q is primary on %d accounts; exactly one may hold it", domain, primary)
+}

--- a/management/server/account_domain_concurrency_test.go
+++ b/management/server/account_domain_concurrency_test.go
@@ -2,12 +2,14 @@ package server
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
 	nbcontext "github.com/openzro/openzro/management/server/context"
+	"github.com/openzro/openzro/management/server/store"
 	"github.com/openzro/openzro/management/server/types"
 )
 
@@ -39,15 +41,19 @@ func TestAccountDomain_ConcurrentFirstLoginAcrossReplicas(t *testing.T) {
 	r := newTwoReplicas(t)
 	ctx := context.Background()
 
-	login := func(am *DefaultAccountManager, userID string) <-chan error {
-		errCh := make(chan error, 1)
+	type loginResult struct {
+		accountID string
+		err       error
+	}
+	login := func(am *DefaultAccountManager, userID string) <-chan loginResult {
+		resCh := make(chan loginResult, 1)
 		go func() {
 			b := userAuthFor(userID, domain)
 			b.UserId = userID
-			_, _, err := am.GetAccountIDFromUserAuth(ctx, b)
-			errCh <- err
+			accountID, _, err := am.GetAccountIDFromUserAuth(ctx, b)
+			resCh <- loginResult{accountID: accountID, err: err}
 		}()
-		return errCh
+		return resCh
 	}
 
 	// Warm each replica first: the barrier aligns the calls, not the moment
@@ -60,32 +66,46 @@ func TestAccountDomain_ConcurrentFirstLoginAcrossReplicas(t *testing.T) {
 
 	errA, errB := login(r.A, "user-a"), login(r.B, "user-b")
 
-	join := func(name string, ch <-chan error) error {
+	join := func(name string, ch <-chan loginResult) loginResult {
 		t.Helper()
 		select {
-		case err := <-ch:
-			return err
+		case res := <-ch:
+			return res
 		case <-time.After(30 * time.Second):
 			t.Fatalf("replica %s never returned from GetAccountIDFromUserAuth", name)
-			return nil
+			return loginResult{}
 		}
 	}
 	resultA, resultB := join("A", errA), join("B", errB)
 
 	// Neither user may be turned away: losing the race is not a login failure.
-	require.NoError(t, resultA, "first login on replica A must succeed")
-	require.NoError(t, resultB, "first login on replica B must succeed")
+	require.NoError(t, resultA.err, "first login on replica A must succeed")
+	require.NoError(t, resultB.err, "first login on replica B must succeed")
 
 	// Measured from committed state through the other replica's store.
 	accounts := r.B.Store.GetAllAccounts(ctx)
-	primary := 0
+	var primaryIDs []string
 	for _, acc := range accounts {
-		if acc.Domain == domain && acc.IsDomainPrimaryAccount && acc.DomainCategory == types.PrivateCategory {
-			primary++
+		if strings.EqualFold(acc.Domain, domain) && acc.IsDomainPrimaryAccount && acc.DomainCategory == types.PrivateCategory {
+			primaryIDs = append(primaryIDs, acc.Id)
 		}
 	}
-	require.Equal(t, 1, primary,
-		"the domain %q is primary on %d accounts; exactly one may hold it", domain, primary)
+	require.Len(t, primaryIDs, 1,
+		"the domain %q is primary on %d accounts %v; exactly one may hold it", domain, len(primaryIDs), primaryIDs)
+
+	// Counting primaries is not enough on its own. The failure mode measured
+	// on MySQL (#161) is a save that reports success and writes nothing: the
+	// loser is told it has an account, one primary row exists, and the count
+	// above is satisfied while that user has in fact been dropped. What
+	// separates the two is where each caller was sent.
+	require.Equal(t, primaryIDs[0], resultA.accountID, "replica A was sent to an account that does not hold the domain")
+	require.Equal(t, primaryIDs[0], resultB.accountID, "replica B was sent to an account that does not hold the domain")
+
+	for _, userID := range []string{"user-a", "user-b"} {
+		user, err := r.B.Store.GetUserByUserID(ctx, store.LockingStrengthNone, userID)
+		require.NoError(t, err, "%s has no user row; the losing login returned an account it was never added to", userID)
+		require.Equal(t, primaryIDs[0], user.AccountID, "%s landed outside the account that holds the domain", userID)
+	}
 }
 
 // userAuthFor builds the claims a first login carries for a private domain.

--- a/management/server/account_domain_concurrency_test.go
+++ b/management/server/account_domain_concurrency_test.go
@@ -45,9 +45,11 @@ func TestAccountDomain_ConcurrentFirstLoginAcrossReplicas(t *testing.T) {
 		accountID string
 		err       error
 	}
+	align := newBarrier()
 	login := func(am *DefaultAccountManager, userID string) <-chan loginResult {
 		resCh := make(chan loginResult, 1)
 		go func() {
+			align.wait(t)
 			b := userAuthFor(userID, domain)
 			b.UserId = userID
 			accountID, _, err := am.GetAccountIDFromUserAuth(ctx, b)
@@ -156,9 +158,11 @@ func TestAccountDomain_ConcurrentExistingLoginAcrossReplicas(t *testing.T) {
 		require.NoError(t, r.A.Store.SaveAccount(ctx, account))
 	}
 
+	align := newBarrier()
 	login := func(am *DefaultAccountManager, userID string) <-chan error {
 		errCh := make(chan error, 1)
 		go func() {
+			align.wait(t)
 			_, _, err := am.GetAccountIDFromUserAuth(ctx, userAuthFor(userID, domain))
 			errCh <- err
 		}()

--- a/management/server/account_domain_race_test.go
+++ b/management/server/account_domain_race_test.go
@@ -1,0 +1,134 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/rs/xid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openzro/openzro/management/server/status"
+	"github.com/openzro/openzro/management/server/store"
+	"github.com/openzro/openzro/management/server/types"
+)
+
+// The concurrent paths reach lostPrimaryDomainRace through whichever shape the
+// engine happens to raise, and after the signup path moved to CreateAccount
+// every measured conflict — both engines, both paths — arrives as the typed
+// AlreadyExists. A plain INSERT blocks until the winner commits and then
+// reports a duplicate key; the upsert it replaced deadlocked instead.
+//
+// So the MySQL deadlock branch is a contingency that the cross-replica tests no
+// longer exercise. It is kept because InnoDB gap locks under REPEATABLE READ
+// are a real mechanism for this predicate and were observed on this path
+// earlier in this work, but a branch no test reaches is a branch nobody can
+// trust. This pins it directly.
+func TestLostPrimaryDomainRace(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "no error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "the typed violation the store classifies, and what both engines actually raise",
+			err:  status.NewPrimaryPrivateDomainExistsError("contested.example"),
+			want: true,
+		},
+		{
+			name: "the mysql gap-lock deadlock, which arrives untyped",
+			err:  errors.New("Error 1213 (40001): Deadlock found when trying to get lock; try restarting transaction"),
+			want: true,
+		},
+		{
+			// Postgres has no gap locks on this path, so a deadlock here comes
+			// from unrelated work in the same transaction. Reading it as a lost
+			// domain race would silently send the caller into another account.
+			name: "a postgres deadlock, which is not this race",
+			err:  errors.New("ERROR: deadlock detected (SQLSTATE 40P01)"),
+			want: false,
+		},
+		{
+			name: "an unrelated failure",
+			err:  status.Errorf(status.Internal, "failed to create account in store"),
+			want: false,
+		},
+		{
+			name: "a different typed error",
+			err:  status.NewAccountNotFoundError("acc-1"),
+			want: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, lostPrimaryDomainRace(tc.err))
+		})
+	}
+}
+
+// waitForPrimaryDomainWinner exists for the deadlock shape above: it is the
+// only one that tells the loser it lost before the winner has committed, so an
+// immediate lookup finds nothing. With CreateAccount the winner is always
+// already visible and the loop returns on its first attempt, which is what the
+// cross-replica runs measure. This drives the other case.
+func TestWaitForPrimaryDomainWinner(t *testing.T) {
+	ctx := context.Background()
+	const domain = "late-winner.example"
+
+	t.Run("returns the winner once it becomes visible", func(t *testing.T) {
+		s, cleanup, err := store.NewTestStoreFromSQL(ctx, "", t.TempDir())
+		t.Cleanup(cleanup)
+		require.NoError(t, err)
+
+		am := &DefaultAccountManager{Store: s}
+
+		winner := &types.Account{
+			Id:                     xid.New().String(),
+			Domain:                 domain,
+			DomainCategory:         types.PrivateCategory,
+			IsDomainPrimaryAccount: true,
+			Network:                types.NewNetwork(),
+		}
+		// Lands after the first attempt has already missed.
+		go func() {
+			time.Sleep(20 * time.Millisecond)
+			_ = s.CreateAccount(ctx, winner)
+		}()
+
+		got, err := am.waitForPrimaryDomainWinner(ctx, domain)
+		require.NoError(t, err, "the winner committed inside the budget and must be found")
+		require.Equal(t, winner.Id, got)
+	})
+
+	t.Run("gives up rather than inventing a winner", func(t *testing.T) {
+		s, cleanup, err := store.NewTestStoreFromSQL(ctx, "", t.TempDir())
+		t.Cleanup(cleanup)
+		require.NoError(t, err)
+
+		am := &DefaultAccountManager{Store: s}
+
+		start := time.Now()
+		_, err = am.waitForPrimaryDomainWinner(ctx, "nobody-owns-this.example")
+		require.Error(t, err, "no account holds the domain; the caller has to report its original failure")
+		require.Less(t, time.Since(start), time.Second, "the wait must stay under a second in total")
+	})
+
+	t.Run("gives up on the caller's context", func(t *testing.T) {
+		s, cleanup, err := store.NewTestStoreFromSQL(ctx, "", t.TempDir())
+		t.Cleanup(cleanup)
+		require.NoError(t, err)
+
+		am := &DefaultAccountManager{Store: s}
+
+		canceledCtx, cancel := context.WithCancel(ctx)
+		cancel()
+
+		_, err = am.waitForPrimaryDomainWinner(canceledCtx, "nobody-owns-this.example")
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}

--- a/management/server/account_domain_race_test.go
+++ b/management/server/account_domain_race_test.go
@@ -112,10 +112,21 @@ func TestWaitForPrimaryDomainWinner(t *testing.T) {
 
 		am := &DefaultAccountManager{Store: s}
 
+		var budget time.Duration
+		for _, d := range primaryDomainWinnerBackoff {
+			budget += d
+		}
+		require.Less(t, budget, time.Second, "the backoff schedule must stay under a second in total")
+
 		start := time.Now()
 		_, err = am.waitForPrimaryDomainWinner(ctx, "nobody-owns-this.example")
+		elapsed := time.Since(start)
 		require.Error(t, err, "no account holds the domain; the caller has to report its original failure")
-		require.Less(t, time.Since(start), time.Second, "the wait must stay under a second in total")
+		// Derived from the schedule rather than a wall-clock ceiling: asserting
+		// it finished "within a second" would measure the machine, and the
+		// budget itself is checked above. This checks it actually waited out
+		// every attempt instead of giving up early.
+		require.GreaterOrEqual(t, elapsed, budget, "gave up before exhausting the backoff")
 	})
 
 	t.Run("gives up on the caller's context", func(t *testing.T) {

--- a/management/server/migration/migration.go
+++ b/management/server/migration/migration.go
@@ -440,3 +440,107 @@ func CreateIndexIfNotExists[T any](ctx context.Context, db *gorm.DB, indexName s
 	log.WithContext(ctx).Infof("successfully created index %s on table %s", indexName, tableName)
 	return nil
 }
+
+// PrimaryPrivateDomainIndex is the name of the unique index that keeps a
+// private domain primary on at most one account. Exported so callers can tell
+// a violation of this rule apart from any other unique constraint the accounts
+// table may grow.
+const PrimaryPrivateDomainIndex = "idx_accounts_primary_private_domain"
+
+// primaryPrivateDomainColumn is the generated column MySQL needs to express
+// that index; the other engines use a partial index and add no column.
+const primaryPrivateDomainColumn = "primary_private_domain"
+
+// CreatePrimaryPrivateDomainUniqueIndexIfNotExists enforces, in the database,
+// that at most one account holds a given private domain as primary.
+//
+// The rule is the one GetAccountIDByPrivateDomain reads:
+//
+//	domain = ? AND is_domain_primary_account = true AND domain_category = 'private'
+//
+// It is keyed on LOWER(domain) rather than the column, deliberately. The lookup
+// lowercases what it searches for (sql_store.go), and the signup path stores a
+// lowercased domain — but the third writer does not:
+// updateAccountDomainAttributesIfNotUpToDate rewrites whatever the account
+// already had unless an admin is changing it. Indexing the raw column would let
+// "Foo.com" and "foo.com" both be primary while the lookup, searching in lower
+// case, would only ever find one of them.
+//
+// Deliberately not folded into CreateIndexIfNotExists: this needs a different
+// statement per dialect, and a general conditional-index helper is more
+// machinery than one invariant justifies.
+//
+// It fails when the data already violates the rule. That is the point — the
+// operator has to decide which account keeps the domain. See the pull request
+// for the query that finds them.
+func CreatePrimaryPrivateDomainUniqueIndexIfNotExists[T any](ctx context.Context, db *gorm.DB) error {
+	var account T
+	if !db.Migrator().HasTable(&account) {
+		log.WithContext(ctx).Debugf("table for %T does not exist, no migration needed", account)
+		return nil
+	}
+	if db.Migrator().HasIndex(&account, PrimaryPrivateDomainIndex) {
+		log.WithContext(ctx).Infof("index %s already exists", PrimaryPrivateDomainIndex)
+		return nil
+	}
+
+	stmt := &gorm.Statement{DB: db}
+	if err := stmt.Parse(&account); err != nil {
+		return fmt.Errorf("parse model schema: %w", err)
+	}
+	table := stmt.Schema.Table
+
+	switch dialect := db.Dialector.Name(); dialect {
+	case "postgres":
+		// is_domain_primary_account is boolean here, so it stands alone.
+		return execIndex(ctx, db, fmt.Sprintf(
+			`CREATE UNIQUE INDEX IF NOT EXISTS %s ON %s (LOWER(domain))
+			 WHERE is_domain_primary_account AND domain_category = 'private'`,
+			PrimaryPrivateDomainIndex, table))
+
+	case "sqlite":
+		// Partial indexes exist here too, but the flag is stored as an
+		// integer, so it has to be compared explicitly.
+		return execIndex(ctx, db, fmt.Sprintf(
+			`CREATE UNIQUE INDEX IF NOT EXISTS %s ON %s (LOWER(domain))
+			 WHERE is_domain_primary_account = 1 AND domain_category = 'private'`,
+			PrimaryPrivateDomainIndex, table))
+
+	case "mysql":
+		// No filtered indexes. A stored generated column carries the domain
+		// only for rows inside the predicate and NULL for the rest, and NULLs
+		// repeat freely in a unique index. varchar(191) matches the domain
+		// column's own width.
+		//
+		// The column is intentionally absent from types.Account: it is a
+		// physical detail of expressing this index on MySQL, not a property of
+		// the domain model, and GORM's AutoMigrate leaves unknown columns
+		// alone.
+		if !db.Migrator().HasColumn(&account, primaryPrivateDomainColumn) {
+			if err := db.Exec(fmt.Sprintf(
+				`ALTER TABLE %s ADD COLUMN %s VARCHAR(191)
+				 GENERATED ALWAYS AS (
+				   CASE WHEN is_domain_primary_account = 1 AND domain_category = 'private'
+				        THEN LOWER(domain) ELSE NULL END
+				 ) STORED`, table, primaryPrivateDomainColumn)).Error; err != nil {
+				return fmt.Errorf("add %s column: %w", primaryPrivateDomainColumn, err)
+			}
+			log.WithContext(ctx).Infof("added generated column %s", primaryPrivateDomainColumn)
+		}
+		return execIndex(ctx, db, fmt.Sprintf(
+			"CREATE UNIQUE INDEX %s ON %s (%s)",
+			PrimaryPrivateDomainIndex, table, primaryPrivateDomainColumn))
+
+	default:
+		return fmt.Errorf("unsupported dialect %q for %s", dialect, PrimaryPrivateDomainIndex)
+	}
+}
+
+func execIndex(ctx context.Context, db *gorm.DB, stmt string) error {
+	log.WithContext(ctx).Infof("executing index creation: %s", stmt)
+	if err := db.Exec(stmt).Error; err != nil {
+		return fmt.Errorf("create %s: %w", PrimaryPrivateDomainIndex, err)
+	}
+	log.WithContext(ctx).Infof("successfully created index %s", PrimaryPrivateDomainIndex)
+	return nil
+}

--- a/management/server/status/error.go
+++ b/management/server/status/error.go
@@ -164,6 +164,14 @@ func NewGroupNotFoundError(groupID string) error {
 	return Errorf(NotFound, "group: %s not found", groupID)
 }
 
+// NewPrimaryPrivateDomainExistsError creates a new Error for a private domain
+// already held as primary by another account. Returned by the store when
+// idx_accounts_primary_private_domain refuses the write, which is how a
+// concurrent first login from the same organization loses the race.
+func NewPrimaryPrivateDomainExistsError(domain string) error {
+	return Errorf(AlreadyExists, "another account is already primary for domain %s", domain)
+}
+
 // NewPostureCheckNameAlreadyExistsError creates a new Error for a posture check
 // name already taken in the account. Returned both by the manager's own check
 // and by the store when the unique index refuses the write, so the loser of a

--- a/management/server/store/primary_domain_index_test.go
+++ b/management/server/store/primary_domain_index_test.go
@@ -128,3 +128,48 @@ func TestCreateAccountReportsPrimaryDomainConflict(t *testing.T) {
 	_, err = store.GetAccount(ctx, loser.Id)
 	require.Error(t, err, "the refused account must not have been created")
 }
+
+// The index normalizes with LOWER(domain); the lookups have to agree.
+//
+// A row stored as "MixedCase.Example" occupies the lowercase slot in the
+// index, so the database counts it as the primary account for
+// "mixedcase.example". If GetAccountIDByPrivateDomain compares the raw column
+// it will not find that row on Postgres or SQLite, where = is case sensitive,
+// and the caller concludes the domain is free. It then writes, the index
+// refuses it, and the retry looks for a winner that the lookup still cannot
+// see — turning a domain that has an owner into a failed login.
+//
+// Mixed case reaches the column from data written before the domain was
+// normalized on the way in, not from a live writer: signup lowercases, and
+// updateAccountDomainAttributesIfNotUpToDate lowercases what it sets. It
+// carries forward whatever the account already had, which is how an old row
+// survives every later login.
+func TestPrivateDomainLookupsMatchTheIndex(t *testing.T) {
+	ctx := context.Background()
+
+	store, cleanup, err := NewTestStoreFromSQL(ctx, "", t.TempDir())
+	t.Cleanup(cleanup)
+	require.NoError(t, err)
+
+	mixed := "MixedCase.Example"
+	account := &types.Account{
+		Id:                     xid.New().String(),
+		Domain:                 mixed,
+		DomainCategory:         types.PrivateCategory,
+		IsDomainPrimaryAccount: true,
+		Network:                types.NewNetwork(),
+	}
+	require.NoError(t, store.CreateAccount(ctx, account))
+
+	t.Run("GetAccountIDByPrivateDomain finds it", func(t *testing.T) {
+		id, err := store.GetAccountIDByPrivateDomain(ctx, LockingStrengthNone, "mixedcase.example")
+		require.NoError(t, err, "the index owns this domain but the lookup cannot see the owner")
+		require.Equal(t, account.Id, id)
+	})
+
+	t.Run("CountAccountsByPrivateDomain counts it", func(t *testing.T) {
+		count, err := store.CountAccountsByPrivateDomain(ctx, "mixedcase.example")
+		require.NoError(t, err)
+		require.EqualValues(t, 1, count)
+	})
+}

--- a/management/server/store/primary_domain_index_test.go
+++ b/management/server/store/primary_domain_index_test.go
@@ -1,0 +1,130 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rs/xid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openzro/openzro/management/server/types"
+)
+
+// idx_accounts_primary_private_domain has a different shape on every engine: a
+// partial index on Postgres and SQLite, a stored generated column plus a plain
+// unique index on MySQL. The cross-replica tests that motivated it run only on
+// Postgres and MySQL, because SQLite serializes on a single connection and
+// cannot exhibit the race — which would leave the SQLite DDL written but never
+// executed.
+//
+// So this exercises the index directly instead of through a race: does the
+// database refuse the second account, and does it refuse only the rows the
+// predicate covers.
+//
+// Through CreateAccount rather than SaveAccount, deliberately. SaveAccount's
+// upsert absorbs the violation on MySQL and reports success — see
+// TestCreateAccountReportsPrimaryDomainConflict below. Asserting the index
+// through SaveAccount would measure the upsert, not the index.
+func TestPrimaryPrivateDomainIndex(t *testing.T) {
+	ctx := context.Background()
+
+	newAccount := func(domain, category string, primary bool) *types.Account {
+		return &types.Account{
+			Id:                     xid.New().String(),
+			Domain:                 domain,
+			DomainCategory:         category,
+			IsDomainPrimaryAccount: primary,
+			Network:                types.NewNetwork(),
+		}
+	}
+
+	t.Run("a second primary private account for the same domain is refused", func(t *testing.T) {
+		store, cleanup, err := NewTestStoreFromSQL(ctx, "", t.TempDir())
+		t.Cleanup(cleanup)
+		require.NoError(t, err)
+
+		require.NoError(t, store.CreateAccount(ctx, newAccount("contested.example", types.PrivateCategory, true)))
+
+		err = store.CreateAccount(ctx, newAccount("contested.example", types.PrivateCategory, true))
+		require.Error(t, err, "the index must refuse a second primary account for the domain")
+	})
+
+	t.Run("the domain is compared case-insensitively", func(t *testing.T) {
+		store, cleanup, err := NewTestStoreFromSQL(ctx, "", t.TempDir())
+		t.Cleanup(cleanup)
+		require.NoError(t, err)
+
+		require.NoError(t, store.CreateAccount(ctx, newAccount("mixedcase.example", types.PrivateCategory, true)))
+
+		// The lookup lowercases what it searches for, but not every writer
+		// lowercases what it stores. Keying the index on LOWER(domain) is what
+		// stops "Foo.com" and "foo.com" from both being primary while the
+		// lookup can only ever find one of them.
+		err = store.CreateAccount(ctx, newAccount("MixedCase.Example", types.PrivateCategory, true))
+		require.Error(t, err, "the index must treat the domain case-insensitively")
+	})
+
+	// The negative cases matter as much: an index that refuses too much would
+	// break accounts that are legitimately allowed to share a domain.
+	t.Run("rows outside the predicate may share the domain", func(t *testing.T) {
+		for _, tc := range []struct {
+			name     string
+			category string
+			primary  bool
+		}{
+			{"private but not primary", types.PrivateCategory, false},
+			{"primary but not private", "public", true},
+			{"neither", "public", false},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				store, cleanup, err := NewTestStoreFromSQL(ctx, "", t.TempDir())
+				t.Cleanup(cleanup)
+				require.NoError(t, err)
+
+				require.NoError(t, store.CreateAccount(ctx, newAccount("shared.example", types.PrivateCategory, true)))
+				require.NoError(t, store.CreateAccount(ctx, newAccount("shared.example", tc.category, tc.primary)),
+					"the index must not constrain rows outside its predicate")
+			})
+		}
+	})
+}
+
+// TestCreateAccountReportsPrimaryDomainConflict guards the trap the tests above
+// walked past.
+//
+// SaveAccount carries clause.OnConflict{UpdateAll: true}. Postgres renders that
+// with the primary key as the conflict target, so a violation of any other
+// unique index still surfaces. MySQL renders ON DUPLICATE KEY UPDATE, which has
+// no target and absorbs every unique key — so SaveAccount returns nil, writes
+// nothing, and hands the caller an account id for a row that does not exist.
+//
+// That is worse than a duplicate and completely silent, which is why creation
+// paths that can collide on idx_accounts_primary_private_domain use
+// CreateAccount instead. This asserts both halves: the conflict is reported,
+// and the account really was not created.
+func TestCreateAccountReportsPrimaryDomainConflict(t *testing.T) {
+	ctx := context.Background()
+
+	store, cleanup, err := NewTestStoreFromSQL(ctx, "", t.TempDir())
+	t.Cleanup(cleanup)
+	require.NoError(t, err)
+
+	winner := &types.Account{
+		Id: xid.New().String(), Domain: "conflict.example",
+		DomainCategory: types.PrivateCategory, IsDomainPrimaryAccount: true, Network: types.NewNetwork(),
+	}
+	require.NoError(t, store.CreateAccount(ctx, winner))
+
+	loser := &types.Account{
+		Id: xid.New().String(), Domain: "conflict.example",
+		DomainCategory: types.PrivateCategory, IsDomainPrimaryAccount: true, Network: types.NewNetwork(),
+	}
+	err = store.CreateAccount(ctx, loser)
+	require.Error(t, err, "creating a second primary account for the domain must be reported, never absorbed")
+
+	// The account the caller was told about must not exist. A nil error with a
+	// missing row is the failure mode this test exists for; so is an error with
+	// the row written anyway.
+	_, err = store.GetAccount(ctx, loser.Id)
+	require.Error(t, err, "the refused account must not have been created")
+}

--- a/management/server/store/primary_domain_index_test.go
+++ b/management/server/store/primary_domain_index_test.go
@@ -161,15 +161,21 @@ func TestPrivateDomainLookupsMatchTheIndex(t *testing.T) {
 	}
 	require.NoError(t, store.CreateAccount(ctx, account))
 
-	t.Run("GetAccountIDByPrivateDomain finds it", func(t *testing.T) {
-		id, err := store.GetAccountIDByPrivateDomain(ctx, LockingStrengthNone, "mixedcase.example")
-		require.NoError(t, err, "the index owns this domain but the lookup cannot see the owner")
-		require.Equal(t, account.Id, id)
-	})
+	// Both spellings, because two different normalizations have to agree: the
+	// caller's argument is lowercased in Go, and the column is lowercased in
+	// SQL. Searching only in lower case would exercise the second and leave
+	// the first unproven.
+	for _, searched := range []string{"mixedcase.example", "MIXEDCASE.EXAMPLE", "MixedCase.Example"} {
+		t.Run("GetAccountIDByPrivateDomain finds it, searching "+searched, func(t *testing.T) {
+			id, err := store.GetAccountIDByPrivateDomain(ctx, LockingStrengthNone, searched)
+			require.NoError(t, err, "the index owns this domain but the lookup cannot see the owner")
+			require.Equal(t, account.Id, id)
+		})
 
-	t.Run("CountAccountsByPrivateDomain counts it", func(t *testing.T) {
-		count, err := store.CountAccountsByPrivateDomain(ctx, "mixedcase.example")
-		require.NoError(t, err)
-		require.EqualValues(t, 1, count)
-	})
+		t.Run("CountAccountsByPrivateDomain counts it, searching "+searched, func(t *testing.T) {
+			count, err := store.CountAccountsByPrivateDomain(ctx, searched)
+			require.NoError(t, err)
+			require.EqualValues(t, 1, count)
+		})
+	}
 }

--- a/management/server/store/sql_store.go
+++ b/management/server/store/sql_store.go
@@ -24,6 +24,7 @@ import (
 	"gorm.io/gorm/logger"
 
 	nbdns "github.com/openzro/openzro/dns"
+	"github.com/openzro/openzro/management/server/migration"
 	resourceTypes "github.com/openzro/openzro/management/server/networks/resources/types"
 	routerTypes "github.com/openzro/openzro/management/server/networks/routers/types"
 	networkTypes "github.com/openzro/openzro/management/server/networks/types"
@@ -178,6 +179,37 @@ func (s *SqlStore) AcquireReadLockByUID(ctx context.Context, uniqueID string) (u
 	return unlock
 }
 
+// CreateAccount inserts a brand new account, and fails if anything already in
+// the database refuses it.
+//
+// Deliberately not SaveAccount. That one carries
+// clause.OnConflict{UpdateAll: true}, which Postgres renders with the primary
+// key as its conflict target — so a violation of any other unique index still
+// surfaces — while MySQL renders ON DUPLICATE KEY UPDATE, which has no target
+// and absorbs *every* unique key. A SaveAccount that collides with
+// idx_accounts_primary_private_domain on MySQL therefore returns nil while
+// creating nothing, and the caller is handed an account id for a row that does
+// not exist.
+//
+// Creation paths that can collide on that index have to insert plainly instead,
+// so losing the race is reported rather than swallowed. SaveAccount is left as
+// it is for the paths that genuinely mean "write this account, whatever is
+// there" — see #143.
+func (s *SqlStore) CreateAccount(ctx context.Context, account *types.Account) error {
+	generateAccountSQLTypes(account)
+
+	err := s.db.Session(&gorm.Session{FullSaveAssociations: true}).Create(account).Error
+	if err != nil {
+		log.WithContext(ctx).Errorf("failed to create account in store: %v", err)
+		if isPrimaryPrivateDomainViolation(err) {
+			return status.NewPrimaryPrivateDomainExistsError(account.Domain)
+		}
+		return status.Errorf(status.Internal, "failed to create account in store")
+	}
+
+	return nil
+}
+
 func (s *SqlStore) SaveAccount(ctx context.Context, account *types.Account) error {
 	start := time.Now()
 	defer func() {
@@ -223,6 +255,10 @@ func (s *SqlStore) SaveAccount(ctx context.Context, account *types.Account) erro
 		s.metrics.StoreMetrics().CountPersistenceDuration(took)
 	}
 	log.WithContext(ctx).Debugf("took %d ms to persist an account to the store", took.Milliseconds())
+
+	if isPrimaryPrivateDomainViolation(err) {
+		return status.NewPrimaryPrivateDomainExistsError(account.Domain)
+	}
 
 	return err
 }
@@ -383,6 +419,9 @@ func (s *SqlStore) UpdateAccountDomainAttributes(ctx context.Context, accountID 
 		Where(idQueryCondition, accountID).
 		Updates(&accountCopy)
 	if result.Error != nil {
+		if isPrimaryPrivateDomainViolation(result.Error) {
+			return status.NewPrimaryPrivateDomainExistsError(domain)
+		}
 		return status.Errorf(status.Internal, "failed to update account domain attributes to store: %v", result.Error)
 	}
 
@@ -2781,6 +2820,21 @@ func (s *SqlStore) SaveNetworkResource(ctx context.Context, lockStrength Locking
 	}
 
 	return nil
+}
+
+// isPrimaryPrivateDomainViolation reports whether err is the database refusing
+// a second account claiming the same private domain as primary.
+//
+// Matched on the index name rather than on "some unique violation": the
+// accounts table may grow other unique constraints, and attributing all of
+// them to the domain would report the wrong thing. The engines each name the
+// offending index in their message — Postgres and MySQL directly, SQLite as
+// "index 'name'".
+func isPrimaryPrivateDomainViolation(err error) bool {
+	if err == nil || !isUniqueConstraintViolation(err) {
+		return false
+	}
+	return strings.Contains(err.Error(), migration.PrimaryPrivateDomainIndex)
 }
 
 // isUniqueConstraintViolation reports whether err is the database refusing a

--- a/management/server/store/sql_store.go
+++ b/management/server/store/sql_store.go
@@ -549,9 +549,14 @@ func (s *SqlStore) GetAccountIDByPrivateDomain(ctx context.Context, lockStrength
 		tx = tx.Clauses(clause.Locking{Strength: string(lockStrength)})
 	}
 
+	// LOWER(domain), not the column: idx_accounts_primary_private_domain is
+	// keyed that way, so a row stored as "MixedCase.Example" owns the
+	// "mixedcase.example" slot in the index. Comparing the raw column would not
+	// find that row on Postgres or SQLite, where = is case sensitive, and the
+	// caller would conclude a domain that has an owner is free.
 	var accountID string
 	result := tx.Model(&types.Account{}).Select("id").
-		Where("domain = ? and is_domain_primary_account = ? and domain_category = ?",
+		Where("LOWER(domain) = ? and is_domain_primary_account = ? and domain_category = ?",
 			strings.ToLower(domain), true, types.PrivateCategory,
 		).First(&accountID)
 	if result.Error != nil {
@@ -3009,8 +3014,11 @@ func (s *SqlStore) GetPeerIdByLabel(ctx context.Context, lockStrength LockingStr
 
 func (s *SqlStore) CountAccountsByPrivateDomain(ctx context.Context, domain string) (int64, error) {
 	var count int64
+	// Same normalization as GetAccountIDByPrivateDomain and the index; see
+	// there. A count that disagrees with the lookup would report a domain as
+	// unused while an account holds it.
 	result := s.db.Model(&types.Account{}).
-		Where("domain = ? AND domain_category = ?",
+		Where("LOWER(domain) = ? AND domain_category = ?",
 			strings.ToLower(domain), types.PrivateCategory,
 		).Count(&count)
 	if result.Error != nil {

--- a/management/server/store/store.go
+++ b/management/server/store/store.go
@@ -88,6 +88,9 @@ type Store interface {
 	GetAccountDNSSettings(ctx context.Context, lockStrength LockingStrength, accountID string) (*types.DNSSettings, error)
 	GetAccountCreatedBy(ctx context.Context, lockStrength LockingStrength, accountID string) (string, error)
 	SaveAccount(ctx context.Context, account *types.Account) error
+	// CreateAccount inserts a new account without upsert semantics, so a
+	// unique-index violation is reported instead of silently absorbed.
+	CreateAccount(ctx context.Context, account *types.Account) error
 	DeleteAccount(ctx context.Context, account *types.Account) error
 	UpdateAccountDomainAttributes(ctx context.Context, accountID string, domain string, category string, isPrimaryDomain bool) error
 	SaveDNSSettings(ctx context.Context, lockStrength LockingStrength, accountID string, settings *types.DNSSettings) error
@@ -429,6 +432,15 @@ func getMigrationsPostAuto(ctx context.Context) []migrationFunc {
 		func(db *gorm.DB) error {
 			return migration.CreateIndexIfNotExists[posture.Checks](ctx, db,
 				"idx_posture_checks_account_name", "account_id", "name")
+		},
+		// At most one account may hold a private domain as primary. Enforced
+		// only by a read-then-write until now, under a global lock that is a
+		// mutex inside one process — so two replicas could both claim a domain
+		// on the first login from an organization. Needs its own migration
+		// rather than CreateIndexIfNotExists: the rule is conditional, and the
+		// three engines express that differently.
+		func(db *gorm.DB) error {
+			return migration.CreatePrimaryPrivateDomainUniqueIndexIfNotExists[types.Account](ctx, db)
 		},
 	}
 }

--- a/management/server/user.go
+++ b/management/server/user.go
@@ -820,6 +820,9 @@ func (am *DefaultAccountManager) GetOrCreateAccountByUser(ctx context.Context, u
 			if err != nil {
 				return nil, err
 			}
+			// After the save, not inside newAccount: an account.create for an
+			// account that failed to store is a false audit record.
+			am.StoreEvent(ctx, userID, account.Id, account.Id, activity.AccountCreated, nil)
 		} else {
 			// other error
 			return nil, err


### PR DESCRIPTION
Third of the six invariants in #143 step 3, and the most reachable one:
it needs no administrator doing anything unusual, only two people from
the same company signing in for the first time at the same moment, on
different replicas.

## The invariant

Exactly one account may hold a private domain as primary.
`GetAccountIDByPrivateDomain` matches `domain`,
`is_domain_primary_account` and `domain_category = 'private'` together,
and onboarding assumes it finds at most one.

Until now that was proven by a read and then written on, protected by
`getPrivateDomainWithGlobalLock`: look the domain up, take
`AcquireGlobalLock` when nothing is found, look again, then write. The
second lookup exists precisely because of "simultaneous requests" — but
`AcquireGlobalLock` is `s.globalAccountLock`, a mutex inside one
process. With two replicas it protects nothing, and the result is two
primary accounts for one domain. From then on, which account a user
lands in depends on which row the lookup happens to return.

## What changed

A conditional unique index over `LOWER(domain)`, restricted to the rows
the lookup reads, plus the three write paths learning what to do when
the database refuses them.

| | |
|---|---|
| `postgres` | partial index; the flag is boolean and stands alone |
| `sqlite` | partial index; the flag is an integer, compared explicitly |
| `mysql` | no filtered indexes — a stored generated column carrying the domain only for rows inside the predicate and `NULL` for the rest, which repeat freely in a unique index |

The generated column lives in the DDL, not in the Go model, so nothing
in the type ever writes it.

Keyed on `LOWER(domain)` rather than the column, because the writers
disagree about case. The lookup lowercases what it searches for and
signup stores a lowercased domain, but
`updateAccountDomainAttributesIfNotUpToDate` rewrites whatever the
account already had. Indexing the raw column would let `Foo.com` and
`foo.com` both be primary while the lookup, searching in lower case,
would only ever find one of them.

The three writers now answer for the refusal. None of them may surface
as a failed login — losing this race is the normal outcome of a
simultaneous signup, and the account the user should land in exists by
the time they are told they lost.

| caller | on conflict |
|---|---|
| `addNewPrivateAccount` | joins the winner through `addNewUserToDomainAccount` — the path the lookup would have taken had it seen the winner in time |
| `updateAccountDomainAttributesIfNotUpToDate` | retries the same write with the primary flag `false`; this account simply is not the primary one |
| `UpdateToPrimaryAccount` | propagates, no retry. An explicit promotion, and refusing it is the correct answer |

`lostPrimaryDomainRace` reads two error shapes, because the engines
refuse at different moments. Postgres has no gap locks, so the insert
reaches the index and comes back as a unique violation the store
classifies. MySQL under REPEATABLE READ takes a gap lock on the position
the row would occupy, so the two writers deadlock before either insert
lands and the loser sees `1213` instead — the same race, reported
earlier. Neither error decides anything on its own; the lookup that
follows does, and when no account holds the domain the original error is
propagated rather than a winner invented.

`waitForPrimaryDomainWinner` exists only because of that earlier report:
on MySQL the loser is told it lost before the winner has committed, so
an immediate lookup finds nothing. Five attempts, 10/25/50/100/200ms,
under a second in total, giving up on the caller's context. It is not a
retry policy and should not grow into one — that is #157.

## Review round 1

Three findings, each with its own commit.

**The index normalized with `LOWER(domain)` and the lookups did not.**
A row stored as `MixedCase.Example` owns the `mixedcase.example` slot in
the index, so the database considers the domain taken, while
`GetAccountIDByPrivateDomain` comparing the raw column does not find it
on Postgres or SQLite. The caller concludes the domain is free, writes,
is refused, and then cannot find the winner it is told exists — a domain
with an owner turns into a failed login. Measured red on Postgres and
SQLite, green on MySQL, whose default collation is case insensitive and
hid the gap.

Both lookups now compare `LOWER(domain)`, matching the expression the
index is keyed on. The filters are deliberately not identical:
`GetAccountIDByPrivateDomain` carries the index's full predicate, while
`CountAccountsByPrivateDomain` counts every private account for the
domain and so omits `is_domain_primary_account` on purpose. What has to
agree between them is the normalization, and that now does. Query plans measured on
Postgres with 400 accounts: the lookup gets an `Index Scan using
idx_accounts_primary_private_domain`, better than the
`idx_accounts_domain` plus filter it had; the count drops to a `Seq
Scan`. The count regression is accepted rather than answered with more
DDL — it has no caller anywhere in the tree outside the `Store`
interface and this test.

Normalizing on write instead was considered and rejected: `newAccount`
passes its domain argument through to the column untouched, so that
route means auditing each writer plus a data migration over existing
rows. Aligning the read is one change and holds regardless of who wrote
the row.

**The signup test never checked where each caller landed.** Its own
comment claimed "one account, and both users inside it"; it counted
primary accounts and stopped. It now captures the account ID each
replica returned and requires both, plus `user-a` and `user-b`, to be
the account that holds the domain.

The reason this was raised does not hold, and that is recorded in the
commit rather than quietly dropped: the #161 mode does not reach this
test, because on MySQL the gap-lock deadlock fires before the upsert can
absorb anything — restoring `SaveAccount` on the signup path still
passes. Three mutations of the conflict path were then tried against the
new assertions and all three were caught by the pre-existing `NoError`,
because `GetAccountIDFromUserAuth` already validates the account it
returns and the user's membership. The assertions are kept as a guard,
not claimed as new coverage.

**`lostPrimaryDomainRace` read `SQLSTATE 40P01` too broadly.** Postgres
has no gap locks on this path, so a deadlock here comes from unrelated
work in the same transaction, and reading it as a lost race would
silently send the caller into another account. Removed — there is a
structural reason it cannot be this race, not merely an absence of
sightings.

The MySQL branch stays, and measuring it corrected something the earlier
commits claimed. After signup moved to `CreateAccount`, every conflict
observed is the typed `AlreadyExists`:

Stated as counted, not rounded up. Across the instrumented runs on this
branch — **5 conflicts on Postgres and 15 on MySQL**, spanning both the
signup `INSERT` and the existing-login `UPDATE` — every conflict arrived
as the typed error and **no deadlock was observed at all**. That is
evidence the shape changed, not proof a deadlock cannot happen: it is a
timing-dependent mechanism and these are local runs.

A plain `INSERT` blocks until the winner commits and is then refused on
the index; the upsert it replaced took locks that deadlocked instead.
That is also why `waitForPrimaryDomainWinner` no longer engages: in the
**6 conflicts where the attempt counter was instrumented** (3 per
engine) the winner was found on attempt 0. It stays for the deadlock
shape, the only one that reports before the winner has committed —
retained on the strength of the mechanism and of an earlier measurement
on this branch, when signup still used the upsert, not on anything the
current tests reproduce.

Both were unreachable from any test once the race stopped producing
them, so they are now pinned directly by `TestLostPrimaryDomainRace` and
`TestWaitForPrimaryDomainWinner`, each verified by mutation: restoring
the 40P01 branch fails the Postgres case, and collapsing the loop to a
single lookup fails the late-winner case. The deadlock case necessarily
constructs the driver's error string, since that is what the production
code matches on; it pins the contract and cannot detect the driver
changing its wording.

The lookup test searches the same stored mixed-case row in lower, upper
and mixed case, because two normalizations have to agree — `LOWER()` in
SQL and `strings.ToLower` in Go. Dropping the Go side fails the two
upper cases while the lower case still passes. The backoff test derives
its timing from `primaryDomainWinnerBackoff` rather than asserting a
wall-clock ceiling, which would have measured the runner instead of the
code.

## Review round 2

**`1213` was treated as this race by every caller, but only signup waited
for the winner.** The existing-login path did an immediate lookup, so the
one error shape that reports *before* the winner has committed would
find nothing and turn into a failed login — in the path where it is most
likely, since that is an `UPDATE` moving a row into the index range and
InnoDB gap locks are exactly what raises `1213` there.

Both login paths now use `waitForPrimaryDomainWinner`. They need
different things from it — signup joins the account it returns, while the
existing-login path only needs to know the domain has an owner before
writing itself non-primary — but the guard is the same, and waiting in
one and not the other was an asymmetry with no reason behind it.
`UpdateToPrimaryAccount` still does not wait, deliberately: an explicit
promotion that lost should be refused, not retried.

This is a contingency fix for a shape the tests cannot reproduce, so it
is worth being plain about what backs it: the helper itself is covered by
`TestWaitForPrimaryDomainWinner`, and the change is that the second
caller now uses it. Nothing here demonstrates `1213` occurring.

**The concurrency tests had no barrier, though a comment claimed they
did.** Both goroutines started immediately, so one replica could finish
before the other entered the window and the test would pass without
exercising the race. The comment about the barrier aligning the calls
described machinery that was not there.

Both tests now call `newBarrier().wait(t)` inside each goroutine, like
the earlier tests on this harness. The instrumented runs before this
change did produce a conflict every time, so the race was in fact being
exercised — but by timing rather than by construction, which is not
something to leave resting on luck.

## Review round 3

**`account.create` was announced before the account was stored.**
`newAccount` emitted `AccountCreated` at construction time. That was
close enough to true while the save that followed could not really fail
— and this branch is what made it fail: the loser of a contested private
domain is refused by the index and joins the winner's account, so the
event named an account ID that never reached the database.

The database invariant is unaffected; the audit trail is not. It does
not stay local either — `StoreEvent` feeds the activity store and
whatever SIEM sits behind it, so the false record propagates.

Moved to both callers of `newAccount`, after each one's own successful
write: `CreateAccount` in `addNewPrivateAccount`, `SaveAccount` in
`GetOrCreateAccountByUser`. `newAccount` no longer knows about events,
which is the right boundary — it builds an account, it does not create
one.

`TestAccountCreatedEventFollowsTheStore` pins both halves together on
purpose. The absence check alone would pass just as well with events
switched off, so a second case proves they flow through this setup.
Verified by mutation: restoring the emit inside `newAccount` fails the
absence case.

**The existing-login test measured the symptom, not the semantics.** It
asserted `NoError` and counted one primary account, while this pull
request declares more about that path than that: unlike signup, nobody
joins anybody — each user stays in its own account and only the primary
flag is decided.

It now also requires both seeded accounts to survive, to keep the
domain, to end classified private, exactly one to be written
non-primary, and each user to still belong to the account it started in.
Verified by mutation: swallowing the conflict and writing nothing leaves
the loser unclassified, which the old assertions accepted — one primary,
no error — and the new ones reject.

## Important note — `SaveAccount` is not fixed here, and is worse than this

While measuring the MySQL path I found that `SaveAccount`'s
`clause.OnConflict{UpdateAll: true}` renders differently per engine.
Postgres names the primary key as its conflict target, so a violation of
any *other* unique index still escapes. MySQL renders
`ON DUPLICATE KEY UPDATE`, which has no target and therefore absorbs
*every* unique key — including this new index. Measured: the second save
returns `err=<nil>`, writes nothing, and the caller believes it created
an account. Worse, with `UpdateAll` the update lands on whichever row
held the conflicting key, which the caller never intended to touch.

That is a defect of its own, it is not specific to `account.domain`, and
it is filed separately as **#161**. This pull request works around it
narrowly and leaves `SaveAccount` untouched:

- `CreateAccount` — a new insert-only store method, used by signup
- `UpdateToPrimaryAccount` switched to the narrow
  `UpdateAccountDomainAttributes` instead of a full `SaveAccount`
- `TestCreateAccountReportsPrimaryDomainConflict` pins that the conflict
  is actually reported

Fixing `SaveAccount` itself is an explicit **non-goal** here.

## Migration risk — run this first

The migration fails when existing data already violates the rule. That
is intended: an operator has to decide which account keeps the domain,
and no automatic choice would be safe. Find the conflicts before
upgrading.

PostgreSQL:

```sql
SELECT LOWER(domain)        AS domain,
       COUNT(*)             AS accounts,
       STRING_AGG(id, ', ') AS account_ids
FROM accounts
WHERE is_domain_primary_account
  AND domain_category = 'private'
GROUP BY LOWER(domain)
HAVING COUNT(*) > 1;
```

MySQL / SQLite:

```sql
SELECT LOWER(domain)    AS domain,
       COUNT(*)         AS accounts,
       GROUP_CONCAT(id) AS account_ids
FROM accounts
WHERE is_domain_primary_account = 1
  AND domain_category = 'private'
GROUP BY LOWER(domain)
HAVING COUNT(*) > 1;
```

An empty result means the migration will apply cleanly. Any row names a
domain, how many accounts claim it, and which ones — leave exactly one
primary and clear the flag on the others before upgrading.

## Verification

Three commits, red first.

`d6d2c07e` adds two tests on the two-replica harness (#158), one per
path that writes into the predicate, since they regress independently.
Both fail on `main` with **2 primary accounts** and pass on one replica,
which is what makes them a fork-behavior test and not a flake.

| | postgres | mysql | sqlite |
|---|---|---|---|
| `TestAccountDomain_ConcurrentFirstLoginAcrossReplicas` | pass | pass | n/a (single-writer) |
| `TestAccountDomain_ConcurrentExistingLoginAcrossReplicas` | pass | pass | n/a |
| `TestPrimaryPrivateDomainIndex` | pass | pass | pass |
| `TestCreateAccountReportsPrimaryDomainConflict` | pass | pass | pass |

The index test asserts both directions. A second primary for the same
domain is refused, including when it differs only in case; and rows
outside the predicate — non-primary, or a public category — may still
share a domain freely. Without that negative case the test would pass
just as well against a plain unique index on `domain`, which would break
every deployment holding more than one account per public domain.

`go test ./management/... -count=1` green, 14 packages.

CI: `Relay / Unit` failed on `TestLocator_LookupHitsRemote` with
`cluster locator: no pod owns this peer`, the #155 family, and passed on
rerun. This branch touches `management/` only.

The three DDL statements were executed against live MySQL, PostgreSQL
and SQLite before this branch was opened, and the SQLite migration was
run directly rather than only through the ORM.

Refs #143. Related #161, #157.
