### PR TITLE
fix: unblock SCIM group provisioning and scope names by issuer

### DIFF
--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -3603,6 +3603,236 @@ func TestPropagateUserGroupMemberships(t *testing.T) {
 	})
 }
 
+func TestSCIMCreateGroup_ScopesDisplayNameToIntegrationGroups(t *testing.T) {
+	manager, err := createManager(t)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	initiatorID := "test-user"
+	account, err := manager.GetOrCreateAccountByUser(ctx, initiatorID, "example.com")
+	require.NoError(t, err)
+
+	apiGroup := &types.Group{
+		Name:   "Shared display name",
+		Issued: types.GroupIssuedAPI,
+		Peers:  []string{},
+	}
+	require.NoError(t, manager.SaveGroup(ctx, account.Id, initiatorID, apiGroup, true))
+
+	scimGroup, err := requireSCIMGroupResult(t, func() (*types.Group, error) {
+		return manager.SCIMCreateGroup(ctx, account.Id, initiatorID, apiGroup.Name, nil)
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, apiGroup.ID, scimGroup.ID, "SCIM must not attach to an API group by displayName")
+	require.Equal(t, types.GroupIssuedIntegration, scimGroup.Issued)
+
+	apiGroups := accountGroupsByNameAndIssued(t, manager, account.Id, apiGroup.Name, types.GroupIssuedAPI)
+	require.Len(t, apiGroups, 1)
+	require.Equal(t, apiGroup.ID, apiGroups[0].ID)
+
+	scimGroups := accountGroupsByNameAndIssued(t, manager, account.Id, apiGroup.Name, types.GroupIssuedIntegration)
+	require.Len(t, scimGroups, 1)
+	require.Equal(t, scimGroup.ID, scimGroups[0].ID)
+
+	_, err = requireSCIMGroupResult(t, func() (*types.Group, error) {
+		return manager.SCIMCreateGroup(ctx, account.Id, initiatorID, apiGroup.Name, nil)
+	})
+	require.ErrorIs(t, err, ErrSCIMGroupAlreadyExists)
+	scimGroups = accountGroupsByNameAndIssued(t, manager, account.Id, apiGroup.Name, types.GroupIssuedIntegration)
+	require.Len(t, scimGroups, 1, "SCIM must reject duplicates within the integration source")
+}
+
+func TestSCIMUpdateGroup_ScopesDisplayNameToIntegrationGroups(t *testing.T) {
+	testCases := []struct {
+		name   string
+		rename func(ctx context.Context, manager *DefaultAccountManager, accountID, initiatorID, groupID, displayName string) (*types.Group, error)
+	}{
+		{
+			name: "replace",
+			rename: func(ctx context.Context, manager *DefaultAccountManager, accountID, initiatorID, groupID, displayName string) (*types.Group, error) {
+				return manager.SCIMReplaceGroup(ctx, accountID, initiatorID, groupID, displayName, nil)
+			},
+		},
+		{
+			name: "rename",
+			rename: func(ctx context.Context, manager *DefaultAccountManager, accountID, initiatorID, groupID, displayName string) (*types.Group, error) {
+				return manager.SCIMRenameGroup(ctx, accountID, initiatorID, groupID, displayName)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			manager, err := createManager(t)
+			require.NoError(t, err)
+
+			ctx := context.Background()
+			initiatorID := "test-user"
+			account, err := manager.GetOrCreateAccountByUser(ctx, initiatorID, "example.com")
+			require.NoError(t, err)
+
+			apiGroup := &types.Group{
+				Name:   "Shared display name",
+				Issued: types.GroupIssuedAPI,
+				Peers:  []string{},
+			}
+			require.NoError(t, manager.SaveGroup(ctx, account.Id, initiatorID, apiGroup, true))
+
+			firstSCIMGroup, err := requireSCIMGroupResult(t, func() (*types.Group, error) {
+				return manager.SCIMCreateGroup(ctx, account.Id, initiatorID, "Original SCIM name", nil)
+			})
+			require.NoError(t, err)
+			secondSCIMGroup, err := requireSCIMGroupResult(t, func() (*types.Group, error) {
+				return manager.SCIMCreateGroup(ctx, account.Id, initiatorID, "Other SCIM name", nil)
+			})
+			require.NoError(t, err)
+
+			updated, err := requireSCIMGroupResult(t, func() (*types.Group, error) {
+				return tc.rename(ctx, manager, account.Id, initiatorID, firstSCIMGroup.ID, apiGroup.Name)
+			})
+			require.NoError(t, err)
+			require.Equal(t, apiGroup.Name, updated.Name)
+
+			apiGroups := accountGroupsByNameAndIssued(t, manager, account.Id, apiGroup.Name, types.GroupIssuedAPI)
+			require.Len(t, apiGroups, 1)
+			require.Equal(t, apiGroup.ID, apiGroups[0].ID)
+
+			scimGroups := accountGroupsByNameAndIssued(t, manager, account.Id, apiGroup.Name, types.GroupIssuedIntegration)
+			require.Len(t, scimGroups, 1)
+			require.Equal(t, firstSCIMGroup.ID, scimGroups[0].ID)
+
+			_, err = requireSCIMGroupResult(t, func() (*types.Group, error) {
+				return tc.rename(ctx, manager, account.Id, initiatorID, secondSCIMGroup.ID, apiGroup.Name)
+			})
+			require.ErrorIs(t, err, ErrSCIMGroupAlreadyExists)
+
+			unchanged, err := manager.Store.GetGroupByID(ctx, store.LockingStrengthShare, account.Id, secondSCIMGroup.ID)
+			require.NoError(t, err)
+			require.Equal(t, "Other SCIM name", unchanged.Name)
+		})
+	}
+}
+
+func TestSCIMUpdateGroup_AllowsLegacyIntegrationDuplicateWhenNameIsUnchanged(t *testing.T) {
+	testCases := []struct {
+		name   string
+		rename func(ctx context.Context, manager *DefaultAccountManager, accountID, initiatorID, groupID, displayName string) (*types.Group, error)
+	}{
+		{
+			name: "replace",
+			rename: func(ctx context.Context, manager *DefaultAccountManager, accountID, initiatorID, groupID, displayName string) (*types.Group, error) {
+				return manager.SCIMReplaceGroup(ctx, accountID, initiatorID, groupID, displayName, nil)
+			},
+		},
+		{
+			name: "rename",
+			rename: func(ctx context.Context, manager *DefaultAccountManager, accountID, initiatorID, groupID, displayName string) (*types.Group, error) {
+				return manager.SCIMRenameGroup(ctx, accountID, initiatorID, groupID, displayName)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			manager, err := createManager(t)
+			require.NoError(t, err)
+
+			ctx := context.Background()
+			initiatorID := "test-user"
+			account, err := manager.GetOrCreateAccountByUser(ctx, initiatorID, "example.com")
+			require.NoError(t, err)
+
+			legacyGroups := []*types.Group{
+				{ID: "legacy-scim-1", AccountID: account.Id, Name: "Legacy SCIM name", Issued: types.GroupIssuedIntegration},
+				{ID: "legacy-scim-2", AccountID: account.Id, Name: "Legacy SCIM name", Issued: types.GroupIssuedIntegration},
+			}
+			require.NoError(t, manager.Store.SaveGroups(ctx, store.LockingStrengthUpdate, account.Id, legacyGroups))
+
+			updated, err := requireSCIMGroupResult(t, func() (*types.Group, error) {
+				return tc.rename(ctx, manager, account.Id, initiatorID, legacyGroups[0].ID, legacyGroups[0].Name)
+			})
+			require.NoError(t, err)
+			require.Equal(t, legacyGroups[0].Name, updated.Name)
+
+			matches := accountGroupsByNameAndIssued(t, manager, account.Id, legacyGroups[0].Name, types.GroupIssuedIntegration)
+			require.Len(t, matches, 2, "idempotent SCIM updates must not break existing duplicate data")
+		})
+	}
+}
+
+func TestSCIMDeleteGroup_ReturnsWhileHoldingAccountLock(t *testing.T) {
+	manager, err := createManager(t)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	initiatorID := "test-user"
+	account, err := manager.GetOrCreateAccountByUser(ctx, initiatorID, "example.com")
+	require.NoError(t, err)
+	scimServiceUser := types.NewUser("scim-service-user", types.UserRoleAdmin, true, false, "SCIM", nil, types.UserIssuedAPI)
+	scimServiceUser.AccountID = account.Id
+	require.NoError(t, manager.Store.SaveUser(ctx, store.LockingStrengthUpdate, scimServiceUser))
+
+	scimGroup, err := requireSCIMGroupResult(t, func() (*types.Group, error) {
+		return manager.SCIMCreateGroup(ctx, account.Id, initiatorID, "SCIM group", nil)
+	})
+	require.NoError(t, err)
+
+	err = requireSCIMGroupError(t, func() error {
+		return manager.SCIMDeleteGroup(ctx, account.Id, scimServiceUser.Id, scimGroup.ID)
+	})
+	require.NoError(t, err)
+
+	_, err = manager.Store.GetGroupByID(ctx, store.LockingStrengthShare, account.Id, scimGroup.ID)
+	require.Error(t, err)
+}
+
+type scimGroupResult struct {
+	group *types.Group
+	err   error
+}
+
+func requireSCIMGroupResult(t *testing.T, call func() (*types.Group, error)) (*types.Group, error) {
+	t.Helper()
+
+	done := make(chan scimGroupResult, 1)
+	go func() {
+		group, err := call()
+		done <- scimGroupResult{group: group, err: err}
+	}()
+
+	select {
+	case result := <-done:
+		return result.group, result.err
+	case <-time.After(10 * time.Second):
+		t.Fatal("SCIM group call never returned; it may be blocked on a re-entered account lock")
+		return nil, nil
+	}
+}
+
+func requireSCIMGroupError(t *testing.T, call func() error) error {
+	t.Helper()
+
+	_, err := requireSCIMGroupResult(t, func() (*types.Group, error) {
+		return nil, call()
+	})
+	return err
+}
+
+func accountGroupsByNameAndIssued(t *testing.T, manager *DefaultAccountManager, accountID, name, issued string) []*types.Group {
+	t.Helper()
+
+	groups, err := manager.Store.GetAccountGroups(context.Background(), store.LockingStrengthShare, accountID)
+	require.NoError(t, err)
+
+	var matches []*types.Group
+	for _, group := range groups {
+		if group.Name == name && group.Issued == issued {
+			matches = append(matches, group)
+		}
+	}
+	return matches
+}
+
 // TestSCIMRemoveGroupMember_RecoversFromPartialWrite pins openzro
 // #104 review-1: a retry after a partial-write failure (User.AutoGroups
 // already removed by an earlier attempt, but Group.Peers still

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -3805,7 +3805,7 @@ func requireSCIMGroupResult(t *testing.T, call func() (*types.Group, error)) (*t
 		return result.group, result.err
 	case <-time.After(10 * time.Second):
 		t.Fatal("SCIM group call never returned; it may be blocked on a re-entered account lock")
-		return nil, nil
+		return nil, assert.AnError
 	}
 }
 

