### PR TITLE
fix(management/store): drop the untargeted upsert from SaveAccount

### DIFF
--- a/management/server/save_account_replica_test.go
+++ b/management/server/save_account_replica_test.go
@@ -1,0 +1,193 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openzro/openzro/management/server/status"
+	"github.com/openzro/openzro/management/server/store"
+	"github.com/openzro/openzro/management/server/types"
+)
+
+// Removing clause.OnConflict{UpdateAll: true} from SaveAccount trades silent
+// absorption for a reported conflict, and that trade has to be measured where
+// it lands rather than argued: two replicas calling SaveAccount with no
+// manager lock between them. Both shapes below were absorbed before, and only
+// one of them should have been.
+func TestSaveAccount_ConcurrentAcrossReplicas(t *testing.T) {
+	ctx := context.Background()
+
+	// Same account, two writers, different payloads. Nothing here violates an
+	// invariant — it is the ordinary "two replicas saved the same account"
+	// case, and it must survive: one account, intact, and any error has to be
+	// one a caller can understand rather than a mangled half-write.
+	t.Run("same account id, different payloads", func(t *testing.T) {
+		const accountID = "concurrent-save-acc"
+
+		r := newTwoReplicas(t)
+
+		seed := newAccountWithId(ctx, accountID, "owner-user", "tenant.example", false)
+		require.NoError(t, r.A.Store.SaveAccount(ctx, seed))
+
+		save := func(store interface {
+			SaveAccount(context.Context, *types.Account) error
+		}, groupID string) <-chan error {
+			errCh := make(chan error, 1)
+			go func() {
+				account, err := r.A.Store.GetAccount(ctx, accountID)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				account.Groups[groupID] = &types.Group{ID: groupID, Name: groupID, AccountID: accountID}
+				errCh <- store.SaveAccount(ctx, account)
+			}()
+			return errCh
+		}
+
+		errA, errB := save(r.A.Store, "group-from-a"), save(r.B.Store, "group-from-b")
+
+		join := func(name string, ch <-chan error) error {
+			t.Helper()
+			select {
+			case err := <-ch:
+				return err
+			case <-time.After(30 * time.Second):
+				t.Fatalf("replica %s never returned from SaveAccount", name)
+				return nil
+			}
+		}
+		resultA, resultB := join("A", errA), join("B", errB)
+
+		// Losing this one is acceptable — the two writers genuinely raced on
+		// the same row — but it must not be the poisonous shape: a caller told
+		// nothing while the row went somewhere else.
+		require.False(t, resultA != nil && resultB != nil,
+			"both writers failed; at least one save of the same account must land (A=%v, B=%v)", resultA, resultB)
+
+		// Whatever happened, the account has to be readable and whole from the
+		// other replica's store.
+		stored, err := r.B.Store.GetAccount(ctx, accountID)
+		require.NoError(t, err, "the account must survive two concurrent saves")
+		require.Equal(t, accountID, stored.Id, "the account read back is not the one that was saved")
+		require.Contains(t, stored.Users, "owner-user", "the account lost its owner")
+		require.NotEmpty(t, stored.Network, "the account lost its network")
+		require.Len(t, r.B.Store.GetAllAccounts(ctx), 1, "a concurrent save duplicated the account")
+
+		// The edges are in the children, not in the account row: SaveAccount
+		// deletes the tree and recreates it, so a concurrent writer can leave
+		// a child orphaned from the payload that won, or leave two of it. The
+		// association rows are read directly and compared against what the
+		// account carries, because GetAccount reads them through the same
+		// preload that would hide a mismatch behind its own result.
+		groups, err := r.B.Store.GetAccountGroups(ctx, store.LockingStrengthNone, accountID)
+		require.NoError(t, err)
+		seen := map[string]int{}
+		for _, g := range groups {
+			require.Equal(t, accountID, g.AccountID, "group %s is attached to another account", g.ID)
+			seen[g.ID]++
+		}
+		for id, n := range seen {
+			require.Equal(t, 1, n, "group %s exists %d times after the race", id, n)
+			require.Contains(t, stored.Groups, id, "group %s is an orphan: stored on its own, absent from the account", id)
+		}
+		require.Len(t, groups, len(stored.Groups), "the account and the group rows disagree on how many groups it has")
+
+		// Exactly one of the two concurrent additions may survive: both
+		// writers read the account before either committed, so the payload
+		// that lands last carries its own group and not the other's.
+		_, hasA := stored.Groups["group-from-a"]
+		_, hasB := stored.Groups["group-from-b"]
+		require.True(t, hasA != hasB,
+			"expected exactly one of the concurrently added groups, got a=%v b=%v", hasA, hasB)
+
+		users, err := r.B.Store.GetAccountUsers(ctx, store.LockingStrengthNone, accountID)
+		require.NoError(t, err)
+		require.Len(t, users, len(stored.Users), "the account and the user rows disagree")
+
+		peers, err := r.B.Store.GetAccountPeers(ctx, store.LockingStrengthNone, accountID, "", "")
+		require.NoError(t, err)
+		require.Len(t, peers, len(stored.Peers), "the account and the peer rows disagree")
+	})
+
+	// Different accounts, colliding on idx_accounts_primary_private_domain.
+	// This one has to be refused, and refused legibly — it is #161's shape,
+	// where MySQL's untargeted upsert either reported success and wrote
+	// nothing or redirected the write onto the winner's row.
+	t.Run("different account ids colliding on the primary domain", func(t *testing.T) {
+		const domain = "collide.example"
+
+		r := newTwoReplicas(t)
+
+		primary := func(id, userID string) *types.Account {
+			a := newAccountWithId(ctx, id, userID, domain, false)
+			a.DomainCategory = types.PrivateCategory
+			a.IsDomainPrimaryAccount = true
+			return a
+		}
+
+		align := newBarrier()
+		save := func(am *DefaultAccountManager, account *types.Account) <-chan error {
+			errCh := make(chan error, 1)
+			go func() {
+				align.wait(t)
+				errCh <- am.Store.SaveAccount(ctx, account)
+			}()
+			return errCh
+		}
+
+		errA := save(r.A, primary("collide-acc-a", "user-a"))
+		errB := save(r.B, primary("collide-acc-b", "user-b"))
+
+		join := func(name string, ch <-chan error) error {
+			t.Helper()
+			select {
+			case err := <-ch:
+				return err
+			case <-time.After(30 * time.Second):
+				t.Fatalf("replica %s never returned from SaveAccount", name)
+				return nil
+			}
+		}
+		resultA, resultB := join("A", errA), join("B", errB)
+
+		primaries := 0
+		for _, acc := range r.B.Store.GetAllAccounts(ctx) {
+			if acc.Domain == domain && acc.IsDomainPrimaryAccount && acc.DomainCategory == types.PrivateCategory {
+				primaries++
+			}
+		}
+		require.Equal(t, 1, primaries,
+			"the domain is primary on %d accounts (A=%v, B=%v)", primaries, resultA, resultB)
+
+		losers := 0
+		for name, err := range map[string]error{"A": resultA, "B": resultB} {
+			if err == nil {
+				continue
+			}
+			losers++
+
+			// How the refusal arrives differs by engine, and the difference is
+			// #157, not this change. MySQL under REPEATABLE READ takes a gap
+			// lock on the index range, so the two writers deadlock before
+			// either insert is refused: the invariant holds, the error is one
+			// the caller cannot act on. Measured identical with and without
+			// the upsert clause, so removing it neither causes nor cures this.
+			//
+			// Pinned to that mechanism rather than to "an error happened",
+			// which would pass on a permission failure or a broken fixture.
+			if isRepeatableReadEngine() {
+				require.ErrorContains(t, err, "Error 1213",
+					"replica %s must lose to the gap-lock deadlock, which is what holds this on MySQL today; got %v", name, err)
+				continue
+			}
+			s, ok := status.FromError(err)
+			require.True(t, ok && s.Type() == status.AlreadyExists,
+				"replica %s must be refused with a typed conflict, not a raw driver error; got %v", name, err)
+		}
+		require.Equal(t, 1, losers, "exactly one save must be refused (A=%v, B=%v)", resultA, resultB)
+	})
+}

