### PR TITLE
fix(management/dns): close the zone overlap race on Postgres (MySQL awaits #157)

### DIFF
--- a/management/server/dns_zones.go
+++ b/management/server/dns_zones.go
@@ -91,16 +91,26 @@ func (am *DefaultAccountManager) CreateDNSZone(ctx context.Context, accountID, u
 
 	var updateAccountPeers bool
 	err := am.Store.ExecuteInTransaction(ctx, func(tx store.Store) error {
-		dnsDomain, err := am.resolvePeerDNSDomainTx(ctx, tx, accountID)
-		if err != nil {
+		// Same shape as SaveDNSZone (#156): the zone reads, then the
+		// exclusive account row, then the shared account read it now safely
+		// covers. Taking the account row any earlier would invert the order
+		// against every other writer here, which take a zone row first.
+		if err := validateDNSZone(ctx, tx, accountID, zone, true); err != nil {
 			return err
 		}
-		// Unchanged ordering on purpose: this path still reads the account
-		// row before it writes it, so it still carries the deadlock #143
-		// describes. Fixing it needs a serialization point that survives the
-		// isolation-level difference between Postgres and MySQL, which is
-		// tracked separately — see the note on the pull request.
-		if err := validateDNSZone(ctx, tx, accountID, zone, true); err != nil {
+		if err := tx.IncrementNetworkSerial(ctx, store.LockingStrengthUpdate, accountID); err != nil {
+			return err
+		}
+		// The validation above proves nothing on its own: it reads before the
+		// account row is held, so a create on another replica can commit an
+		// overlapping zone in between. The account row is the only lock both
+		// replicas share, so the answer only counts once it is held. Without
+		// locks, for the reason in checkDNSZoneSiblingOverlap.
+		if err := checkDNSZoneSiblingOverlap(ctx, tx, store.LockingStrengthNone, accountID, zone); err != nil {
+			return err
+		}
+		dnsDomain, err := am.resolvePeerDNSDomainTx(ctx, tx, accountID)
+		if err != nil {
 			return err
 		}
 		if err := validateDNSZonePeerOverlap(zone, dnsDomain); err != nil {
@@ -112,9 +122,6 @@ func (am *DefaultAccountManager) CreateDNSZone(ctx context.Context, accountID, u
 		// other mutations and to keep the wiring uniform.
 		updateAccountPeers, err = areDNSZoneChangesAffectPeers(ctx, tx, accountID, zone, nil)
 		if err != nil {
-			return err
-		}
-		if err := tx.IncrementNetworkSerial(ctx, store.LockingStrengthUpdate, accountID); err != nil {
 			return err
 		}
 		return tx.SaveDNSZone(ctx, store.LockingStrengthUpdate, zone)
@@ -542,6 +549,37 @@ func validateDNSZonePeerOverlap(zone *types.DNSZone, peerDNSDomain string) error
 // rejection against OTHER user-managed zones in the same account
 // (excluding the zone being saved). Called inside the same
 // transaction as the upsert so reads are consistent with the write.
+// checkDNSZoneSiblingOverlap rejects a zone whose domain is a label-aligned
+// suffix of another zone in the account, or the other way round.
+//
+// The lock strength is the caller's because this runs twice on the create
+// path, and the two reads want different things. The first is part of
+// validation and shares the zone rows like every other read there. The second
+// is the re-check under the exclusive account row, and it must not take zone
+// locks at all: by then the transaction holds the account row, and every other
+// writer in this file takes a zone row before the account row, so locking a
+// zone here would invert the order and deadlock against them.
+func checkDNSZoneSiblingOverlap(ctx context.Context, tx store.Store, lockStrength store.LockingStrength, accountID string, zone *types.DNSZone) error {
+	siblings, err := tx.GetAccountDNSZones(ctx, lockStrength, accountID)
+	if err != nil {
+		return fmt.Errorf("load sibling dns zones: %w", err)
+	}
+	for _, s := range siblings {
+		if s.ID == zone.ID {
+			// Excludes the zone being updated from the overlap check
+			// against itself; on create, zone.ID is the freshly-minted
+			// xid which never matches an existing row.
+			continue
+		}
+		if dnsZoneOverlap(zone.Domain, s.Domain) {
+			return status.Errorf(status.InvalidArgument,
+				"dns zone domain %q overlaps with existing zone %q; pick a non-overlapping namespace",
+				zone.Domain, s.Domain)
+		}
+	}
+	return nil
+}
+
 func validateDNSZone(ctx context.Context, tx store.Store, accountID string, zone *types.DNSZone, isCreate bool) error {
 	zone.Domain = strings.TrimSuffix(strings.ToLower(zone.Domain), ".")
 	if zone.Domain == "" {
@@ -562,22 +600,8 @@ func validateDNSZone(ctx context.Context, tx store.Store, accountID string, zone
 	// D1's "NXDOMAIN authoritative for the more-specific zone"
 	// property. Bidirectional suffix overlap is the same primitive
 	// used for the peer-DNS check above.
-	siblings, err := tx.GetAccountDNSZones(ctx, store.LockingStrengthShare, accountID)
-	if err != nil {
-		return fmt.Errorf("load sibling dns zones: %w", err)
-	}
-	for _, s := range siblings {
-		if s.ID == zone.ID {
-			// Excludes the zone being updated from the overlap check
-			// against itself; on create, zone.ID is the freshly-minted
-			// xid which never matches an existing row.
-			continue
-		}
-		if dnsZoneOverlap(zone.Domain, s.Domain) {
-			return status.Errorf(status.InvalidArgument,
-				"dns zone domain %q overlaps with existing zone %q; pick a non-overlapping namespace",
-				zone.Domain, s.Domain)
-		}
+	if err := checkDNSZoneSiblingOverlap(ctx, tx, store.LockingStrengthShare, accountID, zone); err != nil {
+		return err
 	}
 
 	// Distribution-group constraint: ≥1, all in-account, no

--- a/management/server/dns_zones.go
+++ b/management/server/dns_zones.go
@@ -543,12 +543,6 @@ func validateDNSZonePeerOverlap(zone *types.DNSZone, peerDNSDomain string) error
 	return nil
 }
 
-// validateDNSZone enforces the ADR-0022 D5 invariants that need no account
-// read: FQDN syntax, >=1 distribution group
-// (deduplicated), group existence in the account, cross-zone overlap
-// rejection against OTHER user-managed zones in the same account
-// (excluding the zone being saved). Called inside the same
-// transaction as the upsert so reads are consistent with the write.
 // checkDNSZoneSiblingOverlap rejects a zone whose domain is a label-aligned
 // suffix of another zone in the account, or the other way round.
 //
@@ -580,6 +574,14 @@ func checkDNSZoneSiblingOverlap(ctx context.Context, tx store.Store, lockStrengt
 	return nil
 }
 
+// validateDNSZone enforces the ADR-0022 D5 invariants that need no account
+// read: FQDN syntax, >=1 distribution group (deduplicated), group existence in
+// the account, cross-zone overlap rejection against OTHER user-managed zones in
+// the same account (excluding the zone being saved). Called inside the same
+// transaction as the upsert so reads are consistent with the write.
+//
+// The overlap check here is not the one that decides on the create path — see
+// checkDNSZoneSiblingOverlap and the re-check in CreateDNSZone.
 func validateDNSZone(ctx context.Context, tx store.Store, accountID string, zone *types.DNSZone, isCreate bool) error {
 	zone.Domain = strings.TrimSuffix(strings.ToLower(zone.Domain), ".")
 	if zone.Domain == "" {

--- a/management/server/dns_zones_concurrency_test.go
+++ b/management/server/dns_zones_concurrency_test.go
@@ -70,3 +70,59 @@ func TestDNSZones_SaveConcurrentAccountWrite_NoDeadlock(t *testing.T) {
 	require.NoError(t, saveErr, "SaveDNSZone must queue behind a concurrent account write, not deadlock")
 	require.NoError(t, competingErr, "the concurrent account write must not be the deadlock victim either")
 }
+
+// Moving the exclusive account lock ahead of the overlap read in CreateDNSZone
+// changes the order it takes rows in: account row first, then a shared read of
+// every zone in the account. SaveDNSZone and DeleteDNSRecord go the other way —
+// the zone row first, the account row second — and #148 is the standing lesson
+// that reordering one path against the others trades one deadlock for another.
+//
+// So this drives the inversion directly rather than racing for it. A
+// transaction takes the zone row exclusively and holds it across the window in
+// which CreateDNSZone needs to read the zones, then reaches for the account
+// row that CreateDNSZone is holding. If the two orders conflict, one of them
+// dies.
+func TestDNSZones_CreateAgainstZoneFirstWriter_NoDeadlock(t *testing.T) {
+	t.Setenv("OPENZRO_STORE_ENGINE", string(types.PostgresStoreEngine))
+
+	// holdZone has to outlast CreateDNSZone's own walk to the zone reads.
+	const holdZone = 2 * time.Second
+
+	am, zoneID := initDNSZoneTestAccountWithZone(t)
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	var competingErr, createErr error
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		competingErr = am.Store.ExecuteInTransaction(ctx, func(tx store.Store) error {
+			// The order SaveDNSZone and DeleteDNSRecord take: zone row first.
+			if _, err := tx.GetDNSZoneByID(ctx, store.LockingStrengthUpdate, dnsZoneTestAccountID, zoneID); err != nil {
+				return err
+			}
+			time.Sleep(holdZone)
+			return tx.IncrementNetworkSerial(ctx, store.LockingStrengthUpdate, dnsZoneTestAccountID)
+		})
+	}()
+
+	// Let the competing transaction take the zone row first.
+	time.Sleep(200 * time.Millisecond)
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, createErr = am.CreateDNSZone(ctx, dnsZoneTestAccountID, dnsZoneTestUserID, &types.DNSZone{
+			Name:               "second-zone",
+			Domain:             "other.example",
+			Enabled:            true,
+			DistributionGroups: []types.DNSZoneGroup{{GroupID: dnsZoneTestGroupID}},
+		})
+	}()
+
+	wg.Wait()
+
+	require.NoError(t, createErr, "CreateDNSZone must queue behind a zone-first writer, not deadlock")
+	require.NoError(t, competingErr, "the zone-first writer must not be the deadlock victim either")
+}

--- a/management/server/dns_zones_concurrency_test.go
+++ b/management/server/dns_zones_concurrency_test.go
@@ -91,13 +91,13 @@ func TestDNSZones_CreateAgainstZoneFirstWriter_NoDeadlock(t *testing.T) {
 	am, zoneID := initDNSZoneTestAccountWithZone(t)
 	ctx := context.Background()
 
-	var wg sync.WaitGroup
-	var competingErr, createErr error
-
-	wg.Add(1)
+	// Deadlines rather than a WaitGroup, because the failure this test exists
+	// to catch is one side never returning. A regression that blocks without
+	// the database killing either transaction would hang here until the
+	// package timeout and report as a timeout somewhere else entirely.
+	competingCh := make(chan error, 1)
 	go func() {
-		defer wg.Done()
-		competingErr = am.Store.ExecuteInTransaction(ctx, func(tx store.Store) error {
+		competingCh <- am.Store.ExecuteInTransaction(ctx, func(tx store.Store) error {
 			// The order SaveDNSZone and DeleteDNSRecord take: zone row first.
 			if _, err := tx.GetDNSZoneByID(ctx, store.LockingStrengthUpdate, dnsZoneTestAccountID, zoneID); err != nil {
 				return err
@@ -110,18 +110,29 @@ func TestDNSZones_CreateAgainstZoneFirstWriter_NoDeadlock(t *testing.T) {
 	// Let the competing transaction take the zone row first.
 	time.Sleep(200 * time.Millisecond)
 
-	wg.Add(1)
+	createCh := make(chan error, 1)
 	go func() {
-		defer wg.Done()
-		_, createErr = am.CreateDNSZone(ctx, dnsZoneTestAccountID, dnsZoneTestUserID, &types.DNSZone{
+		_, err := am.CreateDNSZone(ctx, dnsZoneTestAccountID, dnsZoneTestUserID, &types.DNSZone{
 			Name:               "second-zone",
 			Domain:             "other.example",
 			Enabled:            true,
 			DistributionGroups: []types.DNSZoneGroup{{GroupID: dnsZoneTestGroupID}},
 		})
+		createCh <- err
 	}()
 
-	wg.Wait()
+	join := func(name string, ch <-chan error) error {
+		t.Helper()
+		select {
+		case err := <-ch:
+			return err
+		case <-time.After(30 * time.Second):
+			t.Fatalf("%s never returned; it is blocked, which is the failure this test watches for", name)
+			return nil
+		}
+	}
+	createErr := join("CreateDNSZone", createCh)
+	competingErr := join("the zone-first writer", competingCh)
 
 	require.NoError(t, createErr, "CreateDNSZone must queue behind a zone-first writer, not deadlock")
 	require.NoError(t, competingErr, "the zone-first writer must not be the deadlock victim either")

--- a/management/server/dns_zones_overlap_concurrency_test.go
+++ b/management/server/dns_zones_overlap_concurrency_test.go
@@ -118,7 +118,17 @@ func TestDNSZones_ConcurrentOverlappingCreateAcrossReplicas(t *testing.T) {
 		// is one the caller cannot act on. Aligning MySQL to READ COMMITTED is
 		// #157, and this assertion is what should flip when it lands.
 		if isRepeatableReadEngine() {
-			require.Error(t, err, "replica %s", name)
+			// Asserted as precisely as the Postgres arm, just against a
+			// different mechanism. Accepting any error would let this pass on
+			// a permission failure, a broken fixture, or some later regression
+			// that happened to leave one zone standing — and the claim being
+			// made is specific: the loser dies at IncrementNetworkSerial,
+			// which is where it was measured.
+			require.ErrorContains(t, err, "failed to increment network serial count",
+				"replica %s must lose at the account row, which is what holds this invariant on MySQL today; it got %v", name, err)
+			s, ok := status.FromError(err)
+			require.True(t, ok && s.Type() == status.Internal,
+				"replica %s must lose with the store's internal error, got %v", name, err)
 			continue
 		}
 		require.ErrorContains(t, err, "overlaps with existing zone",

--- a/management/server/dns_zones_overlap_concurrency_test.go
+++ b/management/server/dns_zones_overlap_concurrency_test.go
@@ -1,0 +1,137 @@
+package server
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openzro/openzro/management/server/status"
+	"github.com/openzro/openzro/management/server/types"
+)
+
+// No DNS zone in an account may be a label-aligned suffix of another —
+// validateDNSZone rejects the overlap because the agent's local resolver
+// flattens records across zones without zone affinity, so two overlapping
+// zones break which one is authoritative for a name.
+//
+// The check is a read followed by a write, and the only thing between them is
+// AcquireWriteLockByUID, a mutex inside one process. With two replicas both
+// reads can see an account with no overlapping zone, and both writes land.
+//
+// This is the fifth of the six invariants in #143 step 3, and the first of the
+// two whose mechanism cannot be a unique index: the predicate is suffix
+// overlap, not equality.
+func TestDNSZones_ConcurrentOverlappingCreateAcrossReplicas(t *testing.T) {
+	const (
+		accountID = "dns-overlap-acc"
+		userID    = "dns-overlap-user"
+		groupID   = "dns-overlap-group"
+		parent    = "overlap.example"
+		child     = "sub.overlap.example"
+	)
+
+	r := newTwoReplicas(t)
+	ctx := context.Background()
+
+	account := newAccountWithId(ctx, accountID, userID, "tenant.example", false)
+	account.Groups[groupID] = &types.Group{ID: groupID, Name: "overlap-group"}
+	require.NoError(t, r.A.Store.SaveAccount(ctx, account))
+
+	// Warm each replica: the barrier aligns the calls, not the moment each
+	// reaches the database, and a cold pool offsets one past the other.
+	for _, am := range []*DefaultAccountManager{r.A, r.B} {
+		_, err := am.ListDNSZones(ctx, accountID, userID)
+		require.NoError(t, err)
+	}
+
+	align := newBarrier()
+	create := func(am *DefaultAccountManager, domain string) <-chan error {
+		errCh := make(chan error, 1)
+		go func() {
+			align.wait(t)
+			_, err := am.CreateDNSZone(ctx, accountID, userID, &types.DNSZone{
+				Name:               domain,
+				Domain:             domain,
+				Enabled:            true,
+				DistributionGroups: []types.DNSZoneGroup{{GroupID: groupID}},
+			})
+			errCh <- err
+		}()
+		return errCh
+	}
+
+	errA, errB := create(r.A, parent), create(r.B, child)
+
+	join := func(name string, ch <-chan error) error {
+		t.Helper()
+		select {
+		case err := <-ch:
+			return err
+		case <-time.After(30 * time.Second):
+			t.Fatalf("replica %s never returned from CreateDNSZone", name)
+			return nil
+		}
+	}
+	resultA, resultB := join("A", errA), join("B", errB)
+
+	// Measured from committed state through the other replica's store.
+	zones, err := r.B.ListDNSZones(ctx, accountID, userID)
+	require.NoError(t, err)
+
+	require.Len(t, zones, 1,
+		"%q and %q overlap; exactly one may exist (A=%v, B=%v)", parent, child, resultA, resultB)
+
+	// One zone is not enough to call this correct. Today the survivor is
+	// decided by the #143 deadlock: the loser dies inside
+	// IncrementNetworkSerial on the shared-to-exclusive upgrade, which happens
+	// to leave one zone standing. That is the bug protecting the invariant,
+	// not the invariant being enforced, and the moment the lock order is
+	// fixed the protection disappears with it.
+	//
+	// So the loser has to be turned away for the right reason: a rejection it
+	// can act on, naming the overlap.
+	losers := 0
+	for name, err := range map[string]error{"A": resultA, "B": resultB} {
+		if err == nil {
+			continue
+		}
+		losers++
+
+		// How the loser is told differs by engine, and the difference is the
+		// whole of #157.
+		//
+		// Postgres runs READ COMMITTED and has no gap locks, so the re-check
+		// under the exclusive account row sees the winner's committed zone and
+		// answers with the rejection the caller can act on.
+		//
+		// MySQL runs REPEATABLE READ. The re-check cannot be a locking read —
+		// that would take zone locks after the account row and deadlock
+		// against every writer in this file, which take a zone row first — and
+		// a non-locking read is served from a snapshot established before the
+		// account row was held, so it cannot see the winner. What holds the
+		// invariant there instead is InnoDB's gap lock on the sibling read: the
+		// two creates deadlock and one dies. The invariant survives; the error
+		// is one the caller cannot act on. Aligning MySQL to READ COMMITTED is
+		// #157, and this assertion is what should flip when it lands.
+		if isRepeatableReadEngine() {
+			require.Error(t, err, "replica %s", name)
+			continue
+		}
+		require.ErrorContains(t, err, "overlaps with existing zone",
+			"replica %s lost, but not by being told the domain overlaps; it got %v", name, err)
+		s, ok := status.FromError(err)
+		require.True(t, ok && s.Type() == status.InvalidArgument,
+			"replica %s must lose with a rejection the caller can act on, got %v", name, err)
+	}
+	require.Equal(t, 1, losers, "exactly one create must be rejected (A=%v, B=%v)", resultA, resultB)
+}
+
+// isRepeatableReadEngine reports whether the store under test defaults to
+// REPEATABLE READ. Only MySQL does; Postgres and SQLite do not.
+func isRepeatableReadEngine() bool {
+	return types.Engine(strings.ToLower(os.Getenv("OPENZRO_STORE_ENGINE"))) == types.MysqlStoreEngine
+}


### PR DESCRIPTION
Fifth of the six invariants in #143 step 3, and the first whose
mechanism cannot be a unique index: the predicate is suffix overlap, not
equality.

Read these three lines before anything else.

- **`CreateDNSZone` only.** `SaveDNSZone` is deliberately untouched: it
  rejects a domain change outright (`dns zone domain is immutable;
  create a new zone instead`), so no save can introduce an overlap.
- **Postgres improves.** It stops depending on a deadlock and starts
  rejecting the overlap with an error the caller can act on.
- **MySQL's error surface does not improve here.** The invariant is not
  weakened either — it holds exactly as it does today. Turning that into
  an actionable rejection depends on #157.

## The invariant, and what was actually holding it

No zone in an account may be a label-aligned suffix of another.
`validateDNSZone` rejects the overlap because the agent's local resolver
flattens records across zones without zone affinity, so two overlapping
zones break which one is authoritative for a name.

The check is a read followed by a write, and the only thing between them
was `AcquireWriteLockByUID` — a mutex inside one process.

The first version of the test passed on both engines, and that was the
finding. Instrumented, the loser dies inside `IncrementNetworkSerial` on
the shared-to-exclusive upgrade — the #143 deadlock — which happens to
leave exactly one zone standing:

```
postgres  A=failed to increment network serial count in store, zones=1
mysql     A=failed to increment network serial count in store, zones=1
```

**The invariant was being held by the bug.** That has a consequence
beyond this pull request: fixing the lock order here without replacing
the protection would open the phantom, so the #143 ordering fix and this
invariant are one change and cannot be split the way step 5 of the issue
assumes.

## Three shapes, two of them wrong

This is the part worth keeping. Two of these look like simplifications
and each reintroduces one of the two failures.

| shape | invariant | lock order |
| --- | --- | --- |
| account row first, then the overlap read | held on both engines | **deadlocks** against every other writer in this file, which take a zone row before the account row — the #148 trade, in the opposite direction |
| first read also made non-locking | **regresses MySQL**: drops the gap lock that was holding the invariant, and two overlapping zones land | fine |
| first read stays locking, re-check non-locking | Postgres closed, MySQL unchanged | fine |

The third is what is here: the shape #156 gave `SaveDNSZone` — zone
reads, then the exclusive account row, then the shared account read it
safely covers — plus the piece `SaveDNSZone` does not need, a re-check
of the sibling overlap once the account row is held. The first check
stays where it is and is only an early rejection; the account row is the
only lock both replicas share, so the answer that counts is the one
taken behind it.

`TestDNSZones_CreateAgainstZoneFirstWriter_NoDeadlock` makes the first
row of that table executable, so the simplification cannot land quietly.

## Why MySQL cannot be finished here

Under REPEATABLE READ the two requirements are mutually exclusive:

- a re-check that **sees** the winner must be a locking read — and that
  takes zone locks after the account row, which deadlocks against
  zone-first writers
- a re-check that **does not invert** the order must be non-locking —
  and it is served from a snapshot established before the account row
  was held, so it cannot see the winner

No ordering of this transaction satisfies both. That is what makes #157
a real blocker for MySQL rather than an assumed one — the earlier
reading in the design survey rested on the re-check being unlocked,
which the code contradicts, and the reading before that assumed a
locking re-check was free, which the inversion test contradicts.

Postgres is at READ COMMITTED and has no gap locks, so the non-locking
re-check sees the winner and the fix lands today.

## Cost, and what is deliberately left

The create path now reads the account's zones twice: once for the early
rejection, once under the account row. Both go through
`GetAccountDNSZones`, which preloads more than the overlap check needs.
This is an administrative path, so the second read is accepted for this
scope rather than answered with a narrow query — that belongs with the
round that closes MySQL, where the shape of the re-check may change
anyway.

`TestDNSZones_SaveConcurrentAccountWrite_NoDeadlock` (from #156) waits on
a `WaitGroup` with no deadline, the same exposure the new inversion guard
had. Flagged rather than fixed here, to keep this pull request to one
subject.

## Verification

Three commits, red first.

`456902c7` fails on Postgres for the right reason — the loser is turned
away by a deadlock rather than by being told the domain overlaps. On
MySQL it asserts the current mechanism instead, and that assertion is
what should flip when #157 lands.

Both arms are pinned to their mechanism, not to "an error happened". The
MySQL arm requires `status.Internal` and the message from
`IncrementNetworkSerial`; changing that error's text fails it.

| | postgres | mysql |
| --- | --- | --- |
| overlap invariant | closed, clean rejection | intact, unchanged mechanism |
| `TestDNSZones_*` `-race -count=3` | pass | pass |
| #156 regression guard | pass | pass |
| zone-first inversion guard | pass | pass |

`go test ./management/... -count=1` green.

Refs #143 (step 3). Blocked-on-#157 for the MySQL half.