--- a/management/server/group.go
+++ b/management/server/group.go
@@ -449,16 +449,15 @@ func validateNewGroup(ctx context.Context, transaction store.Store, accountID st
 	}
 
 	if newGroup.ID == "" && newGroup.Issued == types.GroupIssuedAPI {
-		existingGroup, err := transaction.GetGroupByName(ctx, store.LockingStrengthShare, accountID, newGroup.Name)
+		existingGroupIDs, err := transaction.GetGroupIDsByNameAndIssued(ctx, store.LockingStrengthShare, accountID, newGroup.Name, types.GroupIssuedAPI)
 		if err != nil {
-			if s, ok := status.FromError(err); !ok || s.Type() != status.NotFound {
-				return err
-			}
+			return err
 		}
 
-		// Prevent duplicate groups for API-issued groups.
-		// Integration or JWT groups can be duplicated as they are coming from the IdP that we don't have control of.
-		if existingGroup != nil {
+		// Group display names are unique only within the same issuer.
+		// JWT and integration groups are owned by their IdP source and
+		// may intentionally share a display name with an API group.
+		if len(existingGroupIDs) > 0 {
 			return status.Errorf(status.AlreadyExists, "group with name %s already exists", newGroup.Name)
 		}
 

--- a/management/server/group_scim.go
+++ b/management/server/group_scim.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/rs/xid"
+
 	"github.com/openzro/openzro/management/server/account"
 	"github.com/openzro/openzro/management/server/permissions/modules"
 	"github.com/openzro/openzro/management/server/permissions/operations"
@@ -31,17 +33,18 @@ func (am *DefaultAccountManager) SCIMCreateGroup(ctx context.Context, accountID,
 		return nil, status.Errorf(status.InvalidArgument, "displayName is required")
 	}
 
-	if existing, _ := am.Store.GetGroupByName(ctx, store.LockingStrengthShare, displayName, accountID); existing != nil {
-		return nil, ErrSCIMGroupAlreadyExists
+	if err := am.validateSCIMGroupNameAvailable(ctx, accountID, displayName, ""); err != nil {
+		return nil, err
 	}
 
 	group := &types.Group{
+		ID:        xid.New().String(),
 		AccountID: accountID,
 		Name:      displayName,
 		Issued:    types.GroupIssuedIntegration,
 		Peers:     []string{},
 	}
-	if err := am.SaveGroup(ctx, accountID, callerID, group, true); err != nil {
+	if err := am.SaveGroups(ctx, accountID, callerID, []*types.Group{group}, true); err != nil {
 		return nil, err
 	}
 	propagated, err := am.applySCIMGroupMembers(ctx, accountID, group.ID, memberUserIDs, nil)
@@ -73,10 +76,13 @@ func (am *DefaultAccountManager) SCIMReplaceGroup(ctx context.Context, accountID
 	if err != nil {
 		return nil, ErrSCIMGroupNotFound
 	}
-	if displayName != "" {
+	if displayName != "" && displayName != group.Name {
+		if err := am.validateSCIMGroupNameAvailable(ctx, accountID, displayName, groupID); err != nil {
+			return nil, err
+		}
 		group.Name = displayName
 	}
-	if err := am.SaveGroup(ctx, accountID, callerID, group, false); err != nil {
+	if err := am.SaveGroups(ctx, accountID, callerID, []*types.Group{group}, false); err != nil {
 		return nil, err
 	}
 	prev, err := am.usersInGroup(ctx, accountID, groupID)
@@ -167,10 +173,13 @@ func (am *DefaultAccountManager) SCIMRenameGroup(ctx context.Context, accountID,
 	if err != nil {
 		return nil, ErrSCIMGroupNotFound
 	}
-	if newName != "" {
+	if newName != "" && newName != group.Name {
+		if err := am.validateSCIMGroupNameAvailable(ctx, accountID, newName, groupID); err != nil {
+			return nil, err
+		}
 		group.Name = newName
 	}
-	if err := am.SaveGroup(ctx, accountID, callerID, group, false); err != nil {
+	if err := am.SaveGroups(ctx, accountID, callerID, []*types.Group{group}, false); err != nil {
 		return nil, err
 	}
 	return group, nil
@@ -219,7 +228,7 @@ func (am *DefaultAccountManager) SCIMDeleteGroup(ctx context.Context, accountID,
 	if propagated {
 		am.UpdateAccountPeers(ctx, accountID)
 	}
-	return am.DeleteGroup(ctx, accountID, callerID, groupID)
+	return am.DeleteGroups(ctx, accountID, callerID, []string{groupID})
 }
 
 // SCIMListGroups returns groups in the account, filtered by display
@@ -491,6 +500,19 @@ func (am *DefaultAccountManager) requireSCIMGroupPermission(ctx context.Context,
 	}
 	if !allowed {
 		return status.NewPermissionDeniedError()
+	}
+	return nil
+}
+
+func (am *DefaultAccountManager) validateSCIMGroupNameAvailable(ctx context.Context, accountID, displayName, currentGroupID string) error {
+	groupIDs, err := am.Store.GetGroupIDsByNameAndIssued(ctx, store.LockingStrengthShare, accountID, displayName, types.GroupIssuedIntegration)
+	if err != nil {
+		return err
+	}
+	for _, groupID := range groupIDs {
+		if groupID != currentGroupID {
+			return ErrSCIMGroupAlreadyExists
+		}
 	}
 	return nil
 }

--- a/management/server/group_test.go
+++ b/management/server/group_test.go
@@ -30,36 +30,64 @@ const (
 
 func TestDefaultAccountManager_CreateGroup(t *testing.T) {
 	am, err := createManager(t)
-	if err != nil {
-		t.Error("failed to create account manager")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	account, err := am.GetOrCreateAccountByUser(ctx, groupAdminUserID, "example.com")
+	require.NoError(t, err)
+
+	apiGroup := &types.Group{
+		Name:   "Shared API name",
+		Issued: types.GroupIssuedAPI,
+		Peers:  []string{},
+	}
+	require.NoError(t, am.SaveGroup(ctx, account.Id, groupAdminUserID, apiGroup, true))
+	require.NotEmpty(t, apiGroup.ID)
+
+	apiDuplicate := &types.Group{
+		Name:   apiGroup.Name,
+		Issued: types.GroupIssuedAPI,
+		Peers:  []string{},
+	}
+	err = am.SaveGroup(ctx, account.Id, groupAdminUserID, apiDuplicate, true)
+	require.Error(t, err)
+	s, ok := status.FromError(err)
+	require.True(t, ok)
+	require.Equal(t, status.AlreadyExists, s.Type())
+
+	testCases := []struct {
+		name   string
+		issued string
+	}{
+		{
+			name:   "integration",
+			issued: types.GroupIssuedIntegration,
+		},
+		{
+			name:   "jwt",
+			issued: types.GroupIssuedJWT,
+		},
 	}
 
-	_, account, err := initTestGroupAccount(am)
-	if err != nil {
-		t.Fatalf("failed to init testing account: %s", err)
-	}
-	for _, group := range account.Groups {
-		group.Issued = types.GroupIssuedIntegration
-		err = am.SaveGroup(context.Background(), account.Id, groupAdminUserID, group, true)
-		if err != nil {
-			t.Errorf("should allow to create %s groups", types.GroupIssuedIntegration)
-		}
-	}
+	for _, tc := range testCases {
+		t.Run("api can share a name with "+tc.name, func(t *testing.T) {
+			sourceGroup := &types.Group{
+				ID:     "idp-" + tc.name,
+				Name:   "IdP owned name " + tc.name,
+				Issued: tc.issued,
+				Peers:  []string{},
+			}
+			require.NoError(t, am.SaveGroup(ctx, account.Id, groupAdminUserID, sourceGroup, true))
 
-	for _, group := range account.Groups {
-		group.Issued = types.GroupIssuedJWT
-		err = am.SaveGroup(context.Background(), account.Id, groupAdminUserID, group, true)
-		if err != nil {
-			t.Errorf("should allow to create %s groups", types.GroupIssuedJWT)
-		}
-	}
-	for _, group := range account.Groups {
-		group.Issued = types.GroupIssuedAPI
-		group.ID = ""
-		err = am.SaveGroup(context.Background(), account.Id, groupAdminUserID, group, true)
-		if err == nil {
-			t.Errorf("should not create api group with the same name, %s", group.Name)
-		}
+			apiSameName := &types.Group{
+				Name:   sourceGroup.Name,
+				Issued: types.GroupIssuedAPI,
+				Peers:  []string{},
+			}
+			require.NoError(t, am.SaveGroup(ctx, account.Id, groupAdminUserID, apiSameName, true))
+			require.NotEmpty(t, apiSameName.ID)
+			require.NotEqual(t, sourceGroup.ID, apiSameName.ID)
+		})
 	}
 }
 

--- a/management/server/mock_server/account_mock.go
+++ b/management/server/mock_server/account_mock.go
@@ -46,7 +46,7 @@ type MockAccountManager struct {
 	AddPeerFunc              func(ctx context.Context, setupKey string, userId string, peer *nbpeer.Peer) (*nbpeer.Peer, *types.NetworkMap, []*posture.Checks, error)
 	GetGroupFunc             func(ctx context.Context, accountID, groupID, userID string) (*types.Group, error)
 	GetAllGroupsFunc         func(ctx context.Context, accountID, userID string) ([]*types.Group, error)
-	GetGroupByNameFunc       func(ctx context.Context, accountID, groupName string) (*types.Group, error)
+	GetGroupByNameFunc       func(ctx context.Context, groupName, accountID string) (*types.Group, error)
 	SaveGroupFunc            func(ctx context.Context, accountID, userID string, group *types.Group, create bool) error
 	SaveGroupsFunc           func(ctx context.Context, accountID, userID string, groups []*types.Group, create bool) error
 	DeleteGroupFunc          func(ctx context.Context, accountID, userId, groupID string) error
@@ -463,9 +463,9 @@ func (am *MockAccountManager) AddPeer(
 }
 
 // GetGroupByName mock implementation of GetGroupByName from server.AccountManager interface
-func (am *MockAccountManager) GetGroupByName(ctx context.Context, accountID, groupName string) (*types.Group, error) {
-	if am.GetGroupFunc != nil {
-		return am.GetGroupByNameFunc(ctx, accountID, groupName)
+func (am *MockAccountManager) GetGroupByName(ctx context.Context, groupName, accountID string) (*types.Group, error) {
+	if am.GetGroupByNameFunc != nil {
+		return am.GetGroupByNameFunc(ctx, groupName, accountID)
 	}
 	return nil, status.Errorf(codes.Unimplemented, "method GetGroupByName is not implemented")
 }

--- a/management/server/store/sql_store.go
+++ b/management/server/store/sql_store.go
@@ -1942,6 +1942,25 @@ func (s *SqlStore) GetGroupByName(ctx context.Context, lockStrength LockingStren
 	return &group, nil
 }
 
+// GetGroupIDsByNameAndIssued retrieves group IDs matching an account, display
+// name, and source.
+func (s *SqlStore) GetGroupIDsByNameAndIssued(ctx context.Context, lockStrength LockingStrength, accountID, groupName, issued string) ([]string, error) {
+	tx := s.db
+	if lockStrength != LockingStrengthNone {
+		tx = tx.Clauses(clause.Locking{Strength: string(lockStrength)})
+	}
+
+	var groupIDs []string
+	result := tx.Model(&types.Group{}).
+		Where("account_id = ? AND name = ? AND issued = ?", accountID, groupName, issued).
+		Pluck("id", &groupIDs)
+	if result.Error != nil {
+		log.WithContext(ctx).Errorf("failed to get group IDs by name and issued from store: %v", result.Error)
+		return nil, status.Errorf(status.Internal, "failed to get group IDs by name and issued from store")
+	}
+	return groupIDs, nil
+}
+
 // GetGroupsByIDs retrieves groups by their IDs and account ID.
 func (s *SqlStore) GetGroupsByIDs(ctx context.Context, lockStrength LockingStrength, accountID string, groupIDs []string) (map[string]*types.Group, error) {
 	tx := s.db

--- a/management/server/store/sql_store_test.go
+++ b/management/server/store/sql_store_test.go
@@ -1281,6 +1281,22 @@ func TestSqlite_GetGroupByName(t *testing.T) {
 	require.True(t, group.IsGroupAll())
 }
 
+func TestSqlStore_GetGroupIDsByNameAndIssued(t *testing.T) {
+	runTestForAllEngines(t, "../testdata/extended-store.sql", func(t *testing.T, store Store) {
+		accountID := "bf1c8084-ba50-4ce7-9439-34653001fc3b"
+		groups := []*types.Group{
+			{ID: "api-shared", AccountID: accountID, Name: "Shared", Issued: types.GroupIssuedAPI},
+			{ID: "scim-shared", AccountID: accountID, Name: "Shared", Issued: types.GroupIssuedIntegration},
+			{ID: "scim-other", AccountID: accountID, Name: "Other", Issued: types.GroupIssuedIntegration},
+		}
+		require.NoError(t, store.SaveGroups(context.Background(), LockingStrengthUpdate, accountID, groups))
+
+		groupIDs, err := store.GetGroupIDsByNameAndIssued(context.Background(), LockingStrengthShare, accountID, "Shared", types.GroupIssuedIntegration)
+		require.NoError(t, err)
+		require.Equal(t, []string{"scim-shared"}, groupIDs)
+	})
+}
+
 func Test_DeleteSetupKeySuccessfully(t *testing.T) {
 	t.Setenv("OPENZRO_STORE_ENGINE", string(types.SqliteStoreEngine))
 	store, cleanup, err := NewTestStoreFromSQL(context.Background(), "../testdata/extended-store.sql", t.TempDir())

--- a/management/server/store/store.go
+++ b/management/server/store/store.go
@@ -127,7 +127,7 @@ type Store interface {
 	GetAccountGroups(ctx context.Context, lockStrength LockingStrength, accountID string) ([]*types.Group, error)
 	GetResourceGroups(ctx context.Context, lockStrength LockingStrength, accountID, resourceID string) ([]*types.Group, error)
 	GetGroupByID(ctx context.Context, lockStrength LockingStrength, accountID, groupID string) (*types.Group, error)
-	GetGroupByName(ctx context.Context, lockStrength LockingStrength, accountID, groupName string) (*types.Group, error)
+	GetGroupByName(ctx context.Context, lockStrength LockingStrength, groupName, accountID string) (*types.Group, error)
 	GetGroupIDsByNameAndIssued(ctx context.Context, lockStrength LockingStrength, accountID, groupName, issued string) ([]string, error)
 	GetGroupsByIDs(ctx context.Context, lockStrength LockingStrength, accountID string, groupIDs []string) (map[string]*types.Group, error)
 	SaveGroups(ctx context.Context, lockStrength LockingStrength, accountID string, groups []*types.Group) error

--- a/management/server/store/store.go
+++ b/management/server/store/store.go
@@ -127,7 +127,7 @@ type Store interface {
 	GetAccountGroups(ctx context.Context, lockStrength LockingStrength, accountID string) ([]*types.Group, error)
 	GetResourceGroups(ctx context.Context, lockStrength LockingStrength, accountID, resourceID string) ([]*types.Group, error)
 	GetGroupByID(ctx context.Context, lockStrength LockingStrength, accountID, groupID string) (*types.Group, error)
-	GetGroupByName(ctx context.Context, lockStrength LockingStrength, groupName, accountID string) (*types.Group, error)
+	GetGroupByName(ctx context.Context, lockStrength LockingStrength, accountID, groupName string) (*types.Group, error)
 	GetGroupIDsByNameAndIssued(ctx context.Context, lockStrength LockingStrength, accountID, groupName, issued string) ([]string, error)
 	GetGroupsByIDs(ctx context.Context, lockStrength LockingStrength, accountID string, groupIDs []string) (map[string]*types.Group, error)
 	SaveGroups(ctx context.Context, lockStrength LockingStrength, accountID string, groups []*types.Group) error

--- a/management/server/store/store.go
+++ b/management/server/store/store.go
@@ -127,7 +127,8 @@ type Store interface {
 	GetAccountGroups(ctx context.Context, lockStrength LockingStrength, accountID string) ([]*types.Group, error)
 	GetResourceGroups(ctx context.Context, lockStrength LockingStrength, accountID, resourceID string) ([]*types.Group, error)
 	GetGroupByID(ctx context.Context, lockStrength LockingStrength, accountID, groupID string) (*types.Group, error)
-	GetGroupByName(ctx context.Context, lockStrength LockingStrength, groupName, accountID string) (*types.Group, error)
+	GetGroupByName(ctx context.Context, lockStrength LockingStrength, accountID, groupName string) (*types.Group, error)
+	GetGroupIDsByNameAndIssued(ctx context.Context, lockStrength LockingStrength, accountID, groupName, issued string) ([]string, error)
 	GetGroupsByIDs(ctx context.Context, lockStrength LockingStrength, accountID string, groupIDs []string) (map[string]*types.Group, error)
 	SaveGroups(ctx context.Context, lockStrength LockingStrength, accountID string, groups []*types.Group) error
 	SaveGroup(ctx context.Context, lockStrength LockingStrength, group *types.Group) error


### PR DESCRIPTION
Closes #172.

## What changed
- Fixed a production SCIM deadlock: SCIM create/replace/rename/delete already hold `AcquireWriteLockByUID`, so calling public `SaveGroup`/`DeleteGroup` re-entered the same non-reentrant account mutex and could block forever while holding the account write lock. These paths now call the internal `SaveGroups`/`DeleteGroups` variants while the SCIM method owns the lock.
- Corrected the store interface parameter names for `GetGroupByName` so they match the implementation and call sites.
- Added a narrow store lookup for group IDs by account, display name, and issued source.
- Scoped SCIM `displayName` collision checks to integration-issued groups only.
- Scoped API group creation checks to API-issued groups only, so an IdP-owned JWT/SCIM group no longer blocks a manual/API group with the same display name.
- Generated an ID before saving SCIM-created groups, matching the existing integration-group validation contract.

## Security and compatibility
- Group display names are unique only within the same issuer/source. Cross-source name collisions are allowed, but sync paths must never attach to or overwrite a group owned by another source by name alone.
- SCIM no longer attaches to or rejects a group owned by another source just because the `displayName` matches. API/JWT groups with the same name are left untouched.
- API/manual group creation no longer rejects a name owned only by JWT/SCIM.
- SCIM and API still reject new duplicates within their own source.
- Idempotent update of legacy duplicate integration groups is preserved when the `displayName` is unchanged, so existing data is not made harder to sync.
- This PR deliberately does not add a database unique index for `(account_id, issued, name)`. That would require a separate upgrade plan because group name/source columns are not currently bounded for MySQL indexing, `SaveGroups` still uses `ON CONFLICT`/`ON DUPLICATE KEY`, and case/accent semantics need an explicit product decision.

## Verification
- `go test ./management/server -run 'TestDefaultAccountManager_CreateGroup|TestSCIM(Create|Update|Delete)Group' -count=1`
- `go test ./management/server ./management/server/store -count=1`
- `GOCACHE=/tmp/openzro-scim-gocache2 go test ./management/server -run 'TestSCIM(Create|Update|Delete)Group' -count=1`
- `GOCACHE=/tmp/openzro-scim-store-gocache2 go test ./management/server/store -run 'TestSqlStore_GetGroupIDsByNameAndIssued|TestSqlite_GetGroupByName' -count=1`
- Temporary merge of #175 + #176 in `/tmp/openzro-groups-combo`: `go test ./management/server -run 'TestAccount_SetJWTGroups|TestDefaultAccountManager_CreateGroup|TestSCIM(Create|Update|Delete)Group' -count=1` and `go test ./management/server/store -run 'TestSqlStore_GetGroupIDsByNameAndIssued|TestSqlite_GetGroupByName' -count=1`