--- a/management/server/save_account_replica_test.go
+++ b/management/server/save_account_replica_test.go
@@ -32,6 +32,12 @@ func TestSaveAccount_ConcurrentAcrossReplicas(t *testing.T) {
 		seed := newAccountWithId(ctx, accountID, "owner-user", "tenant.example", false)
 		require.NoError(t, r.A.Store.SaveAccount(ctx, seed))
 
+		// The barrier goes after the read and the mutation, not before them.
+		// What has to collide is the two writes, each carrying a payload built
+		// from a pre-commit snapshot; aligning the reads instead would let a
+		// near-serial run have the second writer read what the first already
+		// committed, and the test would pass without ever racing.
+		align := newBarrier()
 		save := func(store interface {
 			SaveAccount(context.Context, *types.Account) error
 		}, groupID string) <-chan error {
@@ -43,6 +49,7 @@ func TestSaveAccount_ConcurrentAcrossReplicas(t *testing.T) {
 					return
 				}
 				account.Groups[groupID] = &types.Group{ID: groupID, Name: groupID, AccountID: accountID}
+				align.wait(t)
 				errCh <- store.SaveAccount(ctx, account)
 			}()
 			return errCh

--- a/management/server/store/primary_domain_index_test.go
+++ b/management/server/store/primary_domain_index_test.go
@@ -92,16 +92,17 @@ func TestPrimaryPrivateDomainIndex(t *testing.T) {
 // TestCreateAccountReportsPrimaryDomainConflict guards the trap the tests above
 // walked past.
 //
-// SaveAccount carries clause.OnConflict{UpdateAll: true}. Postgres renders that
-// with the primary key as the conflict target, so a violation of any other
-// unique index still surfaces. MySQL renders ON DUPLICATE KEY UPDATE, which has
-// no target and absorbs every unique key — so SaveAccount returns nil, writes
-// nothing, and hands the caller an account id for a row that does not exist.
+// It was written when SaveAccount still carried
+// clause.OnConflict{UpdateAll: true}, which MySQL rendered without a conflict
+// target and which therefore absorbed this index — the save reported success
+// having written nothing, or landed the values on the winner's row. #164
+// removed the clause and TestSaveAccountReportsPrimaryDomainConflict covers
+// that side now.
 //
-// That is worse than a duplicate and completely silent, which is why creation
-// paths that can collide on idx_accounts_primary_private_domain use
-// CreateAccount instead. This asserts both halves: the conflict is reported,
-// and the account really was not created.
+// This one keeps its own value: the creation paths use CreateAccount, and an
+// insert-only method has to report the conflict on its own terms. It asserts
+// both halves — the conflict is reported, and the account really was not
+// created.
 func TestCreateAccountReportsPrimaryDomainConflict(t *testing.T) {
 	ctx := context.Background()
 

--- a/management/server/store/save_account_upsert_test.go
+++ b/management/server/store/save_account_upsert_test.go
@@ -1,0 +1,112 @@
+package store
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	nbpeer "github.com/openzro/openzro/management/server/peer"
+	"github.com/openzro/openzro/management/server/status"
+	"github.com/openzro/openzro/management/server/types"
+)
+
+// SaveAccount ends in a Create carrying clause.OnConflict{UpdateAll: true},
+// and the two engines render that differently. Postgres names the primary key
+// as the conflict target, so a violation of any other unique index still
+// escapes. MySQL renders ON DUPLICATE KEY UPDATE, which has no target and
+// absorbs every unique key — reporting success, writing nothing the caller
+// asked for, and updating whichever row held the conflicting key (#161).
+//
+// That was harmless while accounts carried no unique index but the primary
+// key. idx_accounts_primary_private_domain (#162) is the first, so these tests
+// exist to keep the clause honest — or to prove it is not needed.
+func TestSaveAccountReportsPrimaryDomainConflict(t *testing.T) {
+	runTestForAllEngines(t, "", func(t *testing.T, store Store) {
+		ctx := context.Background()
+
+		winner := newAccountWithId(ctx, "winner-acc", "winner-user", "contested.example")
+		winner.DomainCategory = types.PrivateCategory
+		winner.IsDomainPrimaryAccount = true
+		require.NoError(t, store.SaveAccount(ctx, winner))
+
+		loser := newAccountWithId(ctx, "loser-acc", "loser-user", "contested.example")
+		loser.DomainCategory = types.PrivateCategory
+		loser.IsDomainPrimaryAccount = true
+
+		err := store.SaveAccount(ctx, loser)
+
+		// The poisonous mode is not "wrong error", it is "no error and no
+		// write". Assert the report first, then that the report was true.
+		require.Error(t, err, "a second primary account for the same private domain must be refused")
+		s, ok := status.FromError(err)
+		require.True(t, ok && s.Type() == status.AlreadyExists,
+			"the refusal must be typed so callers can tell it from an outage, got %v", err)
+
+		_, err = store.GetAccount(ctx, loser.Id)
+		require.Error(t, err, "the refused account must not exist; it was reported as refused")
+
+		// And the refusal must not have been paid for by somebody else's row:
+		// with UpdateAll the update lands on whichever row held the
+		// conflicting key, which is the account nobody asked to touch.
+		survivor, err := store.GetAccount(ctx, winner.Id)
+		require.NoError(t, err)
+		require.Equal(t, "contested.example", survivor.Domain)
+		require.True(t, survivor.IsDomainPrimaryAccount)
+		require.Contains(t, survivor.Users, "winner-user",
+			"the winning account was overwritten with the loser's payload")
+	})
+}
+
+// The clause is being removed on the argument that SaveAccount already deletes
+// the account and its associations inside the same transaction, so the upsert
+// is a crutch rather than semantics. That argument is only worth as much as
+// this test: create still creates, and replace still replaces.
+func TestSaveAccountCreatesAndReplaces(t *testing.T) {
+	runTestForAllEngines(t, "", func(t *testing.T, store Store) {
+		ctx := context.Background()
+
+		account := newAccountWithId(ctx, "contract-acc", "owner-user", "")
+		key, _ := types.GenerateDefaultSetupKey()
+		account.SetupKeys[key.Key] = key
+		account.Peers["peer-a"] = &nbpeer.Peer{
+			Key:    "peer-a-key",
+			IP:     net.IP{127, 0, 0, 1},
+			Meta:   nbpeer.PeerSystemMeta{},
+			Name:   "peer a",
+			Status: &nbpeer.PeerStatus{Connected: true, LastSeen: time.Now().UTC()},
+		}
+
+		require.NoError(t, store.SaveAccount(ctx, account), "a new account must be created")
+
+		stored, err := store.GetAccount(ctx, account.Id)
+		require.NoError(t, err)
+		require.Len(t, stored.Peers, 1)
+		require.Len(t, stored.SetupKeys, 1)
+		require.NotEmpty(t, stored.Policies, "the default policy must have come with it")
+
+		// Save it again, changed, with a different association set. This is
+		// the path the removed clause was assumed to serve.
+		stored.Peers["peer-b"] = &nbpeer.Peer{
+			Key:    "peer-b-key",
+			IP:     net.IP{127, 0, 0, 2},
+			Meta:   nbpeer.PeerSystemMeta{},
+			Name:   "peer b",
+			Status: &nbpeer.PeerStatus{Connected: false, LastSeen: time.Now().UTC()},
+		}
+		delete(stored.Peers, "peer-a")
+		stored.Domain = "replaced.example"
+
+		require.NoError(t, store.SaveAccount(ctx, stored), "an existing account must be replaced, not rejected")
+
+		replaced, err := store.GetAccount(ctx, account.Id)
+		require.NoError(t, err)
+		require.Equal(t, "replaced.example", replaced.Domain)
+		require.Len(t, replaced.Peers, 1, "the replacement's peer set must be what was saved")
+		require.Contains(t, replaced.Peers, "peer-b")
+		require.NotContains(t, replaced.Peers, "peer-a", "a peer dropped from the payload must be gone")
+		require.Len(t, store.GetAllAccounts(ctx), 1, "replacing must not leave a second account behind")
+	})
+}

--- a/management/server/store/save_account_upsert_test.go
+++ b/management/server/store/save_account_upsert_test.go
@@ -110,3 +110,46 @@ func TestSaveAccountCreatesAndReplaces(t *testing.T) {
 		require.Len(t, store.GetAllAccounts(ctx), 1, "replacing must not leave a second account behind")
 	})
 }
