### PR TITLE
fix(management/store): rebuild account SQL projections

### DIFF
--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -926,6 +926,7 @@ func TestAccountManager_DeleteAccount(t *testing.T) {
 
 	expectedId := "test_account"
 	userId := "account_creator"
+	serviceUser2ID := "service-user-2"
 	account, err := createAccount(manager, expectedId, userId, "")
 	if err != nil {
 		t.Fatal(err)
@@ -946,16 +947,16 @@ func TestAccountManager_DeleteAccount(t *testing.T) {
 			},
 		},
 	}
-	account.Users[userId] = &types.User{
-		Id:            "service-user-2",
+	account.Users[serviceUser2ID] = &types.User{
+		Id:            serviceUser2ID,
 		Role:          types.UserRoleUser,
 		IsServiceUser: true,
 		Issued:        types.UserIssuedAPI,
 		PATs: map[string]*types.PersonalAccessToken{
 			"pat-2": {
 				ID:          "pat-2",
-				UserID:      userId,
-				Name:        userId,
+				UserID:      serviceUser2ID,
+				Name:        serviceUser2ID,
 				HashedToken: "hashedToken",
 				CreatedAt:   time.Now(),
 			},
@@ -981,7 +982,7 @@ func TestAccountManager_DeleteAccount(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, pats, 0)
 
-	pats, err = manager.Store.GetUserPATs(context.Background(), store.LockingStrengthShare, userId)
+	pats, err = manager.Store.GetUserPATs(context.Background(), store.LockingStrengthShare, serviceUser2ID)
 	require.NoError(t, err)
 	assert.Len(t, pats, 0)
 }

--- a/management/server/store/save_account_upsert_test.go
+++ b/management/server/store/save_account_upsert_test.go
@@ -3,14 +3,17 @@ package store
 import (
 	"context"
 	"net"
+	"net/netip"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 
+	nbdns "github.com/openzro/openzro/dns"
 	nbpeer "github.com/openzro/openzro/management/server/peer"
 	"github.com/openzro/openzro/management/server/status"
 	"github.com/openzro/openzro/management/server/types"
+	nbroute "github.com/openzro/openzro/route"
 )
 
 // SaveAccount used to end in a Create carrying
@@ -119,24 +122,25 @@ func TestSaveAccountCreatesAndReplaces(t *testing.T) {
 // same pointer again when the owner's domain has to be written (user.go:819
 // and user.go:836).
 //
-// generateAccountSQLTypes projects the maps into the *G slices with append and
-// no reset, so the second call leaves every child in there twice — measured,
-// 1 then 2 then 3 across three saves of one object (#165).
-//
-// The worry was that removing the parent's upsert turns each duplicate into a
-// plain insert of a key that already exists. It does not, and this test
-// catches nothing today: the database ends correct on all three engines
-// because GORM upserts the associations itself under FullSaveAssociations,
-// independently of whatever clause the parent Create carries.
-//
-// It is here because that correctness rests on GORM behavior nobody chose to
-// depend on. If association handling changes, this fails rather than
-// GetOrCreateAccountByUser does.
+// The same-pointer path used to leave duplicate rows in the in-memory *G
+// projections (#165). The database still ended correct because GORM upserts
+// associations under FullSaveAssociations, but the object no longer described
+// what was being saved and every subsequent save sent more duplicate work.
 func TestSaveAccountTwiceWithTheSameObject(t *testing.T) {
 	runTestForAllEngines(t, "", func(t *testing.T, store Store) {
 		ctx := context.Background()
 
 		account := newAccountWithId(ctx, "resave-acc", "owner-user", "")
+		account.Users["owner-user"].PATs = map[string]*types.PersonalAccessToken{
+			"pat-a": {
+				ID:          "pat-a",
+				UserID:      "owner-user",
+				Name:        "pat a",
+				HashedToken: "hash-a",
+				CreatedBy:   "owner-user",
+				CreatedAt:   time.Now().UTC(),
+			},
+		}
 		key, _ := types.GenerateDefaultSetupKey()
 		account.SetupKeys[key.Key] = key
 		account.Peers["peer-a"] = &nbpeer.Peer{
@@ -154,12 +158,58 @@ func TestSaveAccountTwiceWithTheSameObject(t *testing.T) {
 		require.NoError(t, store.SaveAccount(ctx, account),
 			"saving the same account object twice must not fail")
 
+		require.Len(t, account.PeersG, len(account.Peers), "generated peers must be rebuilt, not accumulated")
+		require.Len(t, account.UsersG, len(account.Users), "generated users must be rebuilt, not accumulated")
+		require.Len(t, account.SetupKeysG, len(account.SetupKeys), "generated setup keys must be rebuilt, not accumulated")
+		require.Len(t, account.GroupsG, len(account.Groups), "generated groups must be rebuilt, not accumulated")
+		require.Len(t, account.Users["owner-user"].PATsG, 1, "nested PAT projections must be rebuilt too")
+
 		stored, err := store.GetAccount(ctx, account.Id)
 		require.NoError(t, err)
 		require.Equal(t, "resaved.example", stored.Domain)
-		require.Len(t, stored.Peers, 1, "the peer was written twice")
-		require.Len(t, stored.Users, 1, "the user was written twice")
-		require.Len(t, stored.SetupKeys, 1, "the setup key was written twice")
-		require.Len(t, stored.Groups, len(account.Groups), "the groups were written twice")
+		require.Len(t, stored.Peers, 1, "the peer must remain single in the database")
+		require.Len(t, stored.Users, 1, "the user must remain single in the database")
+		require.Len(t, stored.SetupKeys, 1, "the setup key must remain single in the database")
+		require.Len(t, stored.Groups, len(account.Groups), "the groups must remain single in the database")
+		require.Len(t, stored.Users["owner-user"].PATs, 1, "the PAT must remain single in the database")
 	})
+}
+
+func TestGenerateAccountSQLTypesRebuildsEveryProjection(t *testing.T) {
+	ctx := context.Background()
+	account := newAccountWithId(ctx, "projection-acc", "projection-user", "")
+	account.DNSZones = map[string]*types.DNSZone{
+		"zone-a": {AccountID: account.Id, Name: "zone a", Domain: "zone.example"},
+	}
+	account.NameServerGroups["ns-a"] = &nbdns.NameServerGroup{AccountID: account.Id, Name: "ns a"}
+	account.Routes["route-a"] = &nbroute.Route{
+		AccountID:   account.Id,
+		Network:     netip.MustParsePrefix("10.10.0.0/24"),
+		NetworkType: nbroute.IPv4Network,
+	}
+	account.Users["projection-user"].PATs = map[string]*types.PersonalAccessToken{
+		"pat-a": {UserID: "projection-user", Name: "pat a", HashedToken: "hash-a"},
+	}
+	key, _ := types.GenerateDefaultSetupKey()
+	account.SetupKeys[key.Key] = key
+	account.Peers["peer-a"] = &nbpeer.Peer{
+		Key:    "projection-peer-key",
+		IP:     net.IP{127, 0, 0, 4},
+		Meta:   nbpeer.PeerSystemMeta{},
+		Name:   "peer a",
+		Status: &nbpeer.PeerStatus{Connected: true, LastSeen: time.Now().UTC()},
+	}
+
+	for range 3 {
+		generateAccountSQLTypes(account)
+	}
+
+	require.Len(t, account.SetupKeysG, len(account.SetupKeys))
+	require.Len(t, account.PeersG, len(account.Peers))
+	require.Len(t, account.UsersG, len(account.Users))
+	require.Len(t, account.GroupsG, len(account.Groups))
+	require.Len(t, account.RoutesG, len(account.Routes))
+	require.Len(t, account.NameServerGroupsG, len(account.NameServerGroups))
+	require.Len(t, account.DNSZonesG, len(account.DNSZones))
+	require.Len(t, account.Users["projection-user"].PATsG, len(account.Users["projection-user"].PATs))
 }

--- a/management/server/store/sql_store.go
+++ b/management/server/store/sql_store.go
@@ -275,6 +275,14 @@ func (s *SqlStore) SaveAccount(ctx context.Context, account *types.Account) erro
 
 // generateAccountSQLTypes generates the GORM compatible types for the account
 func generateAccountSQLTypes(account *types.Account) {
+	account.SetupKeysG = account.SetupKeysG[:0]
+	account.PeersG = account.PeersG[:0]
+	account.UsersG = account.UsersG[:0]
+	account.GroupsG = account.GroupsG[:0]
+	account.RoutesG = account.RoutesG[:0]
+	account.NameServerGroupsG = account.NameServerGroupsG[:0]
+	account.DNSZonesG = account.DNSZonesG[:0]
+
 	for _, key := range account.SetupKeys {
 		account.SetupKeysG = append(account.SetupKeysG, *key)
 	}
@@ -290,6 +298,7 @@ func generateAccountSQLTypes(account *types.Account) {
 
 	for id, user := range account.Users {
 		user.Id = id
+		user.PATsG = user.PATsG[:0]
 		for id, pat := range user.PATs {
 			pat.ID = id
 			user.PATsG = append(user.PATsG, *pat)


### PR DESCRIPTION
## Summary
- reset the generated Account *G projections before rebuilding them
- reset nested user PAT projections as part of the same generated state
- extend the same-pointer SaveAccount test and add a direct projection test covering every generated slice

## Risk
- Security: no auth, permission, or lock behavior changes.
- Performance: positive; repeated saves no longer resend accumulated duplicate association rows.
- Installed base: no schema or API change, so no upgrade note needed.
- Edge cases: covers nested PATs, routes, nameserver groups, and DNS zones, not only the projections named in #165.

## CI follow-up

The first CI run exposed an invalid fixture in `TestAccountManager_DeleteAccount`: it overwrote the account owner with a service user and then expected that same ID to delete the account. The stale projections had masked that. The fixture now keeps the owner and uses a separate service user for the PAT cleanup assertion.

Fixes #165.

## Verification
- go test ./management/server/store -run TestGenerateAccountSQLTypesRebuildsEveryProjection -count=1
- go test ./management/server/store -run TestSaveAccountTwiceWithTheSameObject -count=1
- go test ./management/server/store -count=1
- go test ./management/server/store -race -run 'TestGenerateAccountSQLTypesRebuildsEveryProjection|TestSaveAccountTwiceWithTheSameObject' -count=3
- go test ./management/server -run TestAccountManager_DeleteAccount -count=1
- go test ./management/server -count=1
