### PR TITLE
fix(management/store): refuse the upgrade instead of silently truncating a name

### DIFF
--- a/docs/operator/upgrade-notes.md
+++ b/docs/operator/upgrade-notes.md
@@ -1,0 +1,194 @@
+# Upgrade notes
+
+Read this before upgrading a management deployment. It lists, per
+release, the checks to run **before** starting the new binary, and
+separately the behavior changes to expect **after** it is running.
+
+The two are different kinds of information and are kept apart on
+purpose. A pre-upgrade check is something you act on now, at a
+maintenance window. A behavior change is something support needs to
+recognize next week.
+
+## How migrations fail, and why that is intended
+
+Some releases add database constraints that make an existing invariant
+enforceable. Those migrations **refuse to run against data that already
+violates the invariant**, and the management service does not start
+until the data is corrected.
+
+That is deliberate. The alternative is for the migration to pick which
+row survives, which would hide from you that the violation happened at
+all and would make a choice only you have the context to make.
+
+What a failing migration guarantees is narrower than "nothing ran", and
+worth stating precisely: it does not pick a winner, and it does not
+correct, truncate or delete your data to make itself pass. The
+management service will not start until the inconsistency is resolved.
+
+It is not a single transaction, though. Schema changes that ran before
+the failing one may already be applied, so treat a failed upgrade as a
+database whose schema is part-way between the two versions — which is
+another reason to take the backup below before starting.
+
+## v0.53.1-alpha.89
+
+### Before upgrading
+
+Three migrations enforce invariants that were previously held only in
+application code. Run all three queries. **Empty results mean the
+migrations apply cleanly.**
+
+PostgreSQL:
+
+```sql
+-- 1. more than one account primary for the same private domain
+SELECT LOWER(domain) AS domain, COUNT(*) AS accounts, STRING_AGG(id, ', ') AS account_ids
+FROM accounts
+WHERE is_domain_primary_account AND domain_category = 'private'
+GROUP BY LOWER(domain) HAVING COUNT(*) > 1;
+
+-- 2. duplicate network resource names within one account
+SELECT account_id, name, COUNT(*) AS n, STRING_AGG(id, ', ') AS ids
+FROM network_resources
+GROUP BY account_id, name HAVING COUNT(*) > 1;
+
+-- 3. duplicate posture check names within one account
+SELECT account_id, name, COUNT(*) AS n, STRING_AGG(id, ', ') AS ids
+FROM posture_checks
+GROUP BY account_id, name HAVING COUNT(*) > 1;
+```
+
+MySQL and SQLite are the same queries with `GROUP_CONCAT(id)` in place
+of `STRING_AGG(id, ', ')`, and `is_domain_primary_account = 1` in the
+first.
+
+Two more, because the same release also bounds those name columns at
+128 characters. Duplicates are not the only thing that can stop the
+upgrade: a name longer than the new column fails when the schema
+changes, and the duplicate queries above would not show it.
+
+```sql
+-- 4. network resource names too long for the new column
+SELECT id, account_id, CHAR_LENGTH(name) AS len
+FROM network_resources
+WHERE CHAR_LENGTH(name) > 128;
+
+-- 5. posture check names too long for the new column
+SELECT id, account_id, CHAR_LENGTH(name) AS len
+FROM posture_checks
+WHERE CHAR_LENGTH(name) > 128;
+```
+
+`CHAR_LENGTH` on PostgreSQL and MySQL; on SQLite use `LENGTH`. Counting
+characters rather than bytes matters here — the bound is 128 characters,
+so a name with accented or non-Latin text is not over the limit just
+because it takes more bytes.
+
+Rename anything these return before upgrading.
+
+The two engines behaved differently here, and the difference was the
+reason this release was held:
+
+| | schema change | your data |
+| --- | --- | --- |
+| MySQL | fails, `Error 1406: Data too long` | preserved |
+| PostgreSQL | **succeeded** | **silently truncated to 128 characters** |
+
+PostgreSQL truncates because the change is applied as an explicit cast
+to `varchar(128)`, and an explicit cast truncates where an assignment
+would have raised an error. The upgrade completed, the service started,
+and nothing said a name had been shortened.
+
+That is fixed: the migration now refuses to run when a name is too
+long, on every engine, and tells you to run the queries above. The
+check is no longer something you have to remember — but run it in your
+maintenance window anyway, so you find out at a moment of your choosing
+rather than when the service declines to start.
+
+### If any query returns rows
+
+Do not upgrade yet. In order:
+
+1. **Back up the database.** Everything below edits rows by hand.
+2. **Audit the impact before changing anything.** The rows are not
+   interchangeable, and which one to keep depends on how the deployment
+   is used — see the notes below.
+3. **Correct the data** so the invariant holds.
+4. **Run the query again** until it returns nothing.
+
+What to weigh in each case:
+
+- **Duplicate primary accounts for a private domain.** Which account
+  stays primary decides where users of that domain land when they log
+  in. Both accounts may already have users, peers and policies. Look at
+  which one is actually in use before clearing the flag on the other;
+  this is a change in login behavior for real people, not a cleanup.
+- **Duplicate network resource names.** Renaming is usually less
+  disruptive than deleting, because a resource may be referenced by
+  policies. Check what references each one first.
+- **Duplicate posture check names.** Same reasoning: a check may be
+  attached to policies. Confirm which duplicate is referenced before
+  removing anything.
+
+If the duplicates look like they were created by the races these
+migrations close — two administrators acting at the same moment, or two
+first logins from one company — the newer row is often the accidental
+one. Often, not always. Confirm rather than assume.
+
+### After upgrading
+
+- **Renaming a posture check to a name already used in the same account
+  is now rejected.** The name was documented as unique per account but
+  was only enforced when creating one. Update is now enforced too, so an
+  API call that previously succeeded can now return a conflict. This is
+  intended.
+- **Network resource names are bounded at 128 characters**, declared in
+  the OpenAPI schema.
+- **Two people signing in from the same company at the same moment no
+  longer creates two accounts for that domain.** The second login joins
+  the first's account instead of creating a competing one.
+- **Creating two DNS zones with overlapping domains at the same moment
+  now returns a clear rejection on PostgreSQL** instead of an internal
+  error. On MySQL this case still returns an internal error — see the
+  limitation below.
+
+## Known limitations
+
+### MySQL: some concurrent conflicts report an unusable error
+
+**PostgreSQL deployments are not affected.**
+
+MySQL runs at REPEATABLE READ, where InnoDB's gap locks refuse certain
+concurrent writes before the constraint that would explain them is
+reached. The invariant holds — nothing incorrect is written — but the
+loser receives a deadlock error rather than a message describing the
+conflict.
+
+Known cases: concurrent creation of overlapping DNS zones, and
+concurrent writes competing for the same primary private domain.
+
+Aligning MySQL's isolation level is tracked in
+[#157](https://github.com/openzro/openzro/issues/157).
+
+### Multi-replica: three invariants are still enforced only in-process
+
+A management deployment running **more than one replica** can still
+produce duplicates for two cases, because the check is a read followed
+by a write protected by a lock that lives inside one process:
+
+- group names issued through the API
+- route prefix and domain overlap
+
+DNS zone overlap is **not** in that list. It is enforced on both
+engines: on PostgreSQL by the constraint added in this release, and on
+MySQL by InnoDB's gap lock, which refuses the second write. What MySQL
+still lacks there is a usable error, which is the limitation above, not
+a duplication risk.
+
+Single-replica deployments are unaffected by any of this — the
+in-process lock is sufficient there. Progress is tracked in
+[#143](https://github.com/openzro/openzro/issues/143).
+
+## Earlier releases
+
+No pre-upgrade checks were required before `v0.53.1-alpha.89`.

--- a/docs/operator/upgrade-notes.md
+++ b/docs/operator/upgrade-notes.md
@@ -34,9 +34,13 @@ another reason to take the backup below before starting.
 
 ### Before upgrading
 
-Three migrations enforce invariants that were previously held only in
-application code. Run all three queries. **Empty results mean the
-migrations apply cleanly.**
+This release enforces in the database several invariants that were
+previously held only in application code, and narrows two columns.
+
+**Run every check below.** They cover the blocks known at the time of
+this release: three for duplicate values, two for values too long for a
+narrowed column. An empty result from all of them means these migrations
+have nothing to refuse.
 
 PostgreSQL:
 
@@ -64,8 +68,8 @@ first.
 
 Two more, because the same release also bounds those name columns at
 128 characters. Duplicates are not the only thing that can stop the
-upgrade: a name longer than the new column fails when the schema
-changes, and the duplicate queries above would not show it.
+upgrade, and the duplicate queries above would not show a name that is
+merely too long.
 
 ```sql
 -- 4. network resource names too long for the new column
@@ -142,8 +146,10 @@ one. Often, not always. Confirm rather than assume.
   was only enforced when creating one. Update is now enforced too, so an
   API call that previously succeeded can now return a conflict. This is
   intended.
-- **Network resource names are bounded at 128 characters**, declared in
-  the OpenAPI schema.
+- **Network resource and posture check names are bounded at 128
+  characters**, declared in the OpenAPI schema for both, on the write
+  payloads as well as the responses. A create or update carrying a
+  longer name is rejected.
 - **Two people signing in from the same company at the same moment no
   longer creates two accounts for that domain.** The second login joins
   the first's account instead of creating a competing one.

--- a/management/server/migration/migration.go
+++ b/management/server/migration/migration.go
@@ -544,3 +544,68 @@ func execIndex(ctx context.Context, db *gorm.DB, stmt string) error {
 	log.WithContext(ctx).Infof("successfully created index %s", PrimaryPrivateDomainIndex)
 	return nil
 }
+
+// MaxNameLength is the bound RefuseOversizedColumn checks against. It matches
+// the gorm size:128 tag on the columns it guards.
+const MaxNameLength = 128
+
+// RefuseOversizedColumn stops the upgrade when a column already holds values
+// longer than the width the model is about to narrow it to.
+//
+// This exists because AutoMigrate's narrowing is not safe on every engine, and
+// the unsafe one is silent. Measured on both affected tables (#166):
+//
+//	postgres  AutoMigrate succeeds, the value is cut to the new width
+//	mysql     AutoMigrate fails with 1406, the value is untouched
+//
+// PostgreSQL truncates because the change is applied as an explicit cast to
+// varchar(n), and an explicit cast truncates where an assignment would raise
+// "value too long". So the operator gets a successful upgrade, a running
+// service, and no indication that a name is now a different name.
+//
+// Refusing here makes both engines behave like the safer one. It reads before
+// anything is altered, and it is deliberately a hard failure rather than a
+// warning: a warning in a startup log is not a decision the operator made.
+func RefuseOversizedColumn[T any](ctx context.Context, db *gorm.DB, column string, maxLen int) error {
+	var model T
+	if !db.Migrator().HasTable(&model) {
+		log.WithContext(ctx).Debugf("table for %T does not exist, nothing to check", model)
+		return nil
+	}
+
+	stmt := &gorm.Statement{DB: db}
+	if err := stmt.Parse(&model); err != nil {
+		return fmt.Errorf("parse model schema: %w", err)
+	}
+	table := stmt.Schema.Table
+
+	// LENGTH counts characters on SQLite and bytes on MySQL; CHAR_LENGTH
+	// counts characters on both MySQL and PostgreSQL. The bound is in
+	// characters, so a name with non-Latin text must not be refused for
+	// taking more bytes than it has characters.
+	lengthFn := "CHAR_LENGTH"
+	if db.Dialector.Name() == "sqlite" {
+		lengthFn = "LENGTH"
+	}
+
+	var offenders []string
+	err := db.Raw(fmt.Sprintf("SELECT id FROM %s WHERE %s(%s) > ?", table, lengthFn, column), maxLen).
+		Scan(&offenders).Error
+	if err != nil {
+		return fmt.Errorf("check %s.%s length: %w", table, column, err)
+	}
+	if len(offenders) == 0 {
+		return nil
+	}
+
+	shown := offenders
+	if len(shown) > 10 {
+		shown = shown[:10]
+	}
+	return fmt.Errorf(
+		"%s.%s: %d row(s) exceed the %d character limit this version introduces, "+
+			"and upgrading would shorten them without telling you on PostgreSQL. "+
+			"Rename them and start again. Offending ids (first %d): %v. "+
+			"See docs/operator/upgrade-notes.md for the queries that list them all",
+		table, column, len(offenders), maxLen, len(shown), shown)
+}

--- a/management/server/migration/migration.go
+++ b/management/server/migration/migration.go
@@ -572,6 +572,16 @@ func RefuseOversizedColumn[T any](ctx context.Context, db *gorm.DB, column strin
 		log.WithContext(ctx).Debugf("table for %T does not exist, nothing to check", model)
 		return nil
 	}
+	// The column has to be checked separately, and this is not defensive
+	// clutter: this runs in migratePreAuto, before AutoMigrate, so the schema
+	// it sees is by definition the older one. A table can exist without the
+	// column that is about to be added, and querying it then fails with
+	// "no such column" — turning a guard against data loss into a crash on
+	// startup.
+	if !db.Migrator().HasColumn(&model, column) {
+		log.WithContext(ctx).Debugf("%T has no column %s yet, nothing to check", model, column)
+		return nil
+	}
 
 	stmt := &gorm.Statement{DB: db}
 	if err := stmt.Parse(&model); err != nil {

--- a/management/server/store/name_length_guard_test.go
+++ b/management/server/store/name_length_guard_test.go
@@ -1,0 +1,120 @@
+package store
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/openzro/openzro/management/server/migration"
+	resourceTypes "github.com/openzro/openzro/management/server/networks/resources/types"
+	"github.com/openzro/openzro/management/server/posture"
+	"github.com/openzro/openzro/management/server/types"
+)
+
+// #159 and #160 narrowed these two name columns to varchar(128), and
+// AutoMigrate applies that to databases that already hold longer values. The
+// engines disagree about what that means, and the disagreement is the bug:
+//
+//	postgres  the change succeeds and the value is cut to 128 — silently
+//	mysql     the change fails with 1406 and the value is untouched
+//
+// PostgreSQL truncates because the narrowing is applied as an explicit cast to
+// varchar(128), and an explicit cast truncates where an assignment would have
+// raised "value too long". So the upgrade completes, the service starts, and
+// a name is now a different name with nothing said about it.
+//
+// The guard runs before AutoMigrate and refuses, so both engines behave like
+// the one that fails loudly. Documentation cannot cover this: the operator who
+// forgets the pre-check query is exactly the one who loses data.
+func TestRefuseOversizedColumn(t *testing.T) {
+	runTestForAllEngines(t, "", func(t *testing.T, store Store) {
+		ctx := context.Background()
+		db := store.(*SqlStore).GetDB()
+
+		account := newAccountWithId(ctx, "guard-acc", "guard-user", "")
+		require.NoError(t, store.SaveAccount(ctx, account))
+
+		t.Run("passes when every name fits", func(t *testing.T) {
+			require.NoError(t, migration.RefuseOversizedColumn[posture.Checks](ctx, db, "name", migration.MaxNameLength))
+			require.NoError(t, migration.RefuseOversizedColumn[resourceTypes.NetworkResource](ctx, db, "name", migration.MaxNameLength))
+		})
+
+		t.Run("passes at exactly the limit", func(t *testing.T) {
+			require.NoError(t, db.Exec(
+				"INSERT INTO posture_checks (id, account_id, name) VALUES (?, ?, ?)",
+				"exactly-128", account.Id, strings.Repeat("a", migration.MaxNameLength)).Error)
+			t.Cleanup(func() { db.Exec("DELETE FROM posture_checks WHERE id = ?", "exactly-128") })
+
+			require.NoError(t, migration.RefuseOversizedColumn[posture.Checks](ctx, db, "name", migration.MaxNameLength),
+				"a name of exactly the limit fits and must not be refused")
+		})
+
+		t.Run("refuses one character over, and says which row", func(t *testing.T) {
+			// The guard runs before AutoMigrate, so the state it sees is the
+			// one from before the narrowing: a column still wide enough to
+			// hold the offending value. Reproduced here, because the current
+			// schema would reject the insert and the test would be measuring
+			// the column instead of the guard.
+			restore := widenNameColumn(t, db, "posture_checks")
+			t.Cleanup(restore)
+
+			require.NoError(t, db.Exec(
+				"INSERT INTO posture_checks (id, account_id, name) VALUES (?, ?, ?)",
+				"one-over", account.Id, strings.Repeat("a", migration.MaxNameLength+1)).Error)
+			t.Cleanup(func() { db.Exec("DELETE FROM posture_checks WHERE id = ?", "one-over") })
+
+			err := migration.RefuseOversizedColumn[posture.Checks](ctx, db, "name", migration.MaxNameLength)
+			require.Error(t, err, "a name over the limit must stop the upgrade")
+			require.ErrorContains(t, err, "one-over", "the operator has to be told which row to fix")
+			require.ErrorContains(t, err, "upgrade-notes.md")
+		})
+
+		t.Run("counts characters, not bytes", func(t *testing.T) {
+			// 100 three-byte characters: 100 long, 300 bytes. Under the limit
+			// by the only measure that matters, and over it by the wrong one.
+			require.NoError(t, db.Exec(
+				"INSERT INTO posture_checks (id, account_id, name) VALUES (?, ?, ?)",
+				"multibyte", account.Id, strings.Repeat("日", 100)).Error)
+			t.Cleanup(func() { db.Exec("DELETE FROM posture_checks WHERE id = ?", "multibyte") })
+
+			require.NoError(t, migration.RefuseOversizedColumn[posture.Checks](ctx, db, "name", migration.MaxNameLength),
+				"a 100-character name must fit even though it is 300 bytes")
+		})
+
+		_ = types.PrivateCategory
+	})
+}
+
+// widenNameColumn puts the name column back to the shape it had before the
+// size:128 tag, so a test can hold a value the current schema would refuse.
+// Returns a function that narrows it again.
+//
+// The unique index has to come off first on MySQL, which will not accept a
+// TEXT column in a key without a prefix length — the same reason the column
+// was sized in the first place.
+func widenNameColumn(t *testing.T, db *gorm.DB, table string) func() {
+	t.Helper()
+
+	index := "idx_" + table + "_account_name"
+	switch db.Dialector.Name() {
+	case "mysql":
+		require.NoError(t, db.Exec("DROP INDEX "+index+" ON "+table).Error)
+		require.NoError(t, db.Exec("ALTER TABLE "+table+" MODIFY name longtext").Error)
+		return func() {
+			db.Exec("ALTER TABLE " + table + " MODIFY name varchar(128)")
+			db.Exec("CREATE UNIQUE INDEX " + index + " ON " + table + " (account_id, name)")
+		}
+	case "postgres":
+		require.NoError(t, db.Exec("ALTER TABLE "+table+" ALTER COLUMN name TYPE text").Error)
+		return func() {
+			db.Exec("ALTER TABLE " + table + " ALTER COLUMN name TYPE varchar(128)")
+		}
+	default:
+		// SQLite does not enforce a varchar width, so the column already
+		// accepts the value and there is nothing to widen.
+		return func() {}
+	}
+}

--- a/management/server/store/name_length_guard_test.go
+++ b/management/server/store/name_length_guard_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/openzro/openzro/management/server/migration"
 	resourceTypes "github.com/openzro/openzro/management/server/networks/resources/types"
 	"github.com/openzro/openzro/management/server/posture"
-	"github.com/openzro/openzro/management/server/types"
 )
 
 // #159 and #160 narrowed these two name columns to varchar(128), and
@@ -72,6 +71,26 @@ func TestRefuseOversizedColumn(t *testing.T) {
 			require.ErrorContains(t, err, "upgrade-notes.md")
 		})
 
+		// The three subtests above prove the function. They do not prove it is
+		// called, and the wiring is the part that actually stops the data
+		// loss: RefuseOversizedColumn only helps because migratePreAuto runs
+		// it before AutoMigrate. Remove the hook or reorder it after the
+		// narrowing and every assertion above still passes while PostgreSQL
+		// goes back to truncating silently.
+		t.Run("migratePreAuto refuses before anything is narrowed", func(t *testing.T) {
+			restore := widenNameColumn(t, db, "network_resources")
+			t.Cleanup(restore)
+
+			require.NoError(t, db.Exec(
+				"INSERT INTO network_resources (id, account_id, name) VALUES (?, ?, ?)",
+				"wired-one-over", account.Id, strings.Repeat("a", migration.MaxNameLength+1)).Error)
+			t.Cleanup(func() { db.Exec("DELETE FROM network_resources WHERE id = ?", "wired-one-over") })
+
+			err := migratePreAuto(ctx, db)
+			require.Error(t, err, "the pre-auto migrations must refuse a name the narrowing would truncate")
+			require.ErrorContains(t, err, "wired-one-over")
+		})
+
 		t.Run("counts characters, not bytes", func(t *testing.T) {
 			// 100 three-byte characters: 100 long, 300 bytes. Under the limit
 			// by the only measure that matters, and over it by the wrong one.
@@ -83,8 +102,6 @@ func TestRefuseOversizedColumn(t *testing.T) {
 			require.NoError(t, migration.RefuseOversizedColumn[posture.Checks](ctx, db, "name", migration.MaxNameLength),
 				"a 100-character name must fit even though it is 300 bytes")
 		})
-
-		_ = types.PrivateCategory
 	})
 }
 

--- a/management/server/store/store.go
+++ b/management/server/store/store.go
@@ -346,6 +346,17 @@ func migratePreAuto(ctx context.Context, db *gorm.DB) error {
 
 func getMigrationsPreAuto(ctx context.Context) []migrationFunc {
 	return []migrationFunc{
+		// Before anything narrows a column. AutoMigrate applies the size:128
+		// tags on these two names, and on PostgreSQL that silently cuts any
+		// value already longer than the new width — the upgrade succeeds and
+		// the name is quietly a different name (#166). Refusing here makes
+		// every engine behave like MySQL, which fails loudly.
+		func(db *gorm.DB) error {
+			return migration.RefuseOversizedColumn[resourceTypes.NetworkResource](ctx, db, "name", migration.MaxNameLength)
+		},
+		func(db *gorm.DB) error {
+			return migration.RefuseOversizedColumn[posture.Checks](ctx, db, "name", migration.MaxNameLength)
+		},
 		func(db *gorm.DB) error {
 			return migration.MigrateFieldFromGobToJSON[types.Account, net.IPNet](ctx, db, "network_net")
 		},


### PR DESCRIPTION
Closes #166, and holds `v0.53.1-alpha.89` until it is in.

## The defect

#159 and #160 put `gorm:"size:128"` on `network_resources.name` and
`posture_checks.name`. `AutoMigrate` applies that to databases that
already hold longer values, and the engines disagree about what that
means. Measured on both tables, both engines, by widening the columns
back to their pre-#159 shape, inserting a 200-character name and running
`AutoMigrate`:

```
postgres/posture_checks     AutoMigrate err=<nil>                      -> stored len=128 (was 200)
postgres/network_resources  AutoMigrate err=<nil>                      -> stored len=128 (was 200)
mysql/posture_checks        AutoMigrate err=Error 1406: Data too long  -> stored len=200 (was 200)
mysql/network_resources     AutoMigrate err=Error 1406: Data too long  -> stored len=200 (was 200)
```

**On PostgreSQL the upgrade succeeds and the name is silently cut to 128
characters.** No error, no warning, the service starts normally, and
nobody learns a name changed until someone looks for a resource by the
name it used to have.

PostgreSQL truncates because the narrowing is applied as an explicit
cast to `varchar(128)`, and an explicit cast truncates where an
assignment would raise "value too long". MySQL has no equivalent
leniency, which is why the defect is invisible from that engine — the
same asymmetry that hid #161 in the other direction.

Neither #159 nor #160 has been released, so no deployment has run this
migration. That is why the release was held rather than the note added
afterwards.

## The fix

`RefuseOversizedColumn` runs in `migratePreAuto`, before anything is
altered, and fails on every engine — making them all behave like the one
that fails loudly. It names the offending rows: refusing without saying
which row to fix turns a guard into an obstacle for whoever is holding
the maintenance window.

A hard failure and not a warning, deliberately. A line in a startup log
is not a decision the operator made, and the operator who misses it is
exactly the one who loses data.

## What the tests pin, and what they did not

Three cases cover the function: every name fits, exactly at the limit
fits, one character over refuses and names the row. Bounded on both
sides on purpose — getting that boundary wrong would block upgrades for
deployments that are inside the rule.

A fourth case covers the **wiring**, which is where the protection
actually lives. Review caught that the first three prove the function is
correct and not that it is called; removing the hook from
`getMigrationsPreAuto` left them all green while PostgreSQL went back to
truncating. That case drives `migratePreAuto` itself, and the mutation
is exact: with the hook removed, only it fails.

Two things the implementation forced, neither obtainable by reasoning:

- `LENGTH` counts characters on SQLite and **bytes** on MySQL;
  `CHAR_LENGTH` counts characters on both MySQL and PostgreSQL. The
  bound is in characters, so a 100-character Japanese name is 300 bytes
  and must not be refused for it. There is a subtest.
- The test cannot simply insert an over-long name — the column is
  already `varchar(128)`, so the insert fails and the test measures the
  column rather than the guard. It reproduces the pre-upgrade schema
  first, which on MySQL means dropping the unique index: `TEXT` is not
  accepted in a key without a prefix length, which is why the column was
  sized to begin with.

The guard also had to learn where it runs. It checked `HasTable` but not
`HasColumn`, and `migratePreAuto` sees the *older* schema by definition
— so a database whose `network_resources` predates the `name` column
failed startup with "no such column", turning a guard against data loss
into a crash. Three tests in `management/client` caught it; running only
the target package would not have.

## Operator documentation

`docs/operator/upgrade-notes.md` is new, and is the durable home for
what has so far lived only in tag messages.

It separates checks to run **before** upgrading from behavior changes to
expect **after**, because those are different kinds of information for
different people at different times. It does not prescribe which
duplicate row to keep — back up, audit the impact, correct, re-run the
query — since which account or check matters is not something a document
can know.

MySQL-only limitations are marked as such before any technical
explanation, and single-replica deployments are told plainly that the
multi-replica invariants do not apply to them.

## Cost

Two full scans at startup, one per table, which cannot use an index.
Both tables are small — a handful of rows per account — and the cost
buys a guarantee that an upgrade never rewrites data.

## Verification

`sqlite`, `postgres` and `mysql` pass. `go test ./management/...` exits
0 with 48 packages ok.