+
+// The same account object saved twice, which is not a contrived case:
+// GetOrCreateAccountByUser saves the account it just built and then saves the
+// same pointer again when the owner's domain has to be written (user.go:819
+// and user.go:836).
+//
+// generateAccountSQLTypes projects the maps into the *G slices with append and
+// no reset, so the second call leaves every child in there twice. The upsert
+// used to absorb that — each duplicate simply updated the row its twin had
+// just written. Without it the duplicate is a plain insert of a key that
+// exists, which is exactly the kind of breakage a narrow fix is supposed not
+// to cause.
+func TestSaveAccountTwiceWithTheSameObject(t *testing.T) {
+	runTestForAllEngines(t, "", func(t *testing.T, store Store) {
+		ctx := context.Background()
+
+		account := newAccountWithId(ctx, "resave-acc", "owner-user", "")
+		key, _ := types.GenerateDefaultSetupKey()
+		account.SetupKeys[key.Key] = key
+		account.Peers["peer-a"] = &nbpeer.Peer{
+			Key:    "resave-peer-key",
+			IP:     net.IP{127, 0, 0, 3},
+			Meta:   nbpeer.PeerSystemMeta{},
+			Name:   "peer a",
+			Status: &nbpeer.PeerStatus{Connected: true, LastSeen: time.Now().UTC()},
+		}
+
+		require.NoError(t, store.SaveAccount(ctx, account))
+
+		// Same pointer, no reload. This is the shape user.go uses.
+		account.Domain = "resaved.example"
+		require.NoError(t, store.SaveAccount(ctx, account),
+			"saving the same account object twice must not fail")
+
+		stored, err := store.GetAccount(ctx, account.Id)
+		require.NoError(t, err)
+		require.Equal(t, "resaved.example", stored.Domain)
+		require.Len(t, stored.Peers, 1, "the peer was written twice")
+		require.Len(t, stored.Users, 1, "the user was written twice")
+		require.Len(t, stored.SetupKeys, 1, "the setup key was written twice")
+		require.Len(t, stored.Groups, len(account.Groups), "the groups were written twice")
+	})
+}

