### PR TITLE
fix: run MySQL store transactions at READ COMMITTED

### DIFF
--- a/docs/operator/upgrade-notes.md
+++ b/docs/operator/upgrade-notes.md
@@ -38,6 +38,13 @@ No pre-upgrade action is required for the route validation change.
 
 ### After upgrading
 
+- **MySQL management transactions now run at READ COMMITTED.** This
+  aligns MySQL with PostgreSQL for the store transactions opened by the
+  management service. Concurrent conflicts that previously relied on
+  InnoDB gap locks can now reach the explicit validation or unique
+  constraint that explains them. For the known cases fixed so far, the
+  loser gets an actionable conflict or validation error instead of a
+  deadlock/internal error.
 - **Editing a route can now expose duplicate direct-peer routes created
   by older versions.** Older releases could allow two routes in the
   same account with the same prefix or domain and the same direct peer.
@@ -176,22 +183,6 @@ one. Often, not always. Confirm rather than assume.
 
 ## Known limitations
 
-### MySQL: some concurrent conflicts report an unusable error
-
-**PostgreSQL deployments are not affected.**
-
-MySQL runs at REPEATABLE READ, where InnoDB's gap locks refuse certain
-concurrent writes before the constraint that would explain them is
-reached. The invariant holds — nothing incorrect is written — but the
-loser receives a deadlock error rather than a message describing the
-conflict.
-
-Known cases: concurrent creation of overlapping DNS zones, and
-concurrent writes competing for the same primary private domain.
-
-Aligning MySQL's isolation level is tracked in
-[#157](https://github.com/openzro/openzro/issues/157).
-
 ### Multi-replica: one known invariant is still enforced only in-process
 
 A management deployment running **more than one replica** can still
@@ -201,10 +192,8 @@ followed by a write protected by a lock that lives inside one process:
 - group names issued through the API
 
 DNS zone overlap is **not** in that list. It is enforced on both
-engines: on PostgreSQL by the validation added in this release, and on
-MySQL by InnoDB's gap lock, which refuses the second write. What MySQL
-still lacks there is a usable error, which is the limitation above, not
-a duplication risk.
+engines by validation under the account-row serialization point, and a
+concurrent loser receives an actionable overlap error.
 
 Single-replica deployments are unaffected by any of this — the
 in-process lock is sufficient there. Progress is tracked in

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -208,20 +208,17 @@ var primaryDomainWinnerBackoff = []time.Duration{
 // waitForPrimaryDomainWinner looks up the account that claimed domain as
 // primary, retrying briefly while it becomes visible.
 //
-// This is not a retry policy and should not grow into one — that belongs to
-// #157. It resolves one known race: the database has already picked a winner
-// for idx_accounts_primary_private_domain, and on MySQL the loser can be told
-// so through a gap-lock deadlock raised before the winner has finished
-// committing. There is nothing to decide, only something to wait for, and
-// without the wait the loser's login fails for a conflict that has already
-// been resolved in its favor.
+// This is not a retry policy and should not grow into one. It resolves one
+// known race: the database has already picked a winner for
+// idx_accounts_primary_private_domain, and the loser needs the winner's account
+// ID to finish login without creating a competing account. There is nothing to
+// decide, only something to wait for, and without the wait the loser's login
+// fails for a conflict that has already been resolved in its favor.
 //
 // Both login paths use it, and must: signup joins the winner it returns, while
 // the existing-login path only needs to know the domain has an owner before
-// writing itself non-primary. Waiting in one and not the other would leave the
-// UPDATE path — where gap locks are most likely — failing on a winner that
-// exists but has not yet committed. UpdateToPrimaryAccount deliberately does
-// not wait: an explicit promotion that lost should be refused, not retried.
+// writing itself non-primary. UpdateToPrimaryAccount deliberately does not
+// wait: an explicit promotion that lost should be refused, not retried.
 //
 // Gives up on the caller's context, and returns the lookup error when no
 // winner appears within the budget so the caller can report the original
@@ -248,32 +245,20 @@ func (am *DefaultAccountManager) waitForPrimaryDomainWinner(ctx context.Context,
 // lostPrimaryDomainRace reports whether err is how a database tells us another
 // account claimed this private domain first.
 //
-// Two shapes, because the engines refuse the second write at different moments.
-// Postgres has no gap locks, so the insert reaches
-// idx_accounts_primary_private_domain and comes back as a unique violation,
-// which the store classifies into a typed AlreadyExists. MySQL under
-// REPEATABLE READ takes a gap lock on the position the row would occupy, so
-// the two writers deadlock before either insert lands and the loser sees 1213
-// instead — the same race, reported earlier.
+// One shape: the store classifies idx_accounts_primary_private_domain into a
+// typed AlreadyExists. Broader database errors are deliberately not treated as
+// this race, because doing so could send a user into another account after an
+// unrelated failure.
 //
-// Deliberately narrow. Postgres deadlocks (SQLSTATE 40P01) are not read here:
-// nothing on this path produces one, and a deadlock raised by unrelated work
-// in the same transaction would otherwise be reclassified as having lost this
-// race — silently joining another account instead of surfacing it.
-//
-// Neither error is the answer on its own: what decides is the lookup the caller
+// The error is not the answer on its own: what decides is the lookup the caller
 // does next. If no account holds the domain, the caller propagates the original
 // error rather than inventing a winner.
 func lostPrimaryDomainRace(err error) bool {
 	if err == nil {
 		return false
 	}
-	if s, ok := status.FromError(err); ok && s.Type() == status.AlreadyExists {
-		return true
-	}
-	// MySQL raises the deadlock before the insert reaches the index, so there
-	// is no typed error to match on.
-	return strings.Contains(err.Error(), "Error 1213 (40001)")
+	s, ok := status.FromError(err)
+	return ok && s.Type() == status.AlreadyExists
 }
 
 func isUniqueConstraintError(err error) bool {
@@ -1365,12 +1350,6 @@ func (am *DefaultAccountManager) updateAccountDomainAttributesIfNotUpToDate(ctx 
 		// simply is not the primary one, which is exactly what the caller
 		// would have written had the lookup seen the winner (#143).
 		if lostPrimaryDomainRace(err) {
-			// The same wait the signup path uses, for the same reason. This is
-			// an UPDATE moving a row into the index range, which is where
-			// InnoDB gap locks are most likely to raise 1213 — and 1213 is the
-			// one shape that reports before the winner has committed, so an
-			// immediate lookup can miss a winner that exists and turn this
-			// into a failed login.
 			winnerID, lookupErr := am.waitForPrimaryDomainWinner(ctx, newDomain)
 			if lookupErr != nil {
 				log.WithContext(ctx).Errorf("primary domain conflict for %s but no primary account found: %v", newDomain, lookupErr)

--- a/management/server/account_domain_concurrency_test.go
+++ b/management/server/account_domain_concurrency_test.go
@@ -32,9 +32,9 @@ import (
 // replicas. What they get is two primary accounts for one domain, and from
 // then on which one a user lands in depends on which row the lookup returns.
 //
-// The engines differ as in #159 and #160: Postgres persists both, MySQL's gap
-// locks under REPEATABLE READ refuse the second insert. The assertion is what
-// both must satisfy — one account, and both users inside it.
+// Before the primary-domain index, Postgres persisted both accounts while
+// MySQL refused the second write through gap-lock behavior. The assertion is
+// what both engines must satisfy now — one account, and both users inside it.
 func TestAccountDomain_ConcurrentFirstLoginAcrossReplicas(t *testing.T) {
 	const domain = "contested-company.example"
 

--- a/management/server/account_domain_race_test.go
+++ b/management/server/account_domain_race_test.go
@@ -14,17 +14,12 @@ import (
 	"github.com/openzro/openzro/management/server/types"
 )
 
-// The concurrent paths reach lostPrimaryDomainRace through whichever shape the
-// engine happens to raise, and after the signup path moved to CreateAccount
-// every measured conflict — both engines, both paths — arrives as the typed
-// AlreadyExists. A plain INSERT blocks until the winner commits and then
-// reports a duplicate key; the upsert it replaced deadlocked instead.
-//
-// So the MySQL deadlock branch is a contingency that the cross-replica tests no
-// longer exercise. It is kept because InnoDB gap locks under REPEATABLE READ
-// are a real mechanism for this predicate and were observed on this path
-// earlier in this work, but a branch no test reaches is a branch nobody can
-// trust. This pins it directly.
+// The concurrent login paths reach lostPrimaryDomainRace when the database
+// reports that another account already owns the primary private domain. Under
+// READ COMMITTED the create/update waits for the winner and then returns the
+// typed unique-index violation; broader deadlock strings are deliberately not
+// classified as this race, because that could send a user into the wrong
+// account after an unrelated failure.
 func TestLostPrimaryDomainRace(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -42,14 +37,11 @@ func TestLostPrimaryDomainRace(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "the mysql gap-lock deadlock, which arrives untyped",
+			name: "a mysql deadlock, which is not specific enough to move a user into another account",
 			err:  errors.New("Error 1213 (40001): Deadlock found when trying to get lock; try restarting transaction"),
-			want: true,
+			want: false,
 		},
 		{
-			// Postgres has no gap locks on this path, so a deadlock here comes
-			// from unrelated work in the same transaction. Reading it as a lost
-			// domain race would silently send the caller into another account.
 			name: "a postgres deadlock, which is not this race",
 			err:  errors.New("ERROR: deadlock detected (SQLSTATE 40P01)"),
 			want: false,
@@ -71,11 +63,9 @@ func TestLostPrimaryDomainRace(t *testing.T) {
 	}
 }
 
-// waitForPrimaryDomainWinner exists for the deadlock shape above: it is the
-// only one that tells the loser it lost before the winner has committed, so an
-// immediate lookup finds nothing. With CreateAccount the winner is always
-// already visible and the loop returns on its first attempt, which is what the
-// cross-replica runs measure. This drives the other case.
+// waitForPrimaryDomainWinner is intentionally bounded. A typed conflict should
+// usually arrive after the winner commits, but the caller still must not invent
+// a winner if the lookup cannot find one.
 func TestWaitForPrimaryDomainWinner(t *testing.T) {
 	ctx := context.Background()
 	const domain = "late-winner.example"

--- a/management/server/dns_zones_overlap_concurrency_test.go
+++ b/management/server/dns_zones_overlap_concurrency_test.go
@@ -2,8 +2,6 @@ package server
 
 import (
 	"context"
-	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -101,36 +99,6 @@ func TestDNSZones_ConcurrentOverlappingCreateAcrossReplicas(t *testing.T) {
 		}
 		losers++
 
-		// How the loser is told differs by engine, and the difference is the
-		// whole of #157.
-		//
-		// Postgres runs READ COMMITTED and has no gap locks, so the re-check
-		// under the exclusive account row sees the winner's committed zone and
-		// answers with the rejection the caller can act on.
-		//
-		// MySQL runs REPEATABLE READ. The re-check cannot be a locking read —
-		// that would take zone locks after the account row and deadlock
-		// against every writer in this file, which take a zone row first — and
-		// a non-locking read is served from a snapshot established before the
-		// account row was held, so it cannot see the winner. What holds the
-		// invariant there instead is InnoDB's gap lock on the sibling read: the
-		// two creates deadlock and one dies. The invariant survives; the error
-		// is one the caller cannot act on. Aligning MySQL to READ COMMITTED is
-		// #157, and this assertion is what should flip when it lands.
-		if isRepeatableReadEngine() {
-			// Asserted as precisely as the Postgres arm, just against a
-			// different mechanism. Accepting any error would let this pass on
-			// a permission failure, a broken fixture, or some later regression
-			// that happened to leave one zone standing — and the claim being
-			// made is specific: the loser dies at IncrementNetworkSerial,
-			// which is where it was measured.
-			require.ErrorContains(t, err, "failed to increment network serial count",
-				"replica %s must lose at the account row, which is what holds this invariant on MySQL today; it got %v", name, err)
-			s, ok := status.FromError(err)
-			require.True(t, ok && s.Type() == status.Internal,
-				"replica %s must lose with the store's internal error, got %v", name, err)
-			continue
-		}
 		require.ErrorContains(t, err, "overlaps with existing zone",
 			"replica %s lost, but not by being told the domain overlaps; it got %v", name, err)
 		s, ok := status.FromError(err)
@@ -138,10 +106,4 @@ func TestDNSZones_ConcurrentOverlappingCreateAcrossReplicas(t *testing.T) {
 			"replica %s must lose with a rejection the caller can act on, got %v", name, err)
 	}
 	require.Equal(t, 1, losers, "exactly one create must be rejected (A=%v, B=%v)", resultA, resultB)
-}
-
-// isRepeatableReadEngine reports whether the store under test defaults to
-// REPEATABLE READ. Only MySQL does; Postgres and SQLite do not.
-func isRepeatableReadEngine() bool {
-	return types.Engine(strings.ToLower(os.Getenv("OPENZRO_STORE_ENGINE"))) == types.MysqlStoreEngine
 }

--- a/management/server/network_resource_concurrency_test.go
+++ b/management/server/network_resource_concurrency_test.go
@@ -2,8 +2,6 @@ package server
 
 import (
 	"context"
-	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -16,7 +14,6 @@ import (
 	networkTypes "github.com/openzro/openzro/management/server/networks/types"
 	"github.com/openzro/openzro/management/server/permissions"
 	"github.com/openzro/openzro/management/server/store"
-	"github.com/openzro/openzro/management/server/types"
 )
 
 // CreateResource rejects a name already taken in the account. It proves that
@@ -38,9 +35,9 @@ import (
 // This is the demonstration half of #143 step 3: the duplicate has to be shown
 // before it is fixed, so the fix lands red to green rather than by argument.
 //
-// The two engines do not fail the same way, and running this on the wrong one
-// would look like proof it does not need fixing. Measured before the unique
-// index existed:
+// The two engines did not fail the same way before #157, and running this on
+// the wrong one used to look like proof it did not need fixing. Measured before
+// the unique index existed:
 //
 //	Postgres   FAIL — two rows with the same name. No gap locks; predicate
 //	           locking only exists at SERIALIZABLE, so the shared-lock read
@@ -49,9 +46,9 @@ import (
 //	           position the row would occupy and refuse the second insert.
 //	           The loser sees a 1213 deadlock rather than a name conflict.
 //
-// So the red is Postgres-only, and the assertion below is what both engines
-// must satisfy afterwards: exactly one row survives, whichever way the database
-// got there.
+// After #157, MySQL also reaches the unique index and the loser is reported as
+// a taken name. The assertion below is what both engines must satisfy: exactly
+// one row survives, and exactly one create is accepted.
 func TestNetworkResource_ConcurrentCreateAcrossReplicas(t *testing.T) {
 	const (
 		accountID    = "resource-race-account"
@@ -165,17 +162,10 @@ func TestNetworkResource_ConcurrentCreateAcrossReplicas(t *testing.T) {
 		named, resourceName, accepted, resultA, resultB)
 	require.Equal(t, 1, accepted, "exactly one create must be accepted")
 
-	// The loser's error is engine-specific, so assert it where it is
-	// deterministic. On Postgres the insert reaches the unique index and the
-	// store maps the violation to the same answer the pre-check gives. On
-	// MySQL the gap lock fires first and the loser sees a 1213 deadlock
-	// instead — see the note at the top of this file.
-	if types.Engine(strings.ToLower(os.Getenv("OPENZRO_STORE_ENGINE"))) == types.PostgresStoreEngine {
-		loser := resultA
-		if loser == nil {
-			loser = resultB
-		}
-		require.ErrorContains(t, loser, "already exists",
-			"the losing create must be reported as a taken name, not an internal error")
+	loser := resultA
+	if loser == nil {
+		loser = resultB
 	}
+	require.ErrorContains(t, loser, "already exists",
+		"the losing create must be reported as a taken name, not an internal error")
 }

--- a/management/server/networks/resources/manager.go
+++ b/management/server/networks/resources/manager.go
@@ -153,7 +153,7 @@ func (m *managerImpl) CreateResource(ctx context.Context, userID string, resourc
 			return fmt.Errorf("failed to get network: %w", err)
 		}
 
-		err = transaction.SaveNetworkResource(ctx, store.LockingStrengthUpdate, resource)
+		err = transaction.CreateNetworkResource(ctx, store.LockingStrengthUpdate, resource)
 		if err != nil {
 			// The store classifies a unique-index violation for us and returns
 			// the same error the name check above produces, so the loser of a

--- a/management/server/posture_check_concurrency_test.go
+++ b/management/server/posture_check_concurrency_test.go
@@ -2,8 +2,6 @@ package server
 
 import (
 	"context"
-	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -11,7 +9,6 @@ import (
 
 	"github.com/openzro/openzro/management/server/posture"
 	"github.com/openzro/openzro/management/server/store"
-	"github.com/openzro/openzro/management/server/types"
 )
 
 // SavePostureChecks rejects a name already taken in the account. It proves that
@@ -39,14 +36,16 @@ import (
 // exactly that reason. The warm-up below removes the offset; without it, a
 // green run means nothing.
 //
-// The engines do not fail this the same way, and running it on MySQL alone
-// would look like proof the invariant is fine:
+// The engines did not fail this the same way before #157, and running it on
+// MySQL alone used to look like proof the invariant was fine:
 //
 //	Postgres   two rows with the same name
 //	MySQL      the second insert is refused by InnoDB's gap locks under
 //	           REPEATABLE READ, and the loser sees a 1213 deadlock
 //
-// The assertion below is what both must satisfy: exactly one row survives.
+// After #157, MySQL also reaches the unique index and the loser is reported as
+// a taken name. The assertion below is what both must satisfy: exactly one row
+// survives, and exactly one create is accepted.
 func TestPostureChecks_ConcurrentCreateAcrossReplicas(t *testing.T) {
 	const (
 		accountID = "posture-race-account"
@@ -128,16 +127,12 @@ func TestPostureChecks_ConcurrentCreateAcrossReplicas(t *testing.T) {
 		named, checkName, accepted, resultA, resultB)
 	require.Equal(t, 1, accepted, "exactly one create must be accepted")
 
-	// The loser's error is engine-specific; assert it where it is
-	// deterministic. See the note at the top of this file.
-	if types.Engine(strings.ToLower(os.Getenv("OPENZRO_STORE_ENGINE"))) == types.PostgresStoreEngine {
-		loser := resultA
-		if loser == nil {
-			loser = resultB
-		}
-		require.ErrorContains(t, loser, "already exists",
-			"the losing create must be reported as a taken name, not an internal error")
+	loser := resultA
+	if loser == nil {
+		loser = resultB
 	}
+	require.ErrorContains(t, loser, "already exists",
+		"the losing create must be reported as a taken name, not an internal error")
 }
 
 // TestPostureChecks_UpdateToTakenNameIsRejected pins the behavior change that

--- a/management/server/posture_checks.go
+++ b/management/server/posture_checks.go
@@ -71,7 +71,10 @@ func (am *DefaultAccountManager) SavePostureChecks(ctx context.Context, accountI
 		}
 
 		postureChecks.AccountID = accountID
-		return transaction.SavePostureChecks(ctx, store.LockingStrengthUpdate, postureChecks)
+		if isUpdate {
+			return transaction.SavePostureChecks(ctx, store.LockingStrengthUpdate, postureChecks)
+		}
+		return transaction.CreatePostureChecks(ctx, store.LockingStrengthUpdate, postureChecks)
 	})
 	if err != nil {
 		return nil, err

--- a/management/server/save_account_replica_test.go
+++ b/management/server/save_account_replica_test.go
@@ -177,20 +177,6 @@ func TestSaveAccount_ConcurrentAcrossReplicas(t *testing.T) {
 			}
 			losers++
 
-			// How the refusal arrives differs by engine, and the difference is
-			// #157, not this change. MySQL under REPEATABLE READ takes a gap
-			// lock on the index range, so the two writers deadlock before
-			// either insert is refused: the invariant holds, the error is one
-			// the caller cannot act on. Measured identical with and without
-			// the upsert clause, so removing it neither causes nor cures this.
-			//
-			// Pinned to that mechanism rather than to "an error happened",
-			// which would pass on a permission failure or a broken fixture.
-			if isRepeatableReadEngine() {
-				require.ErrorContains(t, err, "Error 1213",
-					"replica %s must lose to the gap-lock deadlock, which is what holds this on MySQL today; got %v", name, err)
-				continue
-			}
 			s, ok := status.FromError(err)
 			require.True(t, ok && s.Type() == status.AlreadyExists,
 				"replica %s must be refused with a typed conflict, not a raw driver error; got %v", name, err)

--- a/management/server/store/sql_store.go
+++ b/management/server/store/sql_store.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -125,6 +126,29 @@ func GetKeyQueryCondition(s *SqlStore) string {
 	return keyQueryCondition
 }
 
+func (s *SqlStore) transactionOptions() *sql.TxOptions {
+	if s.storeEngine != types.MysqlStoreEngine {
+		return nil
+	}
+	return &sql.TxOptions{Isolation: sql.LevelReadCommitted}
+}
+
+func (s *SqlStore) transaction(ctx context.Context, db *gorm.DB, operation func(tx *gorm.DB) error) error {
+	db = db.WithContext(ctx)
+	if opts := s.transactionOptions(); opts != nil {
+		return db.Transaction(operation, opts)
+	}
+	return db.Transaction(operation)
+}
+
+func (s *SqlStore) begin(ctx context.Context) *gorm.DB {
+	db := s.db.WithContext(ctx)
+	if opts := s.transactionOptions(); opts != nil {
+		return db.Begin(opts)
+	}
+	return db.Begin()
+}
+
 // AcquireGlobalLock acquires global lock across all the accounts and returns a function that releases the lock
 func (s *SqlStore) AcquireGlobalLock(ctx context.Context) (unlock func()) {
 	log.WithContext(ctx).Tracef("acquiring global lock")
@@ -224,7 +248,7 @@ func (s *SqlStore) SaveAccount(ctx context.Context, account *types.Account) erro
 
 	generateAccountSQLTypes(account)
 
-	err := s.db.Transaction(func(tx *gorm.DB) error {
+	err := s.transaction(ctx, s.db, func(tx *gorm.DB) error {
 		result := tx.Select(clause.Associations).Delete(account.Policies, "account_id = ?", account.Id)
 		if result.Error != nil {
 			return result.Error
@@ -348,7 +372,7 @@ func (s *SqlStore) checkAccountDomainBeforeSave(ctx context.Context, accountID, 
 func (s *SqlStore) DeleteAccount(ctx context.Context, account *types.Account) error {
 	start := time.Now()
 
-	err := s.db.Transaction(func(tx *gorm.DB) error {
+	err := s.transaction(ctx, s.db, func(tx *gorm.DB) error {
 		result := tx.Select(clause.Associations).Delete(account.Policies, "account_id = ?", account.Id)
 		if result.Error != nil {
 			return result.Error
@@ -398,7 +422,7 @@ func (s *SqlStore) SavePeer(ctx context.Context, lockStrength LockingStrength, a
 	peerCopy := peer.Copy()
 	peerCopy.AccountID = accountID
 
-	err := s.db.Clauses(clause.Locking{Strength: string(lockStrength)}).Transaction(func(tx *gorm.DB) error {
+	err := s.transaction(ctx, s.db.Clauses(clause.Locking{Strength: string(lockStrength)}), func(tx *gorm.DB) error {
 		// check if peer exists before saving
 		var peerID string
 		result := tx.Model(&nbpeer.Peer{}).Select("id").Find(&peerID, accountAndIDQueryCondition, accountID, peer.ID)
@@ -709,7 +733,7 @@ func (s *SqlStore) DeleteUserMFA(ctx context.Context, lockStrength LockingStreng
 }
 
 func (s *SqlStore) DeleteUser(ctx context.Context, lockStrength LockingStrength, accountID, userID string) error {
-	err := s.db.Transaction(func(tx *gorm.DB) error {
+	err := s.transaction(ctx, s.db, func(tx *gorm.DB) error {
 		result := tx.Clauses(clause.Locking{Strength: string(lockStrength)}).
 			Delete(&types.PersonalAccessToken{}, "user_id = ?", userID)
 		if result.Error != nil {
@@ -1774,7 +1798,7 @@ func (s *SqlStore) IncrementNetworkSerial(ctx context.Context, lockStrength Lock
 
 func (s *SqlStore) ExecuteInTransaction(ctx context.Context, operation func(store Store) error) error {
 	startTime := time.Now()
-	tx := s.db.Begin()
+	tx := s.begin(ctx)
 	if tx.Error != nil {
 		return tx.Error
 	}
@@ -2040,7 +2064,7 @@ func (s *SqlStore) SavePolicy(ctx context.Context, lockStrength LockingStrength,
 }
 
 func (s *SqlStore) DeletePolicy(ctx context.Context, lockStrength LockingStrength, accountID, policyID string) error {
-	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+	return s.transaction(ctx, s.db, func(tx *gorm.DB) error {
 		if err := tx.Where("policy_id = ?", policyID).Delete(&types.PolicyRule{}).Error; err != nil {
 			return fmt.Errorf("delete policy rules: %w", err)
 		}
@@ -2143,16 +2167,29 @@ func (s *SqlStore) GetPostureChecksByIDs(ctx context.Context, lockStrength Locki
 	return postureChecksMap, nil
 }
 
-// SavePostureChecks saves a posture checks to the database.
+// CreatePostureChecks inserts a new posture check in the database.
+func (s *SqlStore) CreatePostureChecks(ctx context.Context, lockStrength LockingStrength, postureCheck *posture.Checks) error {
+	result := s.db.Clauses(clause.Locking{Strength: string(lockStrength)}).Create(postureCheck)
+	if result.Error != nil {
+		log.WithContext(ctx).Errorf("failed to create posture checks in store: %s", result.Error)
+		// idx_posture_checks_account_name is what holds the per-account name
+		// invariant across replicas, and this is the only layer that sees the
+		// driver error. Attributing any unique violation on this table to the
+		// name holds while that index and the primary key are the only ones.
+		if isUniqueConstraintViolation(result.Error) {
+			return status.NewPostureCheckNameAlreadyExistsError(postureCheck.Name)
+		}
+		return status.Errorf(status.Internal, "failed to create posture checks in store")
+	}
+
+	return nil
+}
+
+// SavePostureChecks saves a posture check to the database.
 func (s *SqlStore) SavePostureChecks(ctx context.Context, lockStrength LockingStrength, postureCheck *posture.Checks) error {
 	result := s.db.Clauses(clause.Locking{Strength: string(lockStrength)}).Save(postureCheck)
 	if result.Error != nil {
 		log.WithContext(ctx).Errorf("failed to save posture checks to store: %s", result.Error)
-		// Same reasoning as SaveNetworkResource: idx_posture_checks_account_name
-		// is what holds the per-account name invariant across replicas, and
-		// this is the only layer that sees the driver error. Attributing any
-		// unique violation on this table to the name holds while that index and
-		// the primary key are the only ones.
 		if isUniqueConstraintViolation(result.Error) {
 			return status.NewPostureCheckNameAlreadyExistsError(postureCheck.Name)
 		}
@@ -2824,10 +2861,10 @@ func (s *SqlStore) GetNetworkResourceByName(ctx context.Context, lockStrength Lo
 	return netResources, nil
 }
 
-func (s *SqlStore) SaveNetworkResource(ctx context.Context, lockStrength LockingStrength, resource *resourceTypes.NetworkResource) error {
-	result := s.db.Clauses(clause.Locking{Strength: string(lockStrength)}).Save(resource)
+func (s *SqlStore) CreateNetworkResource(ctx context.Context, lockStrength LockingStrength, resource *resourceTypes.NetworkResource) error {
+	result := s.db.Clauses(clause.Locking{Strength: string(lockStrength)}).Create(resource)
 	if result.Error != nil {
-		log.WithContext(ctx).Errorf("failed to save network resource to store: %v", result.Error)
+		log.WithContext(ctx).Errorf("failed to create network resource in store: %v", result.Error)
 		// idx_network_resources_account_name is what holds the per-account
 		// name invariant across replicas, so a violation here is the loser of
 		// a real race, not an internal fault. Classified here because this is
@@ -2841,6 +2878,19 @@ func (s *SqlStore) SaveNetworkResource(ctx context.Context, lockStrength Locking
 		// the offending constraint differently (Postgres and MySQL give the
 		// index name, SQLite gives the columns), so it would mean per-engine
 		// parsing rather than one more string match.
+		if isUniqueConstraintViolation(result.Error) {
+			return status.NewResourceNameAlreadyExistsError(resource.Name)
+		}
+		return status.Errorf(status.Internal, "failed to create network resource in store")
+	}
+
+	return nil
+}
+
+func (s *SqlStore) SaveNetworkResource(ctx context.Context, lockStrength LockingStrength, resource *resourceTypes.NetworkResource) error {
+	result := s.db.Clauses(clause.Locking{Strength: string(lockStrength)}).Save(resource)
+	if result.Error != nil {
+		log.WithContext(ctx).Errorf("failed to save network resource to store: %v", result.Error)
 		if isUniqueConstraintViolation(result.Error) {
 			return status.NewResourceNameAlreadyExistsError(resource.Name)
 		}

--- a/management/server/store/store.go
+++ b/management/server/store/store.go
@@ -151,6 +151,7 @@ type Store interface {
 	GetAllPostureChecks(ctx context.Context, lockStrength LockingStrength) ([]*posture.Checks, error)
 	GetPostureChecksByID(ctx context.Context, lockStrength LockingStrength, accountID, postureCheckID string) (*posture.Checks, error)
 	GetPostureChecksByIDs(ctx context.Context, lockStrength LockingStrength, accountID string, postureChecksIDs []string) (map[string]*posture.Checks, error)
+	CreatePostureChecks(ctx context.Context, lockStrength LockingStrength, postureCheck *posture.Checks) error
 	SavePostureChecks(ctx context.Context, lockStrength LockingStrength, postureCheck *posture.Checks) error
 	DeletePostureChecks(ctx context.Context, lockStrength LockingStrength, accountID, postureChecksID string) error
 
@@ -240,6 +241,7 @@ type Store interface {
 	GetNetworkResourcesByAccountID(ctx context.Context, lockStrength LockingStrength, accountID string) ([]*resourceTypes.NetworkResource, error)
 	GetNetworkResourceByID(ctx context.Context, lockStrength LockingStrength, accountID, resourceID string) (*resourceTypes.NetworkResource, error)
 	GetNetworkResourceByName(ctx context.Context, lockStrength LockingStrength, accountID, resourceName string) (*resourceTypes.NetworkResource, error)
+	CreateNetworkResource(ctx context.Context, lockStrength LockingStrength, resource *resourceTypes.NetworkResource) error
 	SaveNetworkResource(ctx context.Context, lockStrength LockingStrength, resource *resourceTypes.NetworkResource) error
 	DeleteNetworkResource(ctx context.Context, lockStrength LockingStrength, accountID, resourceID string) error
 	GetPeerByIP(ctx context.Context, lockStrength LockingStrength, accountID string, ip net.IP) (*nbpeer.Peer, error)

--- a/management/server/store/transaction_isolation_test.go
+++ b/management/server/store/transaction_isolation_test.go
@@ -1,0 +1,81 @@
+package store
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/rs/xid"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+
+	"github.com/openzro/openzro/management/server/types"
+)
+
+func TestSqlStore_MySQLExecuteInTransactionUsesReadCommitted(t *testing.T) {
+	sqlStore := newMySQLIsolationTestStore(t)
+	assertTransactionSeesConcurrentCommit(t, sqlStore, func(fn func(*gorm.DB) error) error {
+		return sqlStore.ExecuteInTransaction(context.Background(), func(tx Store) error {
+			return fn(tx.(*SqlStore).db)
+		})
+	})
+}
+
+func TestSqlStore_MySQLDirectTransactionUsesReadCommitted(t *testing.T) {
+	sqlStore := newMySQLIsolationTestStore(t)
+	assertTransactionSeesConcurrentCommit(t, sqlStore, func(fn func(*gorm.DB) error) error {
+		return sqlStore.transaction(context.Background(), sqlStore.db, fn)
+	})
+}
+
+func newMySQLIsolationTestStore(t *testing.T) *SqlStore {
+	t.Helper()
+
+	if types.Engine(strings.ToLower(os.Getenv("OPENZRO_STORE_ENGINE"))) != types.MysqlStoreEngine {
+		t.Skip("MySQL isolation sentinel only runs in the mysql store job")
+	}
+
+	store, cleanup, err := NewTestStoreFromSQL(context.Background(), "", t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(cleanup)
+
+	sqlStore, ok := store.(*SqlStore)
+	require.True(t, ok, "mysql test store must be *SqlStore")
+	return sqlStore
+}
+
+func assertTransactionSeesConcurrentCommit(t *testing.T, sqlStore *SqlStore, runTx func(func(*gorm.DB) error) error) {
+	t.Helper()
+
+	ctx := context.Background()
+	accountID := xid.New().String()
+	account := &types.Account{
+		Id:      accountID,
+		Network: types.NewNetwork(),
+	}
+	require.NoError(t, sqlStore.CreateAccount(ctx, account))
+
+	err := runTx(func(tx *gorm.DB) error {
+		first := readNetworkSerial(t, tx, accountID)
+
+		require.NoError(t,
+			sqlStore.db.Exec("UPDATE accounts SET network_serial = network_serial + 1 WHERE id = ?", accountID).Error,
+			"the concurrent autocommit write should be visible to a READ COMMITTED transaction")
+
+		second := readNetworkSerial(t, tx, accountID)
+		require.Equal(t, first+1, second,
+			"mysql store transactions must use READ COMMITTED; REPEATABLE READ would keep seeing %d", first)
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func readNetworkSerial(t *testing.T, db *gorm.DB, accountID string) uint64 {
+	t.Helper()
+
+	var serial uint64
+	require.NoError(t,
+		db.Model(&types.Account{}).Select("network_serial").Where("id = ?", accountID).Scan(&serial).Error)
+	return serial
+}


### PR DESCRIPTION
## Summary

Closes #157.

This moves MySQL store transactions to `READ COMMITTED`, matching the PostgreSQL transaction behavior the management server already runs with.

- route all `SqlStore` transaction entry points through a small helper that applies `sql.TxOptions{Isolation: sql.LevelReadCommitted}` only for MySQL
- add MySQL-only sentinels proving both `ExecuteInTransaction` and the direct transaction helper see a concurrent committed write inside the same transaction
- update the concurrency tests whose MySQL branch used to depend on InnoDB gap locks, so MySQL now has to return the same actionable validation/conflict errors as PostgreSQL
- keep create paths for network resources and posture checks insert-only, so the unique indexes added earlier can report the loser instead of being absorbed by GORM `Save`
- update operator notes: no pre-upgrade action for this change, and the old MySQL deadlock/internal-error limitation is removed

## Scope and safety

No schema migration is added here.

The isolation change is limited to transactions opened by `management/server/store.SqlStore`. Migration/activity-store transactions are left alone.

This PR does not try to solve the remaining `group.name` product question from #143. That invariant is still documented as a known multi-replica limitation. I checked the MySQL side before opening this: under `READ COMMITTED` it did not persist duplicate API group names; the path still loses at the existing account-row upgrade deadlock. That is known debt, not a new #157 regression.

Security-wise, this does not widen authorization or change permission checks. The visible behavior change is narrower and intentional: concurrent conflicts that previously surfaced as MySQL deadlock/internal errors now reach the explicit validation or unique constraint and return the conflict the caller can act on.

Performance-wise, this should reduce InnoDB gap-lock contention rather than increase it. The two new `Create*` store methods are used only on create paths and avoid `Save` semantics where an insert-only operation is intended.

## Verification

- `git diff --check`
- `GOCACHE=/tmp/openzro-gocache go test ./management/server/... -count=1`
- `GOCACHE=/tmp/openzro-gocache OPENZRO_STORE_ENGINE=mysql go test ./management/server ./management/server/store -race -run 'TestSqlStore_MySQL(ExecuteInTransaction|DirectTransaction)UsesReadCommitted|TestDNSZones_ConcurrentOverlappingCreateAcrossReplicas|TestRoute_ConcurrentCreateAcrossReplicas|TestNetworkResource_ConcurrentCreateAcrossReplicas|TestPostureChecks_ConcurrentCreateAcrossReplicas|TestAccountDomain_Concurrent|TestSaveAccount_ConcurrentAcrossReplicas|TestLostPrimaryDomainRace|TestWaitForPrimaryDomainWinner' -count=1`
- `GOCACHE=/tmp/openzro-gocache OPENZRO_STORE_ENGINE=postgres go test ./management/server ./management/server/store -race -run 'TestDNSZones_ConcurrentOverlappingCreateAcrossReplicas|TestRoute_ConcurrentCreateAcrossReplicas|TestNetworkResource_ConcurrentCreateAcrossReplicas|TestPostureChecks_ConcurrentCreateAcrossReplicas|TestAccountDomain_Concurrent|TestSaveAccount_ConcurrentAcrossReplicas|TestLostPrimaryDomainRace|TestWaitForPrimaryDomainWinner' -count=1`
