### PR TITLE
fix route conflict race across replicas

### DIFF
--- a/docs/operator/upgrade-notes.md
+++ b/docs/operator/upgrade-notes.md
@@ -30,6 +30,22 @@ the failing one may already be applied, so treat a failed upgrade as a
 database whose schema is part-way between the two versions — which is
 another reason to take the backup below before starting.
 
+## Unreleased
+
+### Before upgrading
+
+No pre-upgrade action is required for the route validation change.
+
+### After upgrading
+
+- **Editing a route can now expose duplicate direct-peer routes created
+  by older versions.** Older releases could allow two routes in the
+  same account with the same prefix or domain and the same direct peer.
+  The new validation rejects that state. If editing either duplicate
+  now returns "already has this route", delete one of the duplicate
+  routes first; simply disabling or editing one duplicate can still be
+  rejected because the other duplicate remains.
+
 ## v0.53.1-alpha.89
 
 ### Before upgrading
@@ -176,17 +192,16 @@ concurrent writes competing for the same primary private domain.
 Aligning MySQL's isolation level is tracked in
 [#157](https://github.com/openzro/openzro/issues/157).
 
-### Multi-replica: three invariants are still enforced only in-process
+### Multi-replica: one known invariant is still enforced only in-process
 
 A management deployment running **more than one replica** can still
-produce duplicates for two cases, because the check is a read followed
-by a write protected by a lock that lives inside one process:
+produce duplicates for one known case, because the check is a read
+followed by a write protected by a lock that lives inside one process:
 
 - group names issued through the API
-- route prefix and domain overlap
 
 DNS zone overlap is **not** in that list. It is enforced on both
-engines: on PostgreSQL by the constraint added in this release, and on
+engines: on PostgreSQL by the validation added in this release, and on
 MySQL by InnoDB's gap lock, which refuses the second write. What MySQL
 still lacks there is a usable error, which is the limitation above, not
 a duplication risk.

--- a/management/server/route.go
+++ b/management/server/route.go
@@ -34,12 +34,12 @@ func (am *DefaultAccountManager) GetRoute(ctx context.Context, accountID string,
 }
 
 // checkRoutePrefixOrDomainsExistForPeers checks if a route with a given prefix exists for a single peer or multiple peer groups.
-func checkRoutePrefixOrDomainsExistForPeers(ctx context.Context, transaction store.Store, accountID string, checkRoute *route.Route, groupsMap map[string]*types.Group) error {
+func checkRoutePrefixOrDomainsExistForPeers(ctx context.Context, transaction store.Store, lockStrength store.LockingStrength, accountID string, checkRoute *route.Route, groupsMap map[string]*types.Group) error {
 	// routes can have both peer and peer_groups
 	prefix := checkRoute.Network
 	domains := checkRoute.Domains
 
-	routesWithPrefix, err := getRoutesByPrefixOrDomains(ctx, transaction, accountID, prefix, domains)
+	routesWithPrefix, err := getRoutesByPrefixOrDomains(ctx, transaction, lockStrength, accountID, prefix, domains)
 	if err != nil {
 		return err
 	}
@@ -56,10 +56,10 @@ func checkRoutePrefixOrDomainsExistForPeers(ctx context.Context, transaction sto
 		}
 
 		if prefixRoute.Peer != "" {
-			seenPeers[string(prefixRoute.ID)] = true
+			seenPeers[prefixRoute.Peer] = true
 		}
 
-		peerGroupsMap, err := transaction.GetGroupsByIDs(ctx, store.LockingStrengthShare, accountID, prefixRoute.PeerGroups)
+		peerGroupsMap, err := transaction.GetGroupsByIDs(ctx, lockStrength, accountID, prefixRoute.PeerGroups)
 		if err != nil {
 			return err
 		}
@@ -83,7 +83,7 @@ func checkRoutePrefixOrDomainsExistForPeers(ctx context.Context, transaction sto
 
 	if peerID := checkRoute.Peer; peerID != "" {
 		// check that peerID exists and is not in any route as single peer or part of the group
-		_, err = transaction.GetPeerByID(context.Background(), store.LockingStrengthShare, accountID, peerID)
+		_, err = transaction.GetPeerByID(context.Background(), lockStrength, accountID, peerID)
 		if err != nil {
 			return status.Errorf(status.InvalidArgument, "peer with ID %s not found", peerID)
 		}
@@ -104,7 +104,7 @@ func checkRoutePrefixOrDomainsExistForPeers(ctx context.Context, transaction sto
 		}
 
 		// check that the peers from peerGroupIDs groups are not the same peers we saw in routesWithPrefix
-		peersMap, err := transaction.GetPeersByIDs(ctx, store.LockingStrengthShare, accountID, group.Peers)
+		peersMap, err := transaction.GetPeersByIDs(ctx, lockStrength, accountID, group.Peers)
 		if err != nil {
 			return err
 		}
@@ -172,7 +172,8 @@ func (am *DefaultAccountManager) CreateRoute(ctx context.Context, accountID stri
 			AccessControlGroups: accessControlGroupIDs,
 		}
 
-		if err = validateRoute(ctx, transaction, accountID, newRoute); err != nil {
+		groupsMap, err := validateRouteFieldsAndRefs(ctx, transaction, accountID, newRoute)
+		if err != nil {
 			return err
 		}
 
@@ -182,6 +183,13 @@ func (am *DefaultAccountManager) CreateRoute(ctx context.Context, accountID stri
 		}
 
 		if err = transaction.IncrementNetworkSerial(ctx, store.LockingStrengthUpdate, accountID); err != nil {
+			return err
+		}
+
+		// The route conflict read is deliberately inside the account-row
+		// serialization point, but non-locking: taking route locks after the
+		// account row would invert against route-first writers.
+		if err = checkRoutePrefixOrDomainsExistForPeers(ctx, transaction, store.LockingStrengthNone, accountID, newRoute, groupsMap); err != nil {
 			return err
 		}
 
@@ -218,7 +226,8 @@ func (am *DefaultAccountManager) SaveRoute(ctx context.Context, accountID, userI
 	var newRouteAffectsPeers bool
 
 	err = am.Store.ExecuteInTransaction(ctx, func(transaction store.Store) error {
-		if err = validateRoute(ctx, transaction, accountID, routeToSave); err != nil {
+		groupsMap, err := validateRouteFieldsAndRefs(ctx, transaction, accountID, routeToSave)
+		if err != nil {
 			return err
 		}
 
@@ -239,6 +248,12 @@ func (am *DefaultAccountManager) SaveRoute(ctx context.Context, accountID, userI
 		routeToSave.AccountID = accountID
 
 		if err = transaction.IncrementNetworkSerial(ctx, store.LockingStrengthUpdate, accountID); err != nil {
+			return err
+		}
+
+		// See CreateRoute: the conflict check belongs under the account-row
+		// serialization point, and must not take route locks after it.
+		if err = checkRoutePrefixOrDomainsExistForPeers(ctx, transaction, store.LockingStrengthNone, accountID, routeToSave, groupsMap); err != nil {
 			return err
 		}
 
@@ -313,25 +328,25 @@ func (am *DefaultAccountManager) ListRoutes(ctx context.Context, accountID, user
 	return am.Store.GetAccountRoutes(ctx, store.LockingStrengthShare, accountID)
 }
 
-func validateRoute(ctx context.Context, transaction store.Store, accountID string, routeToSave *route.Route) error {
+func validateRouteFieldsAndRefs(ctx context.Context, transaction store.Store, accountID string, routeToSave *route.Route) (map[string]*types.Group, error) {
 	if routeToSave == nil {
-		return status.Errorf(status.InvalidArgument, "route provided is nil")
+		return nil, status.Errorf(status.InvalidArgument, "route provided is nil")
 	}
 
 	if routeToSave.Metric < route.MinMetric || routeToSave.Metric > route.MaxMetric {
-		return status.Errorf(status.InvalidArgument, "metric should be between %d and %d", route.MinMetric, route.MaxMetric)
+		return nil, status.Errorf(status.InvalidArgument, "metric should be between %d and %d", route.MinMetric, route.MaxMetric)
 	}
 
 	if utf8.RuneCountInString(string(routeToSave.NetID)) > route.MaxNetIDChar || routeToSave.NetID == "" {
-		return status.Errorf(status.InvalidArgument, "identifier should be between 1 and %d", route.MaxNetIDChar)
+		return nil, status.Errorf(status.InvalidArgument, "identifier should be between 1 and %d", route.MaxNetIDChar)
 	}
 
 	if len(routeToSave.Domains) > 0 && routeToSave.Network.IsValid() {
-		return status.Errorf(status.InvalidArgument, "domains and network should not be provided at the same time")
+		return nil, status.Errorf(status.InvalidArgument, "domains and network should not be provided at the same time")
 	}
 
 	if len(routeToSave.Domains) == 0 && !routeToSave.Network.IsValid() {
-		return status.Errorf(status.InvalidArgument, "invalid Prefix")
+		return nil, status.Errorf(status.InvalidArgument, "invalid Prefix")
 	}
 
 	if len(routeToSave.Domains) > 0 {
@@ -339,15 +354,22 @@ func validateRoute(ctx context.Context, transaction store.Store, accountID strin
 	}
 
 	if routeToSave.Peer != "" && len(routeToSave.PeerGroups) != 0 {
-		return status.Errorf(status.InvalidArgument, "peer with ID and peer groups should not be provided at the same time")
+		return nil, status.Errorf(status.InvalidArgument, "peer with ID and peer groups should not be provided at the same time")
 	}
 
 	groupsMap, err := validateRouteGroups(ctx, transaction, accountID, routeToSave)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return checkRoutePrefixOrDomainsExistForPeers(ctx, transaction, accountID, routeToSave, groupsMap)
+	if routeToSave.Peer != "" {
+		_, err = transaction.GetPeerByID(ctx, store.LockingStrengthShare, accountID, routeToSave.Peer)
+		if err != nil {
+			return nil, status.Errorf(status.InvalidArgument, "peer with ID %s not found", routeToSave.Peer)
+		}
+	}
+
+	return groupsMap, nil
 }
 
 // validateRouteGroups validates the route groups and returns the validated groups map.
@@ -493,8 +515,8 @@ func areRouteChangesAffectPeers(ctx context.Context, transaction store.Store, ro
 }
 
 // GetRoutesByPrefixOrDomains return list of routes by account and route prefix
-func getRoutesByPrefixOrDomains(ctx context.Context, transaction store.Store, accountID string, prefix netip.Prefix, domains domain.List) ([]*route.Route, error) {
-	accountRoutes, err := transaction.GetAccountRoutes(ctx, store.LockingStrengthShare, accountID)
+func getRoutesByPrefixOrDomains(ctx context.Context, transaction store.Store, lockStrength store.LockingStrength, accountID string, prefix netip.Prefix, domains domain.List) ([]*route.Route, error) {
+	accountRoutes, err := transaction.GetAccountRoutes(ctx, lockStrength, accountID)
 	if err != nil {
 		return nil, err
 	}

--- a/management/server/route_concurrency_test.go
+++ b/management/server/route_concurrency_test.go
@@ -1,0 +1,120 @@
+package server
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	nbpeer "github.com/openzro/openzro/management/server/peer"
+	"github.com/openzro/openzro/management/server/status"
+	"github.com/openzro/openzro/management/server/store"
+	"github.com/openzro/openzro/management/server/types"
+	"github.com/openzro/openzro/route"
+)
+
+// A peer may only receive one route for a prefix. The check reads existing
+// routes and then writes on the strength of that absence. AcquireWriteLockByUID
+// makes that safe inside one process, but not across replicas.
+func TestRoute_ConcurrentCreateAcrossReplicas(t *testing.T) {
+	const (
+		accountID = "route-race-account"
+		userID    = "route-race-user"
+		peerID    = "route-race-peer"
+		peerKey   = "route-race-peer-key"
+		groupID   = "route-race-group"
+	)
+
+	r := newTwoReplicas(t)
+	ctx := context.Background()
+
+	account := newAccountWithId(ctx, accountID, userID, "route-race.example", false)
+	account.Peers[peerID] = &nbpeer.Peer{
+		ID:       peerID,
+		AccountID: accountID,
+		Key:      peerKey,
+		IP:       net.ParseIP("100.64.0.10"),
+		Name:     "route-race-peer",
+		DNSLabel: "route-race-peer",
+		UserID:   userID,
+		Status:   &nbpeer.PeerStatus{LastSeen: time.Now().UTC(), Connected: true},
+	}
+	account.Groups[groupID] = &types.Group{
+		ID:    groupID,
+		Name:  "route-race-group",
+		Peers: []string{peerID},
+	}
+	require.NoError(t, r.A.Store.SaveAccount(ctx, account))
+
+	// Warm each replica. The barrier below aligns calls, not the first
+	// statement inside each transaction.
+	for _, am := range []*DefaultAccountManager{r.A, r.B} {
+		_, err := am.ListRoutes(ctx, accountID, userID)
+		require.NoError(t, err)
+	}
+
+	prefix := netip.MustParsePrefix("10.77.0.0/24")
+	align := newBarrier()
+	create := func(am *DefaultAccountManager, netID route.NetID) <-chan error {
+		errCh := make(chan error, 1)
+		go func() {
+			align.wait(t)
+			_, err := am.CreateRoute(ctx, accountID, prefix, route.IPv4Network, nil, "", []string{groupID},
+				"route overlap race", netID, false, 1000, []string{groupID}, nil, true, userID, false)
+			errCh <- err
+		}()
+		return errCh
+	}
+
+	errA, errB := create(r.A, "route-race-a"), create(r.B, "route-race-b")
+
+	join := func(name string, ch <-chan error) error {
+		t.Helper()
+		select {
+		case err := <-ch:
+			return err
+		case <-time.After(30 * time.Second):
+			t.Fatalf("replica %s never returned from CreateRoute", name)
+			return nil
+		}
+	}
+	resultA, resultB := join("A", errA), join("B", errB)
+
+	routes, err := r.B.Store.GetAccountRoutes(ctx, store.LockingStrengthShare, accountID)
+	require.NoError(t, err)
+
+	matching := 0
+	for _, rt := range routes {
+		if rt.Network == prefix && slices.Contains(rt.PeerGroups, groupID) {
+			matching++
+		}
+	}
+
+	require.Equal(t, 1, matching,
+		"the account holds %d routes for group %q and prefix %q (A=%v, B=%v)",
+		matching, groupID, prefix, resultA, resultB)
+
+	losers := 0
+	for name, err := range map[string]error{"A": resultA, "B": resultB} {
+		if err == nil {
+			continue
+		}
+		losers++
+		if isRepeatableReadEngine() {
+			require.ErrorContains(t, err, "failed to increment network serial count",
+				"replica %s must lose at the account row, which is what holds this invariant on MySQL today; it got %v", name, err)
+			s, ok := status.FromError(err)
+			require.True(t, ok && s.Type() == status.Internal,
+				"replica %s must lose with the store's internal error, got %v", name, err)
+			continue
+		}
+		s, ok := status.FromError(err)
+		require.True(t, ok && s.Type() == status.AlreadyExists,
+			"replica %s must lose with an actionable route conflict, got %v", name, err)
+	}
+	require.Equal(t, 1, losers, "exactly one create must be rejected (A=%v, B=%v)", resultA, resultB)
+}

--- a/management/server/route_concurrency_test.go
+++ b/management/server/route_concurrency_test.go
@@ -17,9 +17,29 @@ import (
 	"github.com/openzro/openzro/route"
 )
 
-// A peer may only receive one route for a prefix. The check reads existing
-// routes and then writes on the strength of that absence. AcquireWriteLockByUID
-// makes that safe inside one process, but not across replicas.
+func TestRoute_CreateRejectsDuplicatePeerRoute(t *testing.T) {
+	am, err := createRouterManager(t)
+	require.NoError(t, err)
+
+	account, err := initTestRouteAccount(t, am)
+	require.NoError(t, err)
+
+	prefix := netip.MustParsePrefix("10.78.0.0/24")
+	_, err = am.CreateRoute(context.Background(), account.Id, prefix, route.IPv4Network, nil, peer1ID, nil,
+		"first peer route", "first-peer-route", false, 1000, []string{routeGroup1}, nil, true, userID, false)
+	require.NoError(t, err)
+
+	_, err = am.CreateRoute(context.Background(), account.Id, prefix, route.IPv4Network, nil, peer1ID, nil,
+		"duplicate peer route", "duplicate-peer-route", false, 1000, []string{routeGroup1}, nil, true, userID, false)
+	require.ErrorContains(t, err, "already has this route")
+	s, ok := status.FromError(err)
+	require.True(t, ok && s.Type() == status.AlreadyExists, "duplicate peer route must be an actionable conflict, got %v", err)
+}
+
+// A peer group may only receive one route for a prefix. The check reads
+// existing routes and then writes on the strength of that absence.
+// AcquireWriteLockByUID makes that safe inside one process, but not across
+// replicas.
 func TestRoute_ConcurrentCreateAcrossReplicas(t *testing.T) {
 	const (
 		accountID = "route-race-account"
@@ -34,14 +54,14 @@ func TestRoute_ConcurrentCreateAcrossReplicas(t *testing.T) {
 
 	account := newAccountWithId(ctx, accountID, userID, "route-race.example", false)
 	account.Peers[peerID] = &nbpeer.Peer{
-		ID:       peerID,
+		ID:        peerID,
 		AccountID: accountID,
-		Key:      peerKey,
-		IP:       net.ParseIP("100.64.0.10"),
-		Name:     "route-race-peer",
-		DNSLabel: "route-race-peer",
-		UserID:   userID,
-		Status:   &nbpeer.PeerStatus{LastSeen: time.Now().UTC(), Connected: true},
+		Key:       peerKey,
+		IP:        net.ParseIP("100.64.0.10"),
+		Name:      "route-race-peer",
+		DNSLabel:  "route-race-peer",
+		UserID:    userID,
+		Status:    &nbpeer.PeerStatus{LastSeen: time.Now().UTC(), Connected: true},
 	}
 	account.Groups[groupID] = &types.Group{
 		ID:    groupID,
@@ -104,14 +124,8 @@ func TestRoute_ConcurrentCreateAcrossReplicas(t *testing.T) {
 			continue
 		}
 		losers++
-		if isRepeatableReadEngine() {
-			require.ErrorContains(t, err, "failed to increment network serial count",
-				"replica %s must lose at the account row, which is what holds this invariant on MySQL today; it got %v", name, err)
-			s, ok := status.FromError(err)
-			require.True(t, ok && s.Type() == status.Internal,
-				"replica %s must lose with the store's internal error, got %v", name, err)
-			continue
-		}
+		require.ErrorContains(t, err, "already has this route",
+			"replica %s must lose with an actionable route conflict, got %v", name, err)
 		s, ok := status.FromError(err)
 		require.True(t, ok && s.Type() == status.AlreadyExists,
 			"replica %s must lose with an actionable route conflict, got %v", name, err)

--- a/management/server/store/sql_store.go
+++ b/management/server/store/sql_store.go
@@ -2171,9 +2171,13 @@ func (s *SqlStore) DeletePostureChecks(ctx context.Context, lockStrength Locking
 
 // GetAccountRoutes retrieves network routes for an account.
 func (s *SqlStore) GetAccountRoutes(ctx context.Context, lockStrength LockingStrength, accountID string) ([]*route.Route, error) {
+	tx := s.db
+	if lockStrength != LockingStrengthNone {
+		tx = tx.Clauses(clause.Locking{Strength: string(lockStrength)})
+	}
+
 	var routes []*route.Route
-	result := s.db.Clauses(clause.Locking{Strength: string(lockStrength)}).
-		Find(&routes, accountIDCondition, accountID)
+	result := tx.Find(&routes, accountIDCondition, accountID)
 	if err := result.Error; err != nil {
 		log.WithContext(ctx).Errorf("failed to get routes from the store: %s", err)
 		return nil, status.Errorf(status.Internal, "failed to get routes from store")


### PR DESCRIPTION
## Summary

Closes the route prefix/domain phantom window from #143 without changing the MySQL isolation level.

The route conflict check now runs inside the account-row serialization point and uses non-locking reads there, so it does not invert against route-first writers. This closes the Postgres duplicate and, unlike `dns_zones`, also gives MySQL an actionable route conflict instead of relying on a gap-lock deadlock.

The PR also fixes a pre-existing direct-peer validation bug in the same helper: an existing route with `Peer` was recorded under `route.ID` instead of `route.Peer`, so duplicate direct-peer routes could pass even without concurrency.

## Safety / compatibility

- No DDL, no data migration, no pre-upgrade action required.
- No auth, policy, or route-distribution semantics are expanded.
- Existing invalid duplicate direct-peer routes are not rewritten. They do become visible operationally: editing either duplicate can now return `AlreadyExists` because the other duplicate still exists. The supported cleanup path is to delete one duplicate first; this is documented in `docs/operator/upgrade-notes.md`.
- The route scan still happens once per create/update, not twice, but it now runs under the account-row serialization point. For accounts with many matching routes/groups, that includes `GetAccountRoutes` plus the existing per-route group and peer lookups, so concurrent writes in that account can be serialized for longer. This is the cost of moving the read/write proof under a database-visible lock without adding schema.
- `GetAccountRoutes(...LockingStrengthNone)` now avoids emitting `FOR NONE`, matching the pattern already used by the peer/group getters.

## Verification

- Red on Postgres before the fix:
  - `OPENZRO_STORE_ENGINE=postgres go test ./management/server -run TestRoute_ConcurrentCreateAcrossReplicas -count=1`
  - result: two routes persisted, both creates returned `nil`
- Current branch:
  - `OPENZRO_STORE_ENGINE=postgres go test ./management/server -run 'TestRoute_CreateRejectsDuplicatePeerRoute|TestRoute_ConcurrentCreateAcrossReplicas' -count=1`
  - `OPENZRO_STORE_ENGINE=mysql go test ./management/server -run 'TestRoute_CreateRejectsDuplicatePeerRoute|TestRoute_ConcurrentCreateAcrossReplicas' -count=1`
  - `OPENZRO_STORE_ENGINE=postgres go test ./management/server -run 'TestRoute_CreateRejectsDuplicatePeerRoute|TestRoute_ConcurrentCreateAcrossReplicas' -race -count=3`
  - `OPENZRO_STORE_ENGINE=mysql go test ./management/server -run 'TestRoute_CreateRejectsDuplicatePeerRoute|TestRoute_ConcurrentCreateAcrossReplicas' -race -count=3`
  - `go test ./management/server -run 'Test(CreateRoute|SaveRoute|DeleteRoute|Route_|Account_getPeersRoutes|GetRoutes|Route)' -count=1`
  - `go test ./management/... -count=1`

Part of #143.