--- a/management/server/store/save_account_upsert_test.go
+++ b/management/server/store/save_account_upsert_test.go
@@ -13,16 +13,19 @@ import (
 	"github.com/openzro/openzro/management/server/types"
 )
 
-// SaveAccount ends in a Create carrying clause.OnConflict{UpdateAll: true},
-// and the two engines render that differently. Postgres names the primary key
-// as the conflict target, so a violation of any other unique index still
-// escapes. MySQL renders ON DUPLICATE KEY UPDATE, which has no target and
-// absorbs every unique key — reporting success, writing nothing the caller
-// asked for, and updating whichever row held the conflicting key (#161).
+// SaveAccount used to end in a Create carrying
+// clause.OnConflict{UpdateAll: true}, which the engines rendered
+// differently. Postgres named the primary key as the conflict target, so a
+// violation of any other unique index still escaped. MySQL rendered ON
+// DUPLICATE KEY UPDATE, which has no target: it absorbed every unique key and
+// applied the incoming values to whichever row held the conflicting one
+// (#161). Harmless while accounts carried no unique index but the primary
+// key; idx_accounts_primary_private_domain (#162) was the first, and #164
+// removed the clause.
 //
-// That was harmless while accounts carried no unique index but the primary
-// key. idx_accounts_primary_private_domain (#162) is the first, so these tests
-// exist to keep the clause honest — or to prove it is not needed.
+// These tests are what that removal rests on. The refusal has to be reported,
+// the report has to be true, and it must not be paid for by overwriting the
+// account that won.
 func TestSaveAccountReportsPrimaryDomainConflict(t *testing.T) {
 	runTestForAllEngines(t, "", func(t *testing.T, store Store) {
 		ctx := context.Background()
@@ -117,11 +120,18 @@ func TestSaveAccountCreatesAndReplaces(t *testing.T) {
 // and user.go:836).
 //
 // generateAccountSQLTypes projects the maps into the *G slices with append and
-// no reset, so the second call leaves every child in there twice. The upsert
-// used to absorb that — each duplicate simply updated the row its twin had
-// just written. Without it the duplicate is a plain insert of a key that
-// exists, which is exactly the kind of breakage a narrow fix is supposed not
-// to cause.
+// no reset, so the second call leaves every child in there twice — measured,
+// 1 then 2 then 3 across three saves of one object (#165).
+//
+// The worry was that removing the parent's upsert turns each duplicate into a
+// plain insert of a key that already exists. It does not, and this test
+// catches nothing today: the database ends correct on all three engines
+// because GORM upserts the associations itself under FullSaveAssociations,
+// independently of whatever clause the parent Create carries.
+//
+// It is here because that correctness rests on GORM behavior nobody chose to
+// depend on. If association handling changes, this fails rather than
+// GetOrCreateAccountByUser does.
 func TestSaveAccountTwiceWithTheSameObject(t *testing.T) {
 	runTestForAllEngines(t, "", func(t *testing.T, store Store) {
 		ctx := context.Background()

--- a/management/server/store/sql_store.go
+++ b/management/server/store/sql_store.go
@@ -182,14 +182,16 @@ func (s *SqlStore) AcquireReadLockByUID(ctx context.Context, uniqueID string) (u
 // CreateAccount inserts a brand new account, and fails if anything already in
 // the database refuses it.
 //
-// Deliberately not SaveAccount. That one carries
-// clause.OnConflict{UpdateAll: true}, which Postgres renders with the primary
-// key as its conflict target — so a violation of any other unique index still
-// surfaces — while MySQL renders ON DUPLICATE KEY UPDATE, which has no target
-// and absorbs *every* unique key. A SaveAccount that collides with
-// idx_accounts_primary_private_domain on MySQL therefore returns nil while
-// creating nothing, and the caller is handed an account id for a row that does
-// not exist.
+// Deliberately not SaveAccount, and the reason changed with #164. SaveAccount
+// used to carry clause.OnConflict{UpdateAll: true}, which MySQL rendered
+// without a conflict target and which therefore swallowed this index; that
+// clause is gone, so both now report the conflict. What still separates them
+// is what they mean: SaveAccount replaces an account and its whole tree,
+// deleting the associations and writing them again, while this inserts one new
+// account and nothing else.
+//
+// A creation path wants the second. Reaching for SaveAccount to create would
+// work, and would also delete-and-recreate a tree that does not exist yet.
 //
 // Creation paths that can collide on that index have to insert plainly instead,
 // so losing the race is reported rather than swallowed. SaveAccount is left as

--- a/management/server/store/sql_store.go
+++ b/management/server/store/sql_store.go
@@ -240,9 +240,19 @@ func (s *SqlStore) SaveAccount(ctx context.Context, account *types.Account) erro
 			return result.Error
 		}
 
+		// No OnConflict clause. It used to carry UpdateAll: true, which the
+		// engines render differently — Postgres names the primary key as the
+		// conflict target, MySQL renders ON DUPLICATE KEY UPDATE, which has no
+		// target and absorbs every unique key (#161). That was harmless while
+		// accounts carried no unique index but the primary key; it stopped
+		// being harmless when idx_accounts_primary_private_domain landed.
+		//
+		// It is not needed either way: the account and its associations are
+		// deleted immediately above, in this same transaction, so the insert
+		// has nothing of its own to conflict with. What the clause was
+		// absorbing was somebody *else's* row.
 		result = tx.
 			Session(&gorm.Session{FullSaveAssociations: true}).
-			Clauses(clause.OnConflict{UpdateAll: true}).
 			Create(account)
 		if result.Error != nil {
 			return result.Error

--- a/management/server/store/sql_store.go
+++ b/management/server/store/sql_store.go
@@ -191,12 +191,10 @@ func (s *SqlStore) AcquireReadLockByUID(ctx context.Context, uniqueID string) (u
 // account and nothing else.
 //
 // A creation path wants the second. Reaching for SaveAccount to create would
-// work, and would also delete-and-recreate a tree that does not exist yet.
-//
-// Creation paths that can collide on that index have to insert plainly instead,
-// so losing the race is reported rather than swallowed. SaveAccount is left as
-// it is for the paths that genuinely mean "write this account, whatever is
-// there" — see #143.
+// work, and would also delete-and-recreate a tree that does not exist yet, so
+// this exists to say what the caller means rather than to avoid a trap.
+// SaveAccount stays for the paths that genuinely mean "write this account and
+// its tree, whatever is there" — see #143.
 func (s *SqlStore) CreateAccount(ctx context.Context, account *types.Account) error {
 	generateAccountSQLTypes(account)
 


### PR DESCRIPTION
Closes #161, and with a much narrower change than that issue proposed.

## What the clause was doing

`SaveAccount` ended in a `Create` carrying
`clause.OnConflict{UpdateAll: true}`. The engines render that
differently: Postgres names the primary key as the conflict target, so a
violation of any *other* unique index still escapes; MySQL renders
`ON DUPLICATE KEY UPDATE`, which has no target. It absorbs every unique
key and applies the incoming values to whichever row held the
conflicting one.

Harmless while `accounts` carried no unique index but the primary key.
`idx_accounts_primary_private_domain` (#162) is the first, and it made
the clause reachable.

## Why it can simply go

`SaveAccount` deletes the account and its associations immediately
above, inside the same transaction. The insert has nothing of *its own*
to conflict with — what the clause absorbed was somebody else's row.

That is an argument, and arguments are what this branch has been wrong
about before, so it is measured:

| shape | with the clause | without |
| --- | --- | --- |
| same account id, two replicas, different payloads | passes | **passes** |
| colliding private domain, sequential, MySQL | **FK 1452** | **typed `AlreadyExists`** |
| colliding private domain, concurrent, MySQL | 1213 | 1213 — identical |
| colliding private domain, Postgres | typed | typed |
| `./management/server/...`, all three engines | passes | passes |

**The first row was the actual risk.** The clause might have been
holding availability for two replicas saving one account, rather than
only hiding conflicts. It was not: the delete serializes them, the
account survives whole, and the association rows agree with the tree the
account carries.

**The third row is not this change's to fix.** MySQL's gap lock refuses
the pair before either insert reaches the index, identically before and
after. That is #157.

So the change improves MySQL strictly and moves nothing else.

## #161's description was wrong, and is corrected

The issue records the MySQL symptom as "returns nil, writes nothing".
That is the thin case, an account with no associations. With a real
account it fails loudly:

```
Error 1452 (23000): Cannot add or update a child row: a foreign key
constraint fails (`account_onboardings`, CONSTRAINT
`fk_accounts_onboarding` FOREIGN KEY (`account_id`) REFERENCES
`accounts` (`id`) ON DELETE CASCADE)
```

Which is the better evidence: the upsert applied the values to the
winner's row, so no `accounts` row with the loser's id was created, and
the child insert then failed for a parent that does not exist.
[Corrected on the issue](https://github.com/openzro/openzro/issues/161#issuecomment-5487155238).

## Tests

Three, at the two layers the defect crosses.

- `TestSaveAccountReportsPrimaryDomainConflict` — the refusal is
  reported, the report was true (the refused account does not exist),
  and it was not paid for by overwriting the winner. That last one is
  the `UpdateAll` shape.
- `TestSaveAccountCreatesAndReplaces` — the contract the clause was
  assumed to serve. "The suite still passes" is not a specification, so
  create-creates and replace-replaces are stated directly.
- `TestSaveAccount_ConcurrentAcrossReplicas` — the two concurrent
  shapes, which want opposite things: availability for the same account
  id, refusal for a colliding domain.

The association assertions read rows through their own store calls
rather than through the account `GetAccount` returns. Comparing that
tree against itself would agree with itself whatever happened
underneath, and this method deletes and recreates the whole tree — the
edges are in the children.

The MySQL arm of the concurrent domain case is pinned to `Error 1213`
specifically, not to "an error happened", and the commit records that
it measures identically with and without the clause — so it documents
#157 rather than blaming this change.

## Review round 1

Three points, all in `ad76c2c6`.

**The same-account concurrency case had no barrier.** Both writers read,
mutated and saved, so a near-serial run could let the second read what
the first had already committed — and that case carries the whole
argument that removing the upsert costs no concurrent-write tolerance.
The barrier now sits after the read and the mutation, deliberately: what
has to collide is the two writes, each built from a pre-commit snapshot.
Aligning the reads instead is how this kind of test becomes a placebo.

**Two comments still described the removed clause** and would have sent
the next reader to the wrong version of #161. Rewritten around what
separates the two methods now — insert-only against replace-tree.
`CreateAccount` is still right on a creation path, but because
`SaveAccount` would delete and recreate a tree that does not exist yet,
not because it swallows the conflict.

**The contract test did not cover saving the same pointer twice**, which
matters because `generateAccountSQLTypes` appends into the `*G`
projections without resetting them. Confirmed: 1, then 2, then 3 across
three saves of one object.

That concern's conclusion does not hold, though. Removing the upsert
does not stop the duplication being absorbed — the database ends correct
on all three engines, because GORM upserts the associations itself under
`FullSaveAssociations`, independently of the parent's clause.

`TestSaveAccountTwiceWithTheSameObject` is added regardless, modeled on
`GetOrCreateAccountByUser`, which saves the account it built and then
saves the same pointer again (`user.go:819`, `user.go:836`). **It
catches nothing today**, and the commit says so. It pins that the double
save works, so a future change to association handling fails there
rather than in production — that correctness currently rests on GORM
behavior nobody chose to depend on.

The accumulation itself is #165, not this pull request: a different
axis, in-memory mutation rather than a conflict clause with no target.

## Verification

`-race -count=2` green on Postgres and MySQL for both packages.
`go test ./management/... -count=1` green.

Refs #157, #162.
