### PR TITLE
fix(relay): make cluster lookup timeout configurable

### DIFF
--- a/docs/operator/k8s-deployment-guide.md
+++ b/docs/operator/k8s-deployment-guide.md
@@ -274,6 +274,15 @@ between pods labeled `app.kubernetes.io/name: openzro-relay`. The
 HMAC gate authenticates HELLO either way — NetworkPolicy is
 defense-in-depth, not the primary trust boundary.
 
+The relay waits up to 200 ms for a peer-pod ownership answer on a
+cluster lookup miss. Cache hits and successful lookups return as soon
+as the answer arrives; increasing the value mainly makes a real "peer
+connected nowhere" miss take longer to report. If relay pods run with
+tight CPU limits or on noisy nodes and you see false "peer not found"
+results, set `--cluster-lookup-timeout` or `OZ_CLUSTER_LOOKUP_TIMEOUT`
+to a larger duration such as `2s`. The per-packet forwarding path is
+still capped at 5 s.
+
 See [ADR-0014](../adr/0014-coordinated-multi-pod-relay.md) for the
 full design (broadcast-on-miss locator, single-pod bypass, HELLO
 handshake) and the trade-offs against alternatives like

--- a/relay/cmd/root.go
+++ b/relay/cmd/root.go
@@ -44,10 +44,11 @@ type Config struct {
 	// Multi-pod (ADR-0014) settings — leave ClusterHeadless empty
 	// for single-pod deployments. The relay then runs exactly as
 	// before, with no inter-pod fabric.
-	ClusterHeadless   string // K8s Headless Service FQDN
-	ClusterPort       int    // inter-pod TCP port (default 7090)
-	PodIP             string // POD_IP via the K8s downward API
-	ClusterAuthSecret string // shared HMAC key for HELLO authentication
+	ClusterHeadless      string        // K8s Headless Service FQDN
+	ClusterPort          int           // inter-pod TCP port (default 7090)
+	PodIP                string        // POD_IP via the K8s downward API
+	ClusterAuthSecret    string        // shared HMAC key for HELLO authentication
+	ClusterLookupTimeout time.Duration // locator miss timeout (default 200ms)
 }
 
 func (c Config) Validate() error {
@@ -99,6 +100,7 @@ func init() {
 	rootCmd.PersistentFlags().IntVar(&cobraConfig.ClusterPort, "cluster-port", 0, "inter-pod TCP port (defaults to 7090). Same value on every pod.")
 	rootCmd.PersistentFlags().StringVar(&cobraConfig.PodIP, "pod-ip", "", "this pod's IP, set from the K8s downward API. Required when --cluster-headless is set.")
 	rootCmd.PersistentFlags().StringVar(&cobraConfig.ClusterAuthSecret, "cluster-auth-secret", "", "shared HMAC secret authenticating inter-pod HELLO frames. Same value on every relay pod. Empty = unsigned HELLO (legacy; requires NetworkPolicy isolation).")
+	rootCmd.PersistentFlags().DurationVar(&cobraConfig.ClusterLookupTimeout, "cluster-lookup-timeout", 0, "how long a cluster lookup miss waits for peer-pod answers (defaults to 200ms). Increase when CPU throttling or noisy nodes cause false peer-not-found results.")
 
 	setFlagsFromEnvVars(rootCmd)
 }
@@ -176,18 +178,20 @@ func execute(cmd *cobra.Command, args []string) error {
 	var clusterBoot *server.ClusterBootstrap
 	if cobraConfig.ClusterHeadless != "" {
 		clusterBoot, err = server.StartCluster(clusterCtx, srv.Store(), server.ClusterBootstrapConfig{
-			Headless:   cobraConfig.ClusterHeadless,
-			Port:       cobraConfig.ClusterPort,
-			PodIP:      cobraConfig.PodIP,
-			AuthSecret: cobraConfig.ClusterAuthSecret,
-			Meter:      metricsServer.Meter,
+			Headless:      cobraConfig.ClusterHeadless,
+			Port:          cobraConfig.ClusterPort,
+			PodIP:         cobraConfig.PodIP,
+			AuthSecret:    cobraConfig.ClusterAuthSecret,
+			Meter:         metricsServer.Meter,
+			LookupTimeout: cobraConfig.ClusterLookupTimeout,
 		})
 		if err != nil {
 			return fmt.Errorf("failed to start relay cluster fabric: %w", err)
 		}
 		srv.SetCrossPodForwarder(clusterBoot.Forwarder)
-		log.Infof("relay cluster fabric enabled — headless=%s, pod-ip=%s, port=%d",
-			cobraConfig.ClusterHeadless, cobraConfig.PodIP, cobraConfig.ClusterPort)
+		log.Infof("relay cluster fabric enabled — headless=%s, pod-ip=%s, port=%d, lookup-timeout=%s",
+			cobraConfig.ClusterHeadless, cobraConfig.PodIP, cobraConfig.ClusterPort,
+			clusterBoot.Locator.LookupTimeoutValue())
 	}
 
 	go func() {

--- a/relay/cmd/root.go
+++ b/relay/cmd/root.go
@@ -100,7 +100,7 @@ func init() {
 	rootCmd.PersistentFlags().IntVar(&cobraConfig.ClusterPort, "cluster-port", 0, "inter-pod TCP port (defaults to 7090). Same value on every pod.")
 	rootCmd.PersistentFlags().StringVar(&cobraConfig.PodIP, "pod-ip", "", "this pod's IP, set from the K8s downward API. Required when --cluster-headless is set.")
 	rootCmd.PersistentFlags().StringVar(&cobraConfig.ClusterAuthSecret, "cluster-auth-secret", "", "shared HMAC secret authenticating inter-pod HELLO frames. Same value on every relay pod. Empty = unsigned HELLO (legacy; requires NetworkPolicy isolation).")
-	rootCmd.PersistentFlags().DurationVar(&cobraConfig.ClusterLookupTimeout, "cluster-lookup-timeout", 0, "how long a cluster lookup miss waits for peer-pod answers (defaults to 200ms). Increase when CPU throttling or noisy nodes cause false peer-not-found results.")
+	rootCmd.PersistentFlags().DurationVar(&cobraConfig.ClusterLookupTimeout, "cluster-lookup-timeout", 0, "how long a cluster lookup miss waits for peer-pod answers (defaults to 200ms). Increase when CPU throttling or noisy nodes cause false peer-not-found results; high values make genuine misses wait that long.")
 
 	setFlagsFromEnvVars(rootCmd)
 }

--- a/relay/server/cluster/forwarder_test.go
+++ b/relay/server/cluster/forwarder_test.go
@@ -101,7 +101,7 @@ func makeTransportMsg(t *testing.T, dst messages.PeerID, payload string) []byte 
 // locator, and forwarder. The dispatch handler routes inbound
 // frames through both the locator and the forwarder so a single
 // FrameHandler can serve everything.
-func startForwarderPair(t *testing.T, ownsA, ownsB []messages.PeerID) (
+func startForwarderPair(t *testing.T, ownsA, ownsB []messages.PeerID, opts ...PeerLocatorOption) (
 	*Forwarder, *fakeDispatcher,
 	*Forwarder, *fakeDispatcher,
 	string, string,
@@ -115,8 +115,8 @@ func startForwarderPair(t *testing.T, ownsA, ownsB []messages.PeerID) (
 	transA := NewTransport("127.0.0.1:0", "", nil)
 	transB := NewTransport("127.0.0.1:0", "", nil)
 
-	locA := NewPeerLocator(transA, dispA)
-	locB := NewPeerLocator(transB, dispB)
+	locA := NewPeerLocator(transA, dispA, opts...)
+	locB := NewPeerLocator(transB, dispB, opts...)
 
 	fwdA, err := NewForwarder(transA, locA, dispA)
 	require.NoError(t, err)
@@ -185,6 +185,7 @@ func TestForwarder_RemoteDispatchAcrossPods(t *testing.T) {
 	fwdA, _, _, dispB, _, _ := startForwarderPair(t,
 		nil,
 		[]messages.PeerID{peer}, // B owns the peer
+		WithLookupTimeout(testLookupTimeout),
 	)
 
 	msg := makeTransportMsg(t, peer, "across the fabric")
@@ -268,6 +269,7 @@ func TestForwarder_RemoteDispatchPreservesSrcStamp(t *testing.T) {
 	fwdA, _, _, dispB, _, _ := startForwarderPair(t,
 		nil, // src not on A in this scenario; only matters that dst is on B
 		[]messages.PeerID{dst},
+		WithLookupTimeout(testLookupTimeout),
 	)
 
 	// Seed: build msg as if it came from peer A (slot=dst at this

--- a/relay/server/cluster/locator.go
+++ b/relay/server/cluster/locator.go
@@ -12,11 +12,11 @@ import (
 	"github.com/openzro/openzro/relay/messages"
 )
 
-// LookupTimeout caps how long a single Lookup waits for I_HAVE
-// answers from peer pods. Inter-pod RTT in a healthy cluster is
-// sub-ms; 200 ms is generous and still keeps the relay's hot path
-// responsive when the target peer isn't connected anywhere (every
-// pod stays silent and the lookup times out cleanly into "miss").
+// LookupTimeout is the default cap for how long a single Lookup waits for
+// I_HAVE answers from peer pods. Inter-pod RTT in a healthy cluster is sub-ms;
+// 200 ms keeps the relay's hot path responsive when the target peer isn't
+// connected anywhere. Deployments whose tail latency is dominated by CPU
+// scheduling rather than RTT can raise this per locator.
 const LookupTimeout = 200 * time.Millisecond
 
 // CacheTTL bounds how long a (peer → pod) mapping is trusted
@@ -28,10 +28,10 @@ const LookupTimeout = 200 * time.Millisecond
 // Lookup re-broadcasts.
 const CacheTTL = 5 * time.Minute
 
-// ErrLookupNoOwner is returned when no pod claims the peer within
-// LookupTimeout. The caller should treat this exactly like a
-// single-pod "peer not found" — fail the OpenConn back to the
-// client with the existing error, no retry.
+// ErrLookupNoOwner is returned when no pod claims the peer within the
+// locator's lookup timeout. The caller should treat this exactly like a
+// single-pod "peer not found" — fail the OpenConn back to the client with the
+// existing error, no retry.
 var ErrLookupNoOwner = errors.New("cluster locator: no pod owns this peer")
 
 // LocalOwnership tells the locator which peers this pod owns
@@ -67,6 +67,8 @@ type PeerLocator struct {
 
 	clock   func() time.Time
 	metrics *Metrics
+
+	lookupTimeout time.Duration
 }
 
 type locatorEntry struct {
@@ -82,18 +84,42 @@ type locatorWait struct {
 	done      chan struct{}
 }
 
+// PeerLocatorOption customizes a PeerLocator at construction.
+type PeerLocatorOption func(*PeerLocator)
+
+// WithLookupTimeout sets how long a cache-miss Lookup waits for peer-pod
+// answers. Zero and negative values keep the default.
+func WithLookupTimeout(timeout time.Duration) PeerLocatorOption {
+	return func(pl *PeerLocator) {
+		if timeout > 0 {
+			pl.lookupTimeout = timeout
+		}
+	}
+}
+
+// LookupTimeoutValue returns the effective miss timeout. It is exposed for
+// bootstrap tests and operator diagnostics; callers should still use Lookup.
+func (pl *PeerLocator) LookupTimeoutValue() time.Duration {
+	return pl.lookupTimeout
+}
+
 // NewPeerLocator builds a locator wired to the given transport.
 // `local` answers whether this pod owns a peer (the relay's local
 // peer store). `transport` provides the inter-pod fabric the
 // locator broadcasts on.
-func NewPeerLocator(transport *Transport, local LocalOwnership) *PeerLocator {
-	return &PeerLocator{
-		transport: transport,
-		local:     local,
-		cache:     make(map[messages.PeerID]locatorEntry),
-		waiters:   make(map[messages.PeerID]*locatorWait),
-		clock:     time.Now,
+func NewPeerLocator(transport *Transport, local LocalOwnership, opts ...PeerLocatorOption) *PeerLocator {
+	pl := &PeerLocator{
+		transport:     transport,
+		local:         local,
+		cache:         make(map[messages.PeerID]locatorEntry),
+		waiters:       make(map[messages.PeerID]*locatorWait),
+		clock:         time.Now,
+		lookupTimeout: LookupTimeout,
 	}
+	for _, opt := range opts {
+		opt(pl)
+	}
+	return pl
 }
 
 // SetMetrics installs the cluster metrics handle. Safe to call
@@ -114,7 +140,7 @@ func (pl *PeerLocator) LocalSeqno() uint32 {
 // Lookup resolves the peer to the pod address that currently owns
 // it. Returns the pod's host:port and ok=true on success, or
 // ("", false, ErrLookupNoOwner) if no pod responded within
-// LookupTimeout.
+// the locator's lookup timeout.
 //
 // Cache hits return immediately; misses broadcast WHO_HAS and
 // wait for I_HAVE answers.
@@ -149,7 +175,7 @@ func (pl *PeerLocator) Lookup(ctx context.Context, peer messages.PeerID) (string
 		}
 	}
 
-	timeout := time.NewTimer(LookupTimeout)
+	timeout := time.NewTimer(pl.lookupTimeout)
 	defer timeout.Stop()
 
 	for {

--- a/relay/server/cluster/locator_test.go
+++ b/relay/server/cluster/locator_test.go
@@ -56,9 +56,11 @@ func newPeerID(seed byte) messages.PeerID {
 	return p
 }
 
+const testLookupTimeout = 2 * time.Second
+
 // startPair spins up two transports + locators and dials each
 // other so they form a 2-pod cluster for the test.
-func startPair(t *testing.T, ownsA, ownsB []messages.PeerID) (*PeerLocator, *PeerLocator, string, string) {
+func startPair(t *testing.T, ownsA, ownsB []messages.PeerID, opts ...PeerLocatorOption) (*PeerLocator, *PeerLocator, string, string) {
 	t.Helper()
 	skipOnDarwinCI(t)
 
@@ -68,8 +70,8 @@ func startPair(t *testing.T, ownsA, ownsB []messages.PeerID) (*PeerLocator, *Pee
 	transA := NewTransport("127.0.0.1:0", "", nil)
 	transB := NewTransport("127.0.0.1:0", "", nil)
 
-	locA := NewPeerLocator(transA, ownerA)
-	locB := NewPeerLocator(transB, ownerB)
+	locA := NewPeerLocator(transA, ownerA, opts...)
+	locB := NewPeerLocator(transB, ownerB, opts...)
 
 	transA.handler = &dispatchHandler{loc: locA}
 	transB.handler = &dispatchHandler{loc: locB}
@@ -133,7 +135,7 @@ func waitClusterReady(t *testing.T, tr *Transport, expected string) {
 
 func TestLocator_LookupHitsRemote(t *testing.T) {
 	wanted := newPeerID(0x42)
-	locA, _, _, addrB := startPair(t, nil, []messages.PeerID{wanted})
+	locA, _, _, addrB := startPair(t, nil, []messages.PeerID{wanted}, WithLookupTimeout(testLookupTimeout))
 
 	pod, ok, err := locA.Lookup(context.Background(), wanted)
 	require.NoError(t, err)
@@ -146,7 +148,7 @@ func TestLocator_LookupHitsRemote(t *testing.T) {
 
 func TestLocator_LookupCacheHitSkipsBroadcast(t *testing.T) {
 	wanted := newPeerID(0x10)
-	locA, _, _, addrB := startPair(t, nil, []messages.PeerID{wanted})
+	locA, _, _, addrB := startPair(t, nil, []messages.PeerID{wanted}, WithLookupTimeout(testLookupTimeout))
 
 	_, _, err := locA.Lookup(context.Background(), wanted)
 	require.NoError(t, err)
@@ -190,9 +192,31 @@ func TestLocator_LookupNoPeerPodsFailsFast(t *testing.T) {
 		"with no peer pods to ask, lookup must fail fast — not wait the full timeout")
 }
 
+func TestLocator_LookupTimeoutOption(t *testing.T) {
+	defaulted := NewPeerLocator(
+		NewTransport("127.0.0.1:0", "", nil),
+		newFakeOwner(),
+	)
+	require.Equal(t, LookupTimeout, defaulted.LookupTimeoutValue())
+
+	custom := NewPeerLocator(
+		NewTransport("127.0.0.1:0", "", nil),
+		newFakeOwner(),
+		WithLookupTimeout(2*time.Second),
+	)
+	require.Equal(t, 2*time.Second, custom.LookupTimeoutValue())
+
+	zero := NewPeerLocator(
+		NewTransport("127.0.0.1:0", "", nil),
+		newFakeOwner(),
+		WithLookupTimeout(0),
+	)
+	require.Equal(t, LookupTimeout, zero.LookupTimeoutValue())
+}
+
 func TestLocator_InvalidateDropsCacheEntry(t *testing.T) {
 	wanted := newPeerID(0x55)
-	locA, _, _, _ := startPair(t, nil, []messages.PeerID{wanted})
+	locA, _, _, _ := startPair(t, nil, []messages.PeerID{wanted}, WithLookupTimeout(testLookupTimeout))
 
 	_, _, err := locA.Lookup(context.Background(), wanted)
 	require.NoError(t, err)
@@ -259,7 +283,7 @@ func TestLocator_StaleCacheEntryIsLazilyEvicted(t *testing.T) {
 
 func TestLocator_ConcurrentLookupsShareWaiter(t *testing.T) {
 	wanted := newPeerID(0xAA)
-	locA, _, _, addrB := startPair(t, nil, []messages.PeerID{wanted})
+	locA, _, _, addrB := startPair(t, nil, []messages.PeerID{wanted}, WithLookupTimeout(testLookupTimeout))
 
 	const callers = 8
 	var wg sync.WaitGroup

--- a/relay/server/cluster_fwd.go
+++ b/relay/server/cluster_fwd.go
@@ -12,10 +12,10 @@ import (
 )
 
 // clusterForwardTimeout caps how long handleTransportMsg waits for
-// the cluster fabric to deliver before logging and dropping. The
-// locator's broadcast deadline is ~2 s and inter-pod RTT inside K8s
-// is sub-millisecond; 5 s gives the locator slack while still
-// failing fast on a real partition.
+// the cluster fabric to deliver before logging and dropping. The locator's
+// default miss deadline is shorter, but operators can raise it for
+// CPU-throttled or noisy clusters; 5 s caps that path while still failing fast
+// on a real partition.
 const clusterForwardTimeout = 5 * time.Second
 
 // errClusterPeerNotFound mirrors cluster.ErrPeerNotFound so the

--- a/relay/server/clusterboot.go
+++ b/relay/server/clusterboot.go
@@ -62,6 +62,10 @@ type ClusterBootstrapConfig struct {
 	// Interval is the discovery reconcile period. Defaults to
 	// cluster.DefaultDiscoveryInterval (10 s) when zero.
 	Interval time.Duration
+
+	// LookupTimeout is how long a locator cache miss waits for peer-pod
+	// answers. Defaults to cluster.LookupTimeout when zero.
+	LookupTimeout time.Duration
 }
 
 func (c ClusterBootstrapConfig) validate() error {
@@ -70,6 +74,9 @@ func (c ClusterBootstrapConfig) validate() error {
 	}
 	if c.Port < 0 || c.Port > 65535 {
 		return fmt.Errorf("cluster bootstrap: invalid Port %d", c.Port)
+	}
+	if c.LookupTimeout < 0 {
+		return fmt.Errorf("cluster bootstrap: invalid LookupTimeout %s", c.LookupTimeout)
 	}
 	if c.PodIP == "" {
 		return fmt.Errorf("cluster bootstrap: PodIP is required (set POD_IP via the K8s downward API)")
@@ -122,7 +129,7 @@ func StartCluster(ctx context.Context, st *store.Store, cfg ClusterBootstrapConf
 	}
 
 	dispatcher := NewLocalPeerDispatcher(st)
-	locator := cluster.NewPeerLocator(transport, dispatcher)
+	locator := cluster.NewPeerLocator(transport, dispatcher, cluster.WithLookupTimeout(cfg.LookupTimeout))
 	locator.SetMetrics(metrics)
 	forwarder, err := cluster.NewForwarder(transport, locator, dispatcher)
 	if err != nil {

--- a/relay/server/clusterboot_test.go
+++ b/relay/server/clusterboot_test.go
@@ -22,6 +22,7 @@ func TestStartCluster_RejectsBadConfig(t *testing.T) {
 		{"missing pod ip", ClusterBootstrapConfig{Headless: "x"}},
 		{"negative port", ClusterBootstrapConfig{Headless: "x", PodIP: "10.0.0.1", Port: -1}},
 		{"port too high", ClusterBootstrapConfig{Headless: "x", PodIP: "10.0.0.1", Port: 70000}},
+		{"negative lookup timeout", ClusterBootstrapConfig{Headless: "x", PodIP: "10.0.0.1", LookupTimeout: -time.Second}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -48,10 +49,11 @@ func TestStartCluster_SmokeListensAndStops(t *testing.T) {
 	st := store.NewStore()
 
 	cb, err := StartCluster(context.Background(), st, ClusterBootstrapConfig{
-		Headless: "nope.invalid",
-		Port:     freePort(t),
-		PodIP:    "127.0.0.1",
-		Interval: 50 * time.Millisecond,
+		Headless:      "nope.invalid",
+		Port:          freePort(t),
+		PodIP:         "127.0.0.1",
+		Interval:      50 * time.Millisecond,
+		LookupTimeout: 750 * time.Millisecond,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, cb)
@@ -59,6 +61,7 @@ func TestStartCluster_SmokeListensAndStops(t *testing.T) {
 	require.NotNil(t, cb.Locator)
 	require.NotNil(t, cb.Forwarder)
 	require.NotNil(t, cb.Discovery)
+	require.Equal(t, 750*time.Millisecond, cb.Locator.LookupTimeoutValue())
 
 	// Confirm Stop is idempotent and nil-safe.
 	cb.Stop()

--- a/relay/server/peer.go
+++ b/relay/server/peer.go
@@ -245,9 +245,9 @@ func (p *Peer) handleTransportMsg(msg []byte) {
 	}
 
 	if p.crossPodFwd != nil {
-		// 5 s mirrors the cluster locator's broadcast deadline; a
-		// real K8s in-cluster RTT is sub-millisecond. Anything
-		// slower than 5 s is a partition we'd rather drop on.
+		// 5 s caps the cluster forwarding path even when an operator raises
+		// the locator miss timeout for CPU-throttled or noisy clusters.
+		// Anything slower than this is a partition we'd rather drop on.
 		ctx, cancel := context.WithTimeout(context.Background(), clusterForwardTimeout)
 		defer cancel()
 		if err := p.crossPodFwd.Forward(ctx, *peerID, msg); err != nil {


### PR DESCRIPTION
## Summary
- make the relay cluster lookup timeout configurable per PeerLocator
- expose it through StartCluster and the relay flag/env (`--cluster-lookup-timeout`, `OZ_CLUSTER_LOOKUP_TIMEOUT`)
- keep the production default at 200ms and give the flaky remote-lookup tests a larger per-test timeout without retrying Lookup
- correct stale production comments that described the locator deadline as ~2s

## Risk
- Security: no authentication, frame validation, or trust-boundary changes.
- Performance: cache hits and successful lookups still return immediately. Only real lookup misses can wait longer when an operator opts in, and there is no hard upper bound in code — setting `30s` means a peer connected nowhere can take about `30s` to fail.
- Installed base: default remains 200ms, so existing deployments keep the same behavior.
- Edge cases: negative bootstrap timeouts are rejected; zero keeps the default; tests prove both paths.

Fixes #155.

## Verification
- `go test ./relay/server/cluster -run 'TestLocator_LookupHitsRemote|TestForwarder_RemoteDispatchPreservesSrcStamp|TestLocator_LookupTimeoutOption|TestLocator_ConcurrentLookupsShareWaiter' -race -count=10`
- `go test ./relay/server -run 'TestStartCluster_RejectsBadConfig|TestStartCluster_SmokeListensAndStops' -count=1`
- `go test ./relay/... -count=1`
- `go test ./relay/cmd -count=1`
