### PR TITLE
fix: scope JWT group sync by issuer

### DIFF
--- a/docs/operator/upgrade-notes.md
+++ b/docs/operator/upgrade-notes.md
@@ -52,6 +52,16 @@ No pre-upgrade action is required for the route validation change.
   now returns "already has this route", delete one of the duplicate
   routes first; simply disabling or editing one duplicate can still be
   rejected because the other duplicate remains.
+- **JWT group sync no longer joins a user to a manual/API group just
+  because the IdP sends the same display name.** That unsafe join would
+  let a manually created group grant access by name collision alone. If
+  the IdP sends a name already used by an API group, openZro now creates
+  or uses a separate JWT-managed group with the same name. Existing
+  policies still point to group IDs, so policies that reference the API
+  group will not automatically grant access to the new JWT group. Add
+  the JWT group to the intended policies after it appears; ship the
+  dashboard group-origin labels with this change so operators can tell
+  the two groups apart.
 
 ## v0.53.1-alpha.89
 

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -277,9 +277,11 @@ func isUniqueConstraintError(err error) bool {
 // Returns a bool indicating if there are changes in the JWT group membership, the updated user AutoGroups,
 // newly groups to create and an error if any occurred.
 func (am *DefaultAccountManager) getJWTGroupsChanges(user *types.User, groups []*types.Group, groupNames []string) (bool, []string, []*types.Group, error) {
-	existedGroupsByName := make(map[string]*types.Group)
+	existedJWTGroupsByName := make(map[string]*types.Group)
 	for _, group := range groups {
-		existedGroupsByName[group.Name] = group
+		if group.Issued == types.GroupIssuedJWT {
+			existedJWTGroupsByName[group.Name] = group
+		}
 	}
 
 	newUserAutoGroups, jwtGroupsMap := separateGroups(user.AutoGroups, groups)
@@ -296,7 +298,7 @@ func (am *DefaultAccountManager) getJWTGroupsChanges(user *types.User, groups []
 
 	var modified bool
 	for _, name := range groupsToAdd {
-		group, exists := existedGroupsByName[name]
+		group, exists := existedJWTGroupsByName[name]
 		if !exists {
 			group = &types.Group{
 				ID:        xid.New().String(),

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -2804,6 +2804,21 @@ func TestAccount_SetJWTGroups(t *testing.T) {
 
 	assert.NoError(t, manager.Store.SaveAccount(context.Background(), account), "unable to save account")
 
+	groupsByNameAndIssuer := func(t *testing.T, name, issued string) []*types.Group {
+		t.Helper()
+
+		groups, err := manager.Store.GetAccountGroups(context.Background(), store.LockingStrengthShare, "accountID")
+		require.NoError(t, err)
+
+		var matches []*types.Group
+		for _, group := range groups {
+			if group.Name == name && group.Issued == issued {
+				matches = append(matches, group)
+			}
+		}
+		return matches
+	}
+
 	t.Run("skip sync for token auth type", func(t *testing.T) {
 		claims := nbcontext.UserAuth{
 			UserId:    "user1",
@@ -2833,7 +2848,7 @@ func TestAccount_SetJWTGroups(t *testing.T) {
 		assert.Empty(t, user.AutoGroups, "auto groups must be empty")
 	})
 
-	t.Run("jwt match existing api group", func(t *testing.T) {
+	t.Run("jwt creates its own group when a name matches an existing api group", func(t *testing.T) {
 		claims := nbcontext.UserAuth{
 			UserId:    "user1",
 			AccountId: "accountID",
@@ -2844,14 +2859,19 @@ func TestAccount_SetJWTGroups(t *testing.T) {
 
 		user, err := manager.Store.GetUserByUserID(context.Background(), store.LockingStrengthShare, "user1")
 		assert.NoError(t, err, "unable to get user")
-		assert.Len(t, user.AutoGroups, 0)
+		require.Len(t, user.AutoGroups, 1)
 
-		group1, err := manager.Store.GetGroupByID(context.Background(), store.LockingStrengthShare, "accountID", "group1")
-		assert.NoError(t, err, "unable to get group")
-		assert.Equal(t, group1.Issued, types.GroupIssuedAPI, "group should be api issued")
+		apiGroups := groupsByNameAndIssuer(t, "group1", types.GroupIssuedAPI)
+		require.Len(t, apiGroups, 1, "the API group must remain owned by the API source")
+		assert.NotContains(t, user.AutoGroups, apiGroups[0].ID,
+			"JWT sync must not attach a user to an API group by matching a human-readable name")
+
+		jwtGroups := groupsByNameAndIssuer(t, "group1", types.GroupIssuedJWT)
+		require.Len(t, jwtGroups, 1, "JWT should create its own group with the same display name")
+		assert.Contains(t, user.AutoGroups, jwtGroups[0].ID)
 	})
 
-	t.Run("jwt match existing api group in user auto groups", func(t *testing.T) {
+	t.Run("jwt keeps an existing api group and adds the jwt-owned group with the same name", func(t *testing.T) {
 		account.Users["user1"].AutoGroups = []string{"group1"}
 		assert.NoError(t, manager.Store.SaveUser(context.Background(), store.LockingStrengthUpdate, account.Users["user1"]))
 
@@ -2865,11 +2885,16 @@ func TestAccount_SetJWTGroups(t *testing.T) {
 
 		user, err := manager.Store.GetUserByUserID(context.Background(), store.LockingStrengthShare, "user1")
 		assert.NoError(t, err, "unable to get user")
-		assert.Len(t, user.AutoGroups, 1)
+		require.Len(t, user.AutoGroups, 2)
 
-		group1, err := manager.Store.GetGroupByID(context.Background(), store.LockingStrengthShare, "accountID", "group1")
-		assert.NoError(t, err, "unable to get group")
-		assert.Equal(t, group1.Issued, types.GroupIssuedAPI, "group should be api issued")
+		apiGroups := groupsByNameAndIssuer(t, "group1", types.GroupIssuedAPI)
+		require.Len(t, apiGroups, 1)
+		assert.Contains(t, user.AutoGroups, apiGroups[0].ID,
+			"pre-existing non-JWT groups should be preserved when JWT groups are synced")
+
+		jwtGroups := groupsByNameAndIssuer(t, "group1", types.GroupIssuedJWT)
+		require.Len(t, jwtGroups, 1)
+		assert.Contains(t, user.AutoGroups, jwtGroups[0].ID)
 	})
 
 	t.Run("add jwt group", func(t *testing.T) {
@@ -2883,7 +2908,7 @@ func TestAccount_SetJWTGroups(t *testing.T) {
 
 		user, err := manager.Store.GetUserByUserID(context.Background(), store.LockingStrengthShare, "user1")
 		assert.NoError(t, err, "unable to get user")
-		assert.Len(t, user.AutoGroups, 2, "groups count should not be change")
+		assert.Len(t, user.AutoGroups, 3, "API group1 plus JWT group1 and group2 should remain")
 	})
 
 	t.Run("existed group not update", func(t *testing.T) {
@@ -2911,11 +2936,11 @@ func TestAccount_SetJWTGroups(t *testing.T) {
 
 		groups, err := manager.Store.GetAccountGroups(context.Background(), store.LockingStrengthShare, "accountID")
 		assert.NoError(t, err)
-		assert.Len(t, groups, 3, "new group3 should be added")
+		assert.Len(t, groups, 4, "new group3 should be added alongside the API and JWT group1 groups")
 
 		user, err := manager.Store.GetUserByUserID(context.Background(), store.LockingStrengthShare, "user2")
 		assert.NoError(t, err, "unable to get user")
-		assert.Len(t, user.AutoGroups, 1, "new group should be added")
+		assert.Len(t, user.AutoGroups, 2, "JWT group1 and group3 should be added")
 	})
 
 	t.Run("remove all JWT groups when list is empty", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #173.

JWT group sync now looks up existing groups by name only inside the JWT issuer/source. If a JWT claim has the same display name as an API-created group, sync creates a JWT-owned group with that name and adds the user there.

## Security contract

This keeps the important safe half of the old behavior: JWT sync still does **not** attach a user to an API group by matching a human-readable name.

The new behavior is the missing half of the same contract:

> Group names are unique only within the same issuer/source. Cross-source name collisions are allowed, but sync paths must never overwrite or attach to groups owned by another issuer by name alone.

So the dashboard can show two groups named `Engineering`, but one is API-owned and one is JWT-owned. Same display name, different authority.

## Operator impact

This fixes the silent sync failure, but it does **not** automatically grant the access that an existing API group had.

Policies reference group IDs, not names. If a policy points to the API-owned `Engineering` group, a newly created JWT-owned `Engineering` group is a different group and must be added to the intended policies. Otherwise the user will sync into the JWT group correctly but still not receive policy access.

This should ship with the dashboard group-origin labels (#177) so operators can tell the same-name API/JWT groups apart.

## Verification

- `GOCACHE=/tmp/openzro-gocache go test ./management/server -run 'TestAccount_SetJWTGroups|TestDefaultAccountManager_SyncUserJWTGroups' -count=1`
- `GOCACHE=/tmp/openzro-gocache go test ./management/server -run TestAccount_SetJWTGroups -count=5`
- `GOCACHE=/tmp/openzro-gocache go test ./management/server -count=1`
