### PR TITLE
fix: show group origin in dashboard selectors

### DIFF
--- a/dashboard/src/components/PeerGroupSelector.tsx
+++ b/dashboard/src/components/PeerGroupSelector.tsx
@@ -42,11 +42,22 @@ import {
 } from "@/components/v2/OzTabs";
 import { useGroups } from "@/contexts/GroupsProvider";
 import { useElementSize } from "@/hooks/useElementSize";
-import type { Group, GroupPeer, GroupResource } from "@/interfaces/Group";
+import {
+  GroupIssued,
+  type Group,
+  type GroupPeer,
+  type GroupResource,
+} from "@/interfaces/Group";
 import { NetworkResource } from "@/interfaces/Network";
 import type { Peer } from "@/interfaces/Peer";
 import { PolicyRuleResource } from "@/interfaces/Policy";
 import { User } from "@/interfaces/User";
+import {
+  groupIdentityKey,
+  groupIssuerNameKey,
+  groupSearchText,
+  sameGroupIdentity,
+} from "@/modules/groups/groupIdentity";
 import { HorizontalUsersStack } from "@/modules/users/HorizontalUsersStack";
 
 interface MultiSelectProps {
@@ -116,8 +127,12 @@ export function PeerGroupSelector({
     const clientGroups = dropdownOptions.filter(
       (group) => group.keepClientState,
     );
-    let uniqueGroups = unionBy(sortedGroups, dropdownOptions, "name");
-    uniqueGroups = unionBy(clientGroups, uniqueGroups, "name");
+    let uniqueGroups = unionBy(
+      sortedGroups,
+      dropdownOptions,
+      groupIssuerNameKey,
+    );
+    uniqueGroups = unionBy(clientGroups, uniqueGroups, groupIssuerNameKey);
 
     uniqueGroups = hideAllGroup
       ? uniqueGroups.filter((group) => group.name !== "All")
@@ -127,61 +142,82 @@ export function PeerGroupSelector({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [groups]);
 
-  const toggleGroupByName = (name: string) => {
-    const isSelected = values.find((group) => group.name == name) != undefined;
+  const newGroupOption = (name: string): Group => ({
+    name,
+    issued: GroupIssued.API,
+  });
+
+  const toggleGroup = (option: Group) => {
+    const isSelected =
+      values.find((group) => sameGroupIdentity(group, option)) != undefined;
     if (isSelected) {
-      deselectGroup(name);
+      deselectGroup(option);
     } else {
-      selectGroup(name);
+      selectGroup(option);
     }
   };
 
   // Add group to the groupOptions if it does not exist
-  const selectGroup = (name: string) => {
+  const selectGroup = (selectedGroup: Group) => {
     onResourceChange?.(undefined);
-    const group = groups?.find((group) => group.name == name);
-    const option = dropdownOptions.find((option) => option.name == name);
-    const groupPeers: GroupPeer[] | undefined =
-      (group?.peers as GroupPeer[]) || [];
-    const groupResources: GroupResource[] | undefined =
-      (group?.resources as GroupResource[]) || [];
+    const group = groups?.find((group) =>
+      sameGroupIdentity(group, selectedGroup),
+    );
+    const option =
+      dropdownOptions.find((option) =>
+        sameGroupIdentity(option, selectedGroup),
+      ) ?? selectedGroup;
+    const sourceGroup = group ?? option;
+    const groupPeers: GroupPeer[] | undefined = [
+      ...(((sourceGroup?.peers as GroupPeer[]) || []) as GroupPeer[]),
+    ];
+    const groupResources: GroupResource[] | undefined = [
+      ...(((sourceGroup?.resources as GroupResource[]) ||
+        []) as GroupResource[]),
+    ];
 
-    if (peer) groupPeers?.push({ id: peer?.id as string, name: peer?.name });
+    if (peer && !groupPeers.some((p) => p.id === peer.id)) {
+      groupPeers?.push({ id: peer?.id as string, name: peer?.name });
+    }
 
-    if (!group && !option) {
+    const existsInDropdown = dropdownOptions.some((option) =>
+      sameGroupIdentity(option, selectedGroup),
+    );
+    if (!group && !existsInDropdown) {
       addDropdownOptions([
-        { name: name, peers: groupPeers, resources: groupResources },
+        {
+          ...selectedGroup,
+          peers: groupPeers,
+          resources: groupResources,
+          keepClientState: true,
+        },
       ]);
     }
 
+    const nextGroup: Group = {
+      ...sourceGroup,
+      name: selectedGroup.name,
+      id: group?.id ?? sourceGroup?.id,
+      issued: sourceGroup?.issued ?? selectedGroup.issued ?? GroupIssued.API,
+      peers: groupPeers,
+      resources: groupResources,
+    };
+
     if (max == 1 && values.length == 1) {
-      onChange([
-        {
-          name: name,
-          id: group?.id,
-          peers: groupPeers,
-          resources: groupResources,
-        },
-      ]);
+      onChange([nextGroup]);
     } else {
-      onChange((previous) => [
-        ...previous,
-        {
-          name: name,
-          id: group?.id,
-          peers: groupPeers,
-          resources: groupResources,
-        },
-      ]);
+      onChange((previous) => [...previous, nextGroup]);
     }
 
     if (max == 1) setOpen(false);
   };
 
   // Remove group from the groupOptions if it does not have an id
-  const deselectGroup = (name: string) => {
+  const deselectGroup = (selectedGroup: Group) => {
     onChange((previous) => {
-      return previous.filter((group) => group.name != name);
+      return previous.filter(
+        (group) => !sameGroupIdentity(group, selectedGroup),
+      );
     });
   };
 
@@ -219,8 +255,10 @@ export function PeerGroupSelector({
   }, [open, dropdownOptions]);
 
   const onPeerAssignmentChange = (oldGroup: Group, newGroup: Group) => {
-    const filtered = values.filter((group) => group.name !== oldGroup.name);
-    const union = unionBy([newGroup], filtered, "name");
+    const filtered = values.filter(
+      (group) => !sameGroupIdentity(group, oldGroup),
+    );
+    const union = unionBy([newGroup], filtered, groupIssuerNameKey);
     onChange(union);
   };
 
@@ -292,11 +330,7 @@ export function PeerGroupSelector({
             data-cy={dataCy}
             ref={inputRef}
           >
-            <div
-              className={
-                "flex items-center gap-2 flex-wrap h-full"
-              }
-            >
+            <div className={"flex items-center gap-2 flex-wrap h-full"}>
               {resource && showResources && (
                 <ResourceBadge
                   className={"py-[3px]"}
@@ -312,7 +346,7 @@ export function PeerGroupSelector({
               {values.map((group) => {
                 return (
                   <div
-                    key={group.name}
+                    key={groupIdentityKey(group)}
                     className={cn(
                       showPeerCount
                         ? "flex gap-x-1 gap-y-2 items-center justify-between w-full"
@@ -323,7 +357,7 @@ export function PeerGroupSelector({
                       <GroupBadgeWithEditPeers
                         className={"py-[3px]"}
                         group={group}
-                        key={group.name}
+                        key={groupIdentityKey(group)}
                         showNewBadge={true}
                         onPeerAssignmentChange={onPeerAssignmentChange}
                         useSave={saveGroupAssignments}
@@ -332,14 +366,14 @@ export function PeerGroupSelector({
                       <GroupBadge
                         className={"py-[3px]"}
                         group={group}
-                        key={group.name}
+                        key={groupIdentityKey(group)}
                         showNewBadge={true}
                         onClick={(e) => {
                           e.preventDefault();
                           e.stopPropagation();
                           if (disableInlineRemoveGroup) return;
                           if (peer != undefined && group.name == "All") return; // Prevent removing the "All" group
-                          toggleGroupByName(group.name);
+                          toggleGroup(group);
                         }}
                         showX={
                           peer != undefined
@@ -428,7 +462,7 @@ export function PeerGroupSelector({
                       <CommandItem
                         key={search}
                         onSelect={() => {
-                          toggleGroupByName(search);
+                          toggleGroup(newGroupOption(search));
                           searchRef.current?.focus();
                         }}
                         value={search}
@@ -449,8 +483,9 @@ export function PeerGroupSelector({
 
                     {sortedDropdownOptions.slice(0, slice).map((option) => {
                       const isSelected =
-                        values.find((group) => group.name == option.name) !=
-                        undefined;
+                        values.find((group) =>
+                          sameGroupIdentity(group, option),
+                        ) != undefined;
                       const peerCount =
                         option.peers?.length ?? option?.peers_count ?? 0;
 
@@ -472,17 +507,17 @@ export function PeerGroupSelector({
                           }
                           disabled={!isDisabled}
                           className={"w-full block"}
-                          key={option.name}
+                          key={groupIdentityKey(option)}
                         >
                           <CommandItem
-                            key={option.name}
-                            value={option.name + option.id}
+                            key={groupIdentityKey(option)}
+                            value={groupSearchText(option)}
                             disabled={isDisabled}
                             onSelect={() => {
                               if (peer != undefined && option.name == "All")
                                 return; // Prevent removing the "All" group
                               if (isDisabled) return;
-                              toggleGroupByName(option.name);
+                              toggleGroup(option);
                               searchRef.current?.focus();
                             }}
                             className={cn(isDisabled && "opacity-40")}

--- a/dashboard/src/components/ui/GroupBadge.tsx
+++ b/dashboard/src/components/ui/GroupBadge.tsx
@@ -1,11 +1,13 @@
 import Badge from "@components/Badge";
 import { GroupBadgeIcon } from "@components/ui/GroupBadgeIcon";
+import GroupOriginBadge from "@components/ui/GroupOriginBadge";
 import { SmallBadge } from "@components/ui/SmallBadge";
 import TruncatedText from "@components/ui/TruncatedText";
 import { cn } from "@utils/helpers";
 import { XIcon } from "lucide-react";
 import * as React from "react";
 import { Group } from "@/interfaces/Group";
+import { groupIdentityKey } from "@/modules/groups/groupIdentity";
 
 type Props = {
   group: Group;
@@ -34,7 +36,7 @@ export default function GroupBadge({
 
   return (
     <Badge
-      key={group.id ?? group.name}
+      key={groupIdentityKey(group)}
       useHover={true}
       data-cy={"group-badge"}
       variant={"gray-ghost"}
@@ -51,6 +53,7 @@ export default function GroupBadge({
         maxWidth={maxWidth}
         hideTooltip={hideTooltip}
       />
+      <GroupOriginBadge issued={group?.issued} />
       {children}
       {isNew && showNewBadge && <SmallBadge />}
       {showX && (

--- a/dashboard/src/components/ui/GroupBadgeWithEditPeers.tsx
+++ b/dashboard/src/components/ui/GroupBadgeWithEditPeers.tsx
@@ -1,12 +1,18 @@
 import Badge from "@components/Badge";
+import { GroupBadgeIcon } from "@components/ui/GroupBadgeIcon";
+import GroupOriginBadge from "@components/ui/GroupOriginBadge";
 import TextWithTooltip from "@components/ui/TextWithTooltip";
 import { cn } from "@utils/helpers";
-import { EyeIcon, FolderGit2, SquarePen } from "lucide-react";
+import { EyeIcon, SquarePen } from "lucide-react";
 import * as React from "react";
 import { useMemo, useState } from "react";
 import { useGroups } from "@/contexts/GroupsProvider";
 import { Group } from "@/interfaces/Group";
 import { AssignPeerToGroupModal } from "@/modules/groups/AssignPeerToGroupModal";
+import {
+  groupIdentityKey,
+  sameGroupIdentity,
+} from "@/modules/groups/groupIdentity";
 
 type Props = {
   group: Group;
@@ -30,14 +36,14 @@ export default function GroupBadgeWithEditPeers({
     useGroups();
 
   const currentGroup = useMemo(() => {
-    return dropdownOptions?.find((g) => g.name === group?.name);
+    return dropdownOptions?.find((g) => sameGroupIdentity(g, group));
   }, [group, dropdownOptions]);
 
   const peerCount =
     currentGroup?.peers?.length ?? currentGroup?.peers_count ?? 0;
 
   const updateGroupOptions = (g: Group) => {
-    updateGroupDropdown(group.name, g);
+    updateGroupDropdown(group, g);
     onPeerAssignmentChange?.(group, g);
   };
 
@@ -56,7 +62,7 @@ export default function GroupBadgeWithEditPeers({
       )}
 
       <Badge
-        key={group.id ?? group.name}
+        key={groupIdentityKey(group)}
         useHover={true}
         variant={"gray-ghost"}
         className={cn(
@@ -79,8 +85,9 @@ export default function GroupBadgeWithEditPeers({
               "text-nb-gray-200 flex gap-1.5 items-center z-10 relative"
             }
           >
-            <FolderGit2 size={12} className={"shrink-0"} />
+            <GroupBadgeIcon id={group?.id} issued={group?.issued} />
             <TextWithTooltip text={group?.name || ""} maxChars={20} />
+            <GroupOriginBadge issued={group?.issued} />
             {isNew && showNewBadge && (
               <span
                 className={

--- a/dashboard/src/components/ui/GroupOriginBadge.tsx
+++ b/dashboard/src/components/ui/GroupOriginBadge.tsx
@@ -1,0 +1,39 @@
+import { cn } from "@utils/helpers";
+import { GroupIssued } from "@/interfaces/Group";
+import {
+  groupIssued,
+  groupIssuedDescription,
+  groupIssuedLabel,
+} from "@/modules/groups/groupIdentity";
+
+type Props = {
+  issued?: GroupIssued;
+  className?: string;
+};
+
+const variants: Record<GroupIssued, string> = {
+  [GroupIssued.API]:
+    "border-neutral-300 bg-neutral-100 text-neutral-600 dark:border-nb-gray-700 dark:bg-nb-gray-900 dark:text-nb-gray-300",
+  [GroupIssued.JWT]:
+    "border-sky-300 bg-sky-100 text-sky-700 dark:border-sky-700 dark:bg-sky-950/50 dark:text-sky-300",
+  [GroupIssued.INTEGRATION]:
+    "border-violet-300 bg-violet-100 text-violet-700 dark:border-violet-700 dark:bg-violet-950/50 dark:text-violet-300",
+};
+
+export default function GroupOriginBadge({ issued, className }: Props) {
+  const origin = groupIssued(issued);
+
+  return (
+    <span
+      aria-label={groupIssuedDescription(origin)}
+      title={groupIssuedDescription(origin)}
+      className={cn(
+        "inline-flex shrink-0 items-center rounded-[4px] border px-1 py-[1px] text-[9px] font-semibold leading-none",
+        variants[origin],
+        className,
+      )}
+    >
+      {groupIssuedLabel(origin)}
+    </span>
+  );
+}

--- a/dashboard/src/components/ui/GroupOriginBadge.tsx
+++ b/dashboard/src/components/ui/GroupOriginBadge.tsx
@@ -4,6 +4,8 @@ import {
   groupIssued,
   groupIssuedDescription,
   groupIssuedLabel,
+  type GroupOrigin,
+  unknownGroupIssued,
 } from "@/modules/groups/groupIdentity";
 
 type Props = {
@@ -11,13 +13,15 @@ type Props = {
   className?: string;
 };
 
-const variants: Record<GroupIssued, string> = {
+const variants: Record<GroupOrigin, string> = {
   [GroupIssued.API]:
     "border-neutral-300 bg-neutral-100 text-neutral-600 dark:border-nb-gray-700 dark:bg-nb-gray-900 dark:text-nb-gray-300",
   [GroupIssued.JWT]:
-    "border-sky-300 bg-sky-100 text-sky-700 dark:border-sky-700 dark:bg-sky-950/50 dark:text-sky-300",
+    "border-violet-200 bg-violet-50 text-violet-700 dark:border-violet-800 dark:bg-violet-950/30 dark:text-violet-200",
   [GroupIssued.INTEGRATION]:
-    "border-violet-300 bg-violet-100 text-violet-700 dark:border-violet-700 dark:bg-violet-950/50 dark:text-violet-300",
+    "border-violet-300 bg-violet-100 text-violet-800 dark:border-violet-700 dark:bg-violet-950/50 dark:text-violet-200",
+  [unknownGroupIssued]:
+    "border-neutral-400 bg-neutral-50 text-neutral-800 dark:border-nb-gray-600 dark:bg-nb-gray-900 dark:text-nb-gray-200",
 };
 
 export default function GroupOriginBadge({ issued, className }: Props) {

--- a/dashboard/src/components/ui/PeerBadge.tsx
+++ b/dashboard/src/components/ui/PeerBadge.tsx
@@ -6,6 +6,7 @@ import { useMemo, useState } from "react";
 import { useGroups } from "@/contexts/GroupsProvider";
 import { Group } from "@/interfaces/Group";
 import { AssignPeerToGroupModal } from "@/modules/groups/AssignPeerToGroupModal";
+import { sameGroupIdentity } from "@/modules/groups/groupIdentity";
 
 type Props = {
   children?: React.ReactNode;
@@ -27,7 +28,7 @@ export default function PeerBadge({
   const { dropdownOptions, addDropdownOptions } = useGroups();
 
   const currentGroup = useMemo(() => {
-    return dropdownOptions?.find((g) => g.name === group?.name);
+    return dropdownOptions?.find((g) => sameGroupIdentity(g, group));
   }, [group, dropdownOptions]);
 
   const peerCount = useMemo(() => {

--- a/dashboard/src/components/v2/OzGroupBadge.tsx
+++ b/dashboard/src/components/v2/OzGroupBadge.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { GroupBadgeIcon } from "@components/ui/GroupBadgeIcon";
+import GroupOriginBadge from "@components/ui/GroupOriginBadge";
 import TruncatedText from "@components/ui/TruncatedText";
 import classNames from "classnames";
 import { XIcon } from "lucide-react";
 import * as React from "react";
 import { Group } from "@/interfaces/Group";
+import { groupIdentityKey } from "@/modules/groups/groupIdentity";
 
 // v2 paint of GroupBadge — uses oz2 tokens for surface/border/text
 // instead of the legacy `Badge variant="gray-ghost"`. The
@@ -36,7 +38,7 @@ export default function OzGroupBadge({
 }: Readonly<Props>) {
   return (
     <div
-      key={group.id ?? group.name}
+      key={groupIdentityKey(group)}
       data-cy="group-badge"
       onClick={(e) => {
         e.preventDefault();
@@ -46,7 +48,9 @@ export default function OzGroupBadge({
         "group inline-flex items-center gap-1.5 whitespace-nowrap rounded-full border px-2.5 py-[3px]",
         "border-oz2-border bg-oz2-surface text-oz2-text-2 text-[12px] font-medium",
         "transition-colors",
-        onClick ? "cursor-pointer hover:bg-oz2-hover hover:border-oz2-border-strong" : "",
+        onClick
+          ? "cursor-pointer hover:bg-oz2-hover hover:border-oz2-border-strong"
+          : "",
         className,
       )}
     >
@@ -57,6 +61,7 @@ export default function OzGroupBadge({
         maxWidth={maxWidth}
         hideTooltip={hideTooltip}
       />
+      <GroupOriginBadge issued={group?.issued} />
       {children}
       {showX && (
         <XIcon

--- a/dashboard/src/components/v2/OzPeerBadge.tsx
+++ b/dashboard/src/components/v2/OzPeerBadge.tsx
@@ -7,6 +7,7 @@ import { useMemo, useState } from "react";
 import { useGroups } from "@/contexts/GroupsProvider";
 import { Group } from "@/interfaces/Group";
 import { AssignPeerToGroupModal } from "@/modules/groups/AssignPeerToGroupModal";
+import { sameGroupIdentity } from "@/modules/groups/groupIdentity";
 
 // v2 paint of PeerBadge — chip that shows a group's peer count and
 // opens AssignPeerToGroupModal on click. Same behavior as the legacy
@@ -31,7 +32,7 @@ export default function OzPeerBadge({
   const { dropdownOptions, addDropdownOptions } = useGroups();
 
   const currentGroup = useMemo(
-    () => dropdownOptions?.find((g) => g.name === group?.name),
+    () => dropdownOptions?.find((g) => sameGroupIdentity(g, group)),
     [group, dropdownOptions],
   );
 

--- a/dashboard/src/contexts/GroupsProvider.tsx
+++ b/dashboard/src/contexts/GroupsProvider.tsx
@@ -4,6 +4,10 @@ import React, { useEffect, useState } from "react";
 import { usePermissions } from "@/contexts/PermissionsProvider";
 import { Group, GroupResource } from "@/interfaces/Group";
 import { Peer } from "@/interfaces/Peer";
+import {
+  groupIssuerNameKey,
+  sameGroupIdentity,
+} from "@/modules/groups/groupIdentity";
 
 type Props = {
   children: React.ReactNode;
@@ -19,7 +23,7 @@ const GroupContext = React.createContext(
     isLoading: boolean;
     createOrUpdate: (group: Group) => Promise<Group>;
     reset: () => void;
-    updateGroupDropdown: (oldGroupName: string, newGroup: Group) => void;
+    updateGroupDropdown: (oldGroup: Group, newGroup: Group) => void;
   },
 );
 
@@ -62,20 +66,20 @@ export function GroupsProviderContent({
 
   const addDropdownOptions = (options: Group[]) => {
     setDropdownOptions((prev) => {
-      let union = unionBy(options, prev, "name");
+      let union = unionBy(options, prev, groupIssuerNameKey);
       return sortBy(
         union.map((item) =>
-          merge({}, prev.find((p) => p.name === item.name) || {}, item),
+          merge({}, prev.find((p) => sameGroupIdentity(p, item)) || {}, item),
         ),
         "name",
       );
     });
   };
 
-  const updateGroupDropdown = (oldGroupName: string, newGroup: Group) => {
+  const updateGroupDropdown = (oldGroup: Group, newGroup: Group) => {
     setDropdownOptions((prev) => {
       let updated = prev.map((g) => {
-        if (g.name === oldGroupName) {
+        if (sameGroupIdentity(g, oldGroup)) {
           return newGroup;
         }
         return g;
@@ -89,7 +93,7 @@ export function GroupsProviderContent({
     if (!groups) return;
     const sortedGroups = sortBy([...groups], "name");
     const dropdownGroups = dropdownOptions.filter((g) => g.keepClientState);
-    const union = unionBy(dropdownGroups, sortedGroups, "name");
+    const union = unionBy(dropdownGroups, sortedGroups, groupIssuerNameKey);
     addDropdownOptions(union);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [groups]);
@@ -112,7 +116,9 @@ export function GroupsProviderContent({
     if (group.name === "All") return Promise.resolve(group);
 
     const groupID =
-      group?.id ?? groups?.find((g) => g.name === group.name)?.id ?? undefined;
+      group?.id ??
+      groups?.find((g) => sameGroupIdentity(g, group))?.id ??
+      undefined;
 
     if (groupID) {
       return groupRequest.put(
@@ -121,7 +127,7 @@ export function GroupsProviderContent({
           peers: peers,
           resources: resources,
         },
-        `/${group.id}`,
+        `/${groupID}`,
       );
     } else {
       return groupRequest.post({

--- a/dashboard/src/hooks/useSortedDropdownOptions.ts
+++ b/dashboard/src/hooks/useSortedDropdownOptions.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef } from "react";
 import { Group } from "@/interfaces/Group";
+import { groupIssuerNameKey } from "@/modules/groups/groupIdentity";
 
 const useSortedDropdownOptions = (
   dropdownOptions: Group[],
@@ -16,7 +17,7 @@ const useSortedDropdownOptions = (
       JSON.stringify(values) !== JSON.stringify(prevValuesRef.current)
     ) {
       sortOrderRef.current = new Map(
-        values.map((group, index) => [group.name, index]),
+        values.map((group, index) => [groupIssuerNameKey(group), index]),
       );
       prevValuesRef.current = values;
     }
@@ -26,8 +27,8 @@ const useSortedDropdownOptions = (
   return useMemo(() => {
     const sortOrder = sortOrderRef.current;
     return [...dropdownOptions].sort((a, b) => {
-      const indexA = sortOrder.get(a.name) ?? Infinity;
-      const indexB = sortOrder.get(b.name) ?? Infinity;
+      const indexA = sortOrder.get(groupIssuerNameKey(a)) ?? Infinity;
+      const indexB = sortOrder.get(groupIssuerNameKey(b)) ?? Infinity;
       return indexA - indexB;
     });
   }, [dropdownOptions, sortOrderRef.current]);

--- a/dashboard/src/modules/access-control/useAccessControl.ts
+++ b/dashboard/src/modules/access-control/useAccessControl.ts
@@ -8,6 +8,7 @@ import { usePolicies } from "@/contexts/PoliciesProvider";
 import { Group } from "@/interfaces/Group";
 import { Policy, PortRange, Protocol } from "@/interfaces/Policy";
 import { PostureCheck } from "@/interfaces/PostureCheck";
+import { resolveGroupID } from "@/modules/groups/groupIdentity";
 import useGroupHelper from "@/modules/groups/useGroupHelper";
 import { usePostureCheck } from "@/modules/posture-checks/usePostureCheck";
 
@@ -179,7 +180,7 @@ export const useAccessControl = ({
   const submit = async () => {
     const g1 = getSourceGroupsToUpdate();
     const g2 = getDestinationGroupsToUpdate();
-    const createOrUpdateGroups = uniqBy([...g1, ...g2], "name").map(
+    const createOrUpdateGroups = uniqBy([...g1, ...g2], "key").map(
       (g) => g.promise,
     );
     const groups = await Promise.all(
@@ -204,14 +205,12 @@ export const useAccessControl = ({
 
     let sources = sourceGroups
       .map((g) => {
-        const find = groups.find((group) => group.name === g.name);
-        return find?.id;
+        return resolveGroupID(g, groups);
       })
       .filter((g) => g !== undefined) as string[];
     let destinations = destinationGroups
       .map((g) => {
-        const find = groups.find((group) => group.name === g.name);
-        return find?.id;
+        return resolveGroupID(g, groups);
       })
       .filter((g) => g !== undefined) as string[];
 

--- a/dashboard/src/modules/groups/GroupFilterSelector.tsx
+++ b/dashboard/src/modules/groups/GroupFilterSelector.tsx
@@ -4,6 +4,7 @@ import { CommandItem } from "@components/Command";
 import { Popover, PopoverContent, PopoverTrigger } from "@components/Popover";
 import { ScrollArea } from "@components/ScrollArea";
 import { GroupBadgeIcon } from "@components/ui/GroupBadgeIcon";
+import GroupOriginBadge from "@components/ui/GroupOriginBadge";
 import TextWithTooltip from "@components/ui/TextWithTooltip";
 import { cn } from "@utils/helpers";
 import { Command, CommandGroup, CommandInput, CommandList } from "cmdk";
@@ -18,6 +19,10 @@ import * as React from "react";
 import { useState } from "react";
 import { useElementSize } from "@/hooks/useElementSize";
 import { Group } from "@/interfaces/Group";
+import {
+  groupIdentityKey,
+  groupSearchText,
+} from "@/modules/groups/groupIdentity";
 
 interface MultiSelectProps {
   values: string[];
@@ -136,8 +141,8 @@ export function GroupFilterSelector({
 
                       return (
                         <CommandItem
-                          key={value}
-                          value={value}
+                          key={groupIdentityKey(item)}
+                          value={groupSearchText(item)}
                           className={"p-1"}
                           onSelect={() => {
                             toggle(value);
@@ -166,6 +171,7 @@ export function GroupFilterSelector({
                                   issued={item?.issued}
                                 />
                                 <TextWithTooltip text={value} maxChars={15} />
+                                <GroupOriginBadge issued={item?.issued} />
                               </div>
                               <div
                                 className={

--- a/dashboard/src/modules/groups/GroupsNameCell.tsx
+++ b/dashboard/src/modules/groups/GroupsNameCell.tsx
@@ -1,10 +1,10 @@
 import { GroupBadgeIcon } from "@components/ui/GroupBadgeIcon";
+import GroupOriginBadge from "@components/ui/GroupOriginBadge";
 import TextWithTooltip from "@components/ui/TextWithTooltip";
 import { cn } from "@utils/helpers";
 import React from "react";
 import CircleIcon from "@/assets/icons/CircleIcon";
-import { Group, GroupIssued } from "@/interfaces/Group";
-import SCIMBadge from "@/modules/common/SCIMBadge";
+import { Group } from "@/interfaces/Group";
 
 type Props = {
   active: boolean;
@@ -24,9 +24,7 @@ export default function GroupsNameCell({ active, group }: Readonly<Props>) {
               className={"font-medium flex gap-2 items-center justify-center"}
             >
               <TextWithTooltip text={group?.name} maxChars={25} />
-              {group?.issued === GroupIssued.INTEGRATION && (
-                <SCIMBadge description="Group provisioned via SCIM. Membership changes made here will be overwritten on the next IdP sync." />
-              )}
+              <GroupOriginBadge issued={group?.issued} />
             </div>
           </div>
           <CircleIcon

--- a/dashboard/src/modules/groups/groupIdentity.ts
+++ b/dashboard/src/modules/groups/groupIdentity.ts
@@ -1,0 +1,64 @@
+import { Group, GroupIssued } from "@/interfaces/Group";
+
+type GroupIdentity = Pick<Group, "id" | "issued" | "name">;
+
+export function groupIssued(issued?: GroupIssued): GroupIssued {
+  return issued ?? GroupIssued.API;
+}
+
+export function groupIdentityKey(group?: GroupIdentity): string {
+  if (!group) return "group:none";
+  if (group.id) return `group:id:${group.id}`;
+  return `group:new:${groupIssued(group.issued)}:${group.name}`;
+}
+
+export function groupIssuerNameKey(group?: GroupIdentity): string {
+  if (!group) return "group:none";
+  return `group:issuer-name:${groupIssued(group.issued)}:${group.name}`;
+}
+
+export function sameGroupIdentity(
+  left?: GroupIdentity,
+  right?: GroupIdentity,
+): boolean {
+  if (!left || !right) return false;
+  if (left.id && right.id) return left.id === right.id;
+  return groupIssuerNameKey(left) === groupIssuerNameKey(right);
+}
+
+export function resolveGroupID(
+  selectedGroup: GroupIdentity,
+  resolvedGroups: Group[],
+): string | undefined {
+  if (selectedGroup.id) return selectedGroup.id;
+  return resolvedGroups.find((group) => sameGroupIdentity(group, selectedGroup))
+    ?.id;
+}
+
+export function groupSearchText(group: GroupIdentity): string {
+  return `${group.name} ${groupIssuedLabel(group.issued)}`;
+}
+
+export function groupIssuedLabel(issued?: GroupIssued): string {
+  switch (groupIssued(issued)) {
+    case GroupIssued.JWT:
+      return "JWT";
+    case GroupIssued.INTEGRATION:
+      return "SCIM";
+    case GroupIssued.API:
+    default:
+      return "API";
+  }
+}
+
+export function groupIssuedDescription(issued?: GroupIssued): string {
+  switch (groupIssued(issued)) {
+    case GroupIssued.JWT:
+      return "Created from JWT group claims. Membership is driven by the IdP.";
+    case GroupIssued.INTEGRATION:
+      return "Provisioned by SCIM. Membership changes may be overwritten by the IdP.";
+    case GroupIssued.API:
+    default:
+      return "Created manually in the dashboard or through the API.";
+  }
+}

--- a/dashboard/src/modules/groups/groupIdentity.ts
+++ b/dashboard/src/modules/groups/groupIdentity.ts
@@ -1,20 +1,36 @@
 import { Group, GroupIssued } from "@/interfaces/Group";
 
-type GroupIdentity = Pick<Group, "id" | "issued" | "name">;
+export const unknownGroupIssued = "unknown";
 
-export function groupIssued(issued?: GroupIssued): GroupIssued {
-  return issued ?? GroupIssued.API;
+export type GroupOrigin = GroupIssued | typeof unknownGroupIssued;
+
+type GroupIdentity = Pick<Group, "id" | "name"> & {
+  issued?: GroupIssued | string;
+};
+
+const knownGroupIssued = new Set<string>(Object.values(GroupIssued));
+
+export function groupIssued(issued?: GroupIssued | string): GroupOrigin {
+  if (!issued) return GroupIssued.API;
+  if (knownGroupIssued.has(issued)) return issued as GroupIssued;
+  return unknownGroupIssued;
+}
+
+function groupIssuerKey(issued?: GroupIssued | string): string {
+  const origin = groupIssued(issued);
+  if (origin === unknownGroupIssued && issued) return `${origin}:${issued}`;
+  return origin;
 }
 
 export function groupIdentityKey(group?: GroupIdentity): string {
   if (!group) return "group:none";
   if (group.id) return `group:id:${group.id}`;
-  return `group:new:${groupIssued(group.issued)}:${group.name}`;
+  return `group:new:${groupIssuerKey(group.issued)}:${group.name}`;
 }
 
 export function groupIssuerNameKey(group?: GroupIdentity): string {
   if (!group) return "group:none";
-  return `group:issuer-name:${groupIssued(group.issued)}:${group.name}`;
+  return `group:issuer-name:${groupIssuerKey(group.issued)}:${group.name}`;
 }
 
 export function sameGroupIdentity(
@@ -39,26 +55,28 @@ export function groupSearchText(group: GroupIdentity): string {
   return `${group.name} ${groupIssuedLabel(group.issued)}`;
 }
 
-export function groupIssuedLabel(issued?: GroupIssued): string {
+export function groupIssuedLabel(issued?: GroupIssued | string): string {
   switch (groupIssued(issued)) {
     case GroupIssued.JWT:
       return "JWT";
     case GroupIssued.INTEGRATION:
       return "SCIM";
     case GroupIssued.API:
-    default:
       return "API";
+    case unknownGroupIssued:
+      return "Unknown";
   }
 }
 
-export function groupIssuedDescription(issued?: GroupIssued): string {
+export function groupIssuedDescription(issued?: GroupIssued | string): string {
   switch (groupIssued(issued)) {
     case GroupIssued.JWT:
       return "Created from JWT group claims. Membership is driven by the IdP.";
     case GroupIssued.INTEGRATION:
       return "Provisioned by SCIM. Membership changes may be overwritten by the IdP.";
     case GroupIssued.API:
-    default:
       return "Created manually in the dashboard or through the API.";
+    case unknownGroupIssued:
+      return "Origin is not recognized by this dashboard version. Treat it as externally managed until the dashboard is upgraded.";
   }
 }

--- a/dashboard/src/modules/groups/useGroupHelper.tsx
+++ b/dashboard/src/modules/groups/useGroupHelper.tsx
@@ -6,6 +6,10 @@ import { useGroups } from "@/contexts/GroupsProvider";
 import { usePeerGroups } from "@/contexts/PeerProvider";
 import { type Group, type GroupPeer } from "@/interfaces/Group";
 import { type Peer } from "@/interfaces/Peer";
+import {
+  groupIssuerNameKey,
+  sameGroupIdentity,
+} from "@/modules/groups/groupIdentity";
 
 type Props = {
   initial?: Group[] | string[];
@@ -67,7 +71,8 @@ export default function useGroupHelper({ initial = [], peer }: Props) {
     });
     return groupsToUpdate.map((group) => {
       return {
-        name: group.name,
+        key: groupIssuerNameKey(group),
+        group,
         promise: () => updateOrCreateGroup(group),
       };
     });
@@ -149,12 +154,16 @@ export default function useGroupHelper({ initial = [], peer }: Props) {
       })
       .then((group) => {
         setSelectedGroups((prev) => {
-          const index = prev.findIndex((g) => g.name === selectedGroup.name);
+          const index = prev.findIndex((g) =>
+            sameGroupIdentity(g, selectedGroup),
+          );
+          if (index === -1) return prev;
           const clone = [...prev];
           clone[index] = {
             ...clone[index],
             id: group.id,
             name: group.name,
+            issued: group.issued,
           };
           return clone;
         });

--- a/dashboard/src/modules/networks/routing-peers/NetworkRoutingPeerModal.tsx
+++ b/dashboard/src/modules/networks/routing-peers/NetworkRoutingPeerModal.tsx
@@ -44,6 +44,7 @@ import { Network, NetworkRouter } from "@/interfaces/Network";
 import { OperatingSystem } from "@/interfaces/OperatingSystem";
 import { Peer } from "@/interfaces/Peer";
 import { SetupKey } from "@/interfaces/SetupKey";
+import { resolveGroupID } from "@/modules/groups/groupIdentity";
 import useGroupHelper from "@/modules/groups/useGroupHelper";
 import { RoutingPeerMasqueradeSwitch } from "@/modules/networks/routing-peers/RoutingPeerMasqueradeSwitch";
 import SetupModal from "@/modules/setup-openzro-modal/SetupModal";
@@ -142,10 +143,13 @@ function RoutingPeerModalContent({
 
   const addRouter = async () => {
     const g1 = getAllRoutingGroupsToUpdate();
-    const createOrUpdateGroups = uniqBy([...g1], "name").map((g) => g.promise);
+    const createOrUpdateGroups = uniqBy([...g1], "key").map((g) => g.promise);
     const createdGroups = await Promise.all(
       createOrUpdateGroups.map((call) => call()),
     );
+    const peerGroupIDs = routingPeerGroups
+      .map((group) => resolveGroupID(group, createdGroups))
+      .filter((id) => id !== undefined) as string[];
 
     const isRoutingPeer = type === "peer";
 
@@ -155,9 +159,7 @@ function RoutingPeerModalContent({
       loadingMessage: "Adding Routing Peer...",
       promise: create({
         peer: isRoutingPeer ? routingPeer?.id : undefined,
-        peer_groups: !isRoutingPeer
-          ? createdGroups.map((g) => g.id)
-          : undefined,
+        peer_groups: !isRoutingPeer ? peerGroupIDs : undefined,
         metric: parseInt(metric),
         enabled,
         masquerade: isRoutingPeer && isNonLinuxRoutingPeer ? true : masquerade,
@@ -169,10 +171,13 @@ function RoutingPeerModalContent({
 
   const updateRouter = async () => {
     const g1 = getAllRoutingGroupsToUpdate();
-    const createOrUpdateGroups = uniqBy([...g1], "name").map((g) => g.promise);
+    const createOrUpdateGroups = uniqBy([...g1], "key").map((g) => g.promise);
     const createdGroups = await Promise.all(
       createOrUpdateGroups.map((call) => call()),
     );
+    const peerGroupIDs = routingPeerGroups
+      .map((group) => resolveGroupID(group, createdGroups))
+      .filter((id) => id !== undefined) as string[];
 
     const isRoutingPeer = type === "peer";
 
@@ -182,9 +187,7 @@ function RoutingPeerModalContent({
       loadingMessage: "Adding Routing Peer...",
       promise: update({
         peer: isRoutingPeer ? routingPeer?.id : undefined,
-        peer_groups: !isRoutingPeer
-          ? createdGroups.map((g) => g.id)
-          : undefined,
+        peer_groups: !isRoutingPeer ? peerGroupIDs : undefined,
         metric: parseInt(metric),
         enabled,
         masquerade: isRoutingPeer && isNonLinuxRoutingPeer ? true : masquerade,

--- a/dashboard/src/modules/routes/RouteAddRoutingPeerModal.tsx
+++ b/dashboard/src/modules/routes/RouteAddRoutingPeerModal.tsx
@@ -20,6 +20,7 @@ import OzLabel, { OzHelpText } from "@/components/v2/OzLabel";
 import { useRoutes } from "@/contexts/RoutesProvider";
 import { Peer } from "@/interfaces/Peer";
 import { GroupedRoute, Route } from "@/interfaces/Route";
+import { resolveGroupID } from "@/modules/groups/groupIdentity";
 import useGroupHelper from "@/modules/groups/useGroupHelper";
 
 type Props = {
@@ -96,7 +97,7 @@ function Content({ onSuccess, groupedRoute, peer }: ModalProps) {
     // Create groups that do not exist
     const g2 = getGroupsToUpdate();
     const g3 = getAccessControlGroupsToUpdate();
-    const createOrUpdateGroups = uniqBy([...g2, ...g3], "name").map(
+    const createOrUpdateGroups = uniqBy([...g2, ...g3], "key").map(
       (g) => g.promise,
     );
     const createdGroups = await Promise.all(
@@ -105,8 +106,7 @@ function Content({ onSuccess, groupedRoute, peer }: ModalProps) {
     // Get distribution group ids
     const groupIds = groups
       .map((g) => {
-        const find = createdGroups.find((group) => group.name === g.name);
-        return find?.id;
+        return resolveGroupID(g, createdGroups);
       })
       .filter((g) => g !== undefined) as string[];
 
@@ -114,8 +114,7 @@ function Content({ onSuccess, groupedRoute, peer }: ModalProps) {
     if (accessControlGroups.length > 0) {
       accessControlGroupIds = accessControlGroups
         .map((g) => {
-          const find = createdGroups.find((group) => group.name === g.name);
-          return find?.id;
+          return resolveGroupID(g, createdGroups);
         })
         .filter((g) => g !== undefined) as string[];
     }

--- a/dashboard/src/modules/routes/RouteModal.tsx
+++ b/dashboard/src/modules/routes/RouteModal.tsx
@@ -55,6 +55,7 @@ import { OperatingSystem } from "@/interfaces/OperatingSystem";
 import { Peer } from "@/interfaces/Peer";
 import { Policy } from "@/interfaces/Policy";
 import { Route } from "@/interfaces/Route";
+import { resolveGroupID } from "@/modules/groups/groupIdentity";
 import useGroupHelper from "@/modules/groups/useGroupHelper";
 import { RoutingPeerMasqueradeSwitch } from "@/modules/networks/routing-peers/RoutingPeerMasqueradeSwitch";
 
@@ -245,7 +246,7 @@ export function RouteModalContent({
     const g1 = getAllRoutingGroupsToUpdate();
     const g2 = getGroupsToUpdate();
     const g3 = getAccessControlGroupsToUpdate();
-    const createOrUpdateGroups = uniqBy([...g1, ...g2, ...g3], "name").map(
+    const createOrUpdateGroups = uniqBy([...g1, ...g2, ...g3], "key").map(
       (g) => g.promise,
     );
     const createdGroups = await Promise.all(
@@ -260,8 +261,7 @@ export function RouteModalContent({
     if (!useSinglePeer) {
       peerGroups = routingPeerGroups
         .map((g) => {
-          const find = createdGroups.find((group) => group.name === g.name);
-          return find?.id;
+          return resolveGroupID(g, createdGroups);
         })
         .filter((g) => g !== undefined) as string[];
     }
@@ -269,8 +269,7 @@ export function RouteModalContent({
     // Get distribution group ids
     const groupIds = groups
       .map((g) => {
-        const find = createdGroups.find((group) => group.name === g.name);
-        return find?.id;
+        return resolveGroupID(g, createdGroups);
       })
       .filter((g) => g !== undefined) as string[];
 
@@ -278,8 +277,7 @@ export function RouteModalContent({
     if (accessControlGroups.length > 0) {
       accessControlGroupIds = accessControlGroups
         .map((g) => {
-          const find = createdGroups.find((group) => group.name === g.name);
-          return find?.id;
+          return resolveGroupID(g, createdGroups);
         })
         .filter((g) => g !== undefined) as string[];
     }

--- a/dashboard/src/modules/routes/RouteUpdateModal.tsx
+++ b/dashboard/src/modules/routes/RouteUpdateModal.tsx
@@ -42,6 +42,7 @@ import { useRoutes } from "@/contexts/RoutesProvider";
 import { OperatingSystem } from "@/interfaces/OperatingSystem";
 import { Peer } from "@/interfaces/Peer";
 import { Route } from "@/interfaces/Route";
+import { resolveGroupID } from "@/modules/groups/groupIdentity";
 import useGroupHelper from "@/modules/groups/useGroupHelper";
 import { RoutingPeerMasqueradeSwitch } from "@/modules/networks/routing-peers/RoutingPeerMasqueradeSwitch";
 
@@ -209,7 +210,7 @@ function RouteUpdateModalContent({ onSuccess, route, cell }: ModalProps) {
     const g1 = getAllRoutingGroupsToUpdate();
     const g2 = getGroupsToUpdate();
     const g3 = getAccessControlGroupsToUpdate();
-    const createOrUpdateGroups = uniqBy([...g1, ...g2, ...g3], "name").map(
+    const createOrUpdateGroups = uniqBy([...g1, ...g2, ...g3], "key").map(
       (g) => g.promise,
     );
     const createdGroups = await Promise.all(
@@ -223,8 +224,7 @@ function RouteUpdateModalContent({ onSuccess, route, cell }: ModalProps) {
     if (!useSinglePeer) {
       peerGroups = routingPeerGroups
         .map((g) => {
-          const find = createdGroups.find((group) => group.name === g.name);
-          return find?.id;
+          return resolveGroupID(g, createdGroups);
         })
         .filter((g) => g !== undefined) as string[];
     }
@@ -232,8 +232,7 @@ function RouteUpdateModalContent({ onSuccess, route, cell }: ModalProps) {
     // Get distribution group ids
     const groupIds = groups
       .map((g) => {
-        const find = createdGroups.find((group) => group.name === g.name);
-        return find?.id;
+        return resolveGroupID(g, createdGroups);
       })
       .filter((g) => g !== undefined) as string[];
 
@@ -241,8 +240,7 @@ function RouteUpdateModalContent({ onSuccess, route, cell }: ModalProps) {
     if (accessControlGroups.length > 0) {
       accessControlGroupIds = accessControlGroups
         .map((g) => {
-          const find = createdGroups.find((group) => group.name === g.name);
-          return find?.id;
+          return resolveGroupID(g, createdGroups);
         })
         .filter((g) => g !== undefined) as string[];
     }


### PR DESCRIPTION
Closes #174.

Shows each group's source (API, JWT, SCIM, or Unknown) in group rows, badges, filters, and selectors so same-name groups from different issuers are distinguishable.

Also stops write flows from resolving selected groups by display name alone. Route, routing-peer, and access-control forms now preserve the selected group identity and resolve IDs by id first, falling back to issuer+name only for new client-side groups.

Security/compatibility notes:
- This does not attach JWT/SCIM groups to API groups by name.
- This does not forbid cross-source name collisions.
- Missing `issued` is still treated as API for legacy rows; an unrecognized future `issued` value is shown as `Unknown`, described as externally managed, and kept distinct in identity fallback keys.
- No backend schema or API contract changes.
- The peer table group-name filter still filters by group name because that column is name-based today; this PR only makes its option labels explicit.
- The new origin badge uses neutral/violet tokens only; the previous `sky` accent in this new component was removed.

Verification:
- `npx prettier --write src/modules/groups/groupIdentity.ts src/components/ui/GroupOriginBadge.tsx`
- `npm run build`
