### PR TITLE
fix: ship parquet flow archive reads in linux management

### DIFF
--- a/.github/workflows/golang-test-linux.yml
+++ b/.github/workflows/golang-test-linux.yml
@@ -119,7 +119,7 @@ jobs:
       - name: Build management
         if: steps.cache.outputs.cache-hit != 'true'
         working-directory: management
-        run: CGO_ENABLED=1 go build .
+        run: CGO_ENABLED=1 go build -tags=archive_duckdb .
 
       - name: Build management 386
         if: steps.cache.outputs.cache-hit != 'true'

--- a/.goreleaser.binaries.yaml
+++ b/.goreleaser.binaries.yaml
@@ -50,8 +50,31 @@ builds:
   - id: openzro-mgmt
     dir: management
     binary: openzro-mgmt
+    env:
+      - CGO_ENABLED=1
+      - >-
+        {{- if eq .Runtime.Goos "linux" }}
+          {{- if eq .Arch "arm64"}}CC=aarch64-linux-gnu-gcc{{- end }}
+        {{- end }}
+    goos: [linux]
+    goarch: [amd64, arm64]
+    ldflags:
+      - -s -w -X github.com/openzro/openzro/version.version={{.Version}}
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    # archive_duckdb pulls in github.com/marcboeker/go-duckdb (CGo) so
+    # the published Linux management binary can query Parquet cold
+    # archives after OPENZRO_FLOW_RETENTION has purged the hot DB. The
+    # release workflow installs the arm64 cross compiler before running
+    # GoReleaser. Darwin keeps the CGo-free build below until that path
+    # has its own smoke test.
+    tags:
+      - archive_duckdb
+
+  - id: openzro-mgmt-darwin
+    dir: management
+    binary: openzro-mgmt
     env: [CGO_ENABLED=0]
-    goos: [linux, darwin]
+    goos: [darwin]
     goarch: [amd64, arm64]
     ldflags:
       - -s -w -X github.com/openzro/openzro/version.version={{.Version}}
@@ -108,7 +131,7 @@ archives:
         format: zip
 
   - id: openzro-mgmt
-    builds: [openzro-mgmt]
+    builds: [openzro-mgmt, openzro-mgmt-darwin]
     name_template: >-
       openzro-mgmt_{{ .Version }}_{{ .Os }}_{{ .Arch }}
 

--- a/.goreleaser.binaries.yaml
+++ b/.goreleaser.binaries.yaml
@@ -230,6 +230,8 @@ nfpms:
     bindir: /usr/bin
     builds: [openzro-mgmt]
     formats: [deb]
+    dependencies:
+      - libstdc++6
     contents:
       - src: release_files/management/openzro-management.service
         dst: /lib/systemd/system/openzro-management.service
@@ -252,6 +254,8 @@ nfpms:
     bindir: /usr/bin
     builds: [openzro-mgmt]
     formats: [rpm]
+    dependencies:
+      - libstdc++
     contents:
       - src: release_files/management/openzro-management.service
         dst: /lib/systemd/system/openzro-management.service
@@ -274,6 +278,8 @@ nfpms:
     bindir: /usr/bin
     builds: [openzro-mgmt]
     formats: [archlinux]
+    dependencies:
+      - gcc-libs
     prerelease: "{{ .Prerelease }}"   # see openzro-archlinux comment above
     archlinux:
       pkgbase: openzro-management

--- a/docs/adr/0002-flow-events-storage.md
+++ b/docs/adr/0002-flow-events-storage.md
@@ -346,12 +346,13 @@ from the new list and only `Close()`-ing sinks that left.
 The "PR-F" placeholder at the top of this ADR reserved cold archive
 write-side; the dashboard's read-side over the same data landed in
 [ADR-0012](0012-flow-archive-read-path.md). Brief recap: archive
-sinks now emit Parquet (gated by `OPENZRO_FLOW_ARCHIVE_FORMAT=parquet`)
-and a federated wrapper in `flow/store/federated/` queries either
-the hot store, the archive (via DuckDB embedded — `flow/store/archive/`
-behind the `archive_duckdb` build tag), or both per the requested
-date window. Operators on the legacy NDJSON archive keep their
-write side intact; the federated read engages only when the format
-flips to Parquet.
+sinks can emit Parquet (via `OPENZRO_FLOW_ARCHIVE_FORMAT=parquet` for
+env-configured sinks, or a row-level `format=parquet` on dashboard-
+configured flow exports) and a federated wrapper in
+`flow/store/federated/` queries either the hot store, the archive (via
+DuckDB embedded — `flow/store/archive/` behind the `archive_duckdb`
+build tag), or both per the requested date window. Operators on the
+legacy NDJSON archive keep their write side intact; the federated read
+engages only when the effective format is Parquet.
 
 ## References

--- a/docs/adr/0002-flow-events-storage.md
+++ b/docs/adr/0002-flow-events-storage.md
@@ -146,20 +146,24 @@ to validate against.
 
 ### COLD archive: batched object-storage writes
 
-Per-event POSTs to S3 are wasteful and expensive. The cold path
-buffers events in memory and writes a Parquet file every N minutes
-(default 15 min) to a configured bucket:
+Per-event POSTs to S3 are wasteful and expensive. The cold path buffers
+events in memory and writes an archive object every N minutes (default 15
+min) to a configured bucket. Set `OPENZRO_FLOW_ARCHIVE_FORMAT=parquet` when
+the dashboard should be able to query events after the hot retention window:
 
 ```
 OPENZRO_FLOW_ARCHIVE_S3_BUCKET=openzro-flow-archive
 OPENZRO_FLOW_ARCHIVE_S3_REGION=us-east-1
-OPENZRO_FLOW_ARCHIVE_INTERVAL=15m
+OPENZRO_FLOW_ARCHIVE_S3_FLUSH_INTERVAL=15m
+OPENZRO_FLOW_ARCHIVE_FORMAT=parquet
 ```
 
-GCS and R2 use the same interface with different auth glue. Parquet is
-chosen because it is the universal format for analytical query tools
-(DuckDB, Athena, BigQuery, ClickHouse) — operators querying their
-archive with their own tools should not need openzro-specific
+GCS and R2 use the same interface with different auth glue. Empty or
+unrecognized `OPENZRO_FLOW_ARCHIVE_FORMAT` values keep the older gzipped
+NDJSON output for compatibility with external tools, but the dashboard does
+not query that format. Parquet is chosen because it is the universal format
+for analytical query tools (DuckDB, Athena, BigQuery, ClickHouse) — operators
+querying their archive with their own tools should not need openzro-specific
 decoders.
 
 ### Retention and aging
@@ -174,9 +178,9 @@ Instead: hot and cold receive the **same** real-time write stream. If
 both are configured, every event lands in both. Cold has everything
 since archiving started; hot has only the configurable recent window.
 
-The dashboard's "Network Traffic Events" page queries the hot store
-exclusively and shows: "Older than {retention}? Query your archive
-or SIEM."
+The dashboard's "Network Traffic Events" page queries the hot store for
+recent events and, when the management binary includes `archive_duckdb` and
+the archive format is Parquet, queries the bucket for older events.
 
 ### Backpressure
 
@@ -305,7 +309,7 @@ partitioned-aware code (alpha.27+), not migrated. Justification:
 
 - Default retention is 30 days (`OPENZRO_FLOW_RETENTION=720h` in the
   chart), so the maximum data loss is bounded by that window.
-- Flow events are **not** the source of truth for any client behaviour
+- Flow events are **not** the source of truth for any client behavior
   — peers continue streaming new events the moment they reconnect, so
   the dashboard's view rebuilds from the live stream within minutes.
 - A copy-then-swap migration (rename → create partitioned → INSERT

--- a/docs/adr/0012-flow-archive-read-path.md
+++ b/docs/adr/0012-flow-archive-read-path.md
@@ -136,6 +136,12 @@ Two concrete pieces:
   `OPENZRO_FLOW_ARCHIVE_FORMAT=parquet`; dashboard-configured flow exports can
   do it on the row itself. Row-level format overrides the env default, and the
   federated reader follows the same precedence.
+* The federated reader is assembled at management startup. Dashboard changes
+  to flow export rows are applied immediately to the write-side sinks, but the
+  archive read path sees the changed row only after management restarts. When
+  multiple enabled S3/GCS exports resolve to Parquet, the reader picks the
+  first row by ID and logs that choice; additional Parquet archives keep
+  writing, but are not queried by the UI in this release.
 * The federated read **does not** transparently bridge NDJSON → Parquet.
   A separate one-shot tool (a follow-up ADR — out of scope for this
   one) will re-emit historical NDJSON as Parquet when an operator wants

--- a/docs/adr/0012-flow-archive-read-path.md
+++ b/docs/adr/0012-flow-archive-read-path.md
@@ -59,9 +59,10 @@ Two concrete pieces:
 
 1. **Write side — Apache Parquet** as the archive object format.
    `flow/sinks/s3.go` and `flow/sinks/gcs.go` learn a
-   `OPENZRO_FLOW_ARCHIVE_FORMAT` env knob (`ndjson` | `parquet`) defaulting
-   to **`parquet` for new installs** and **`ndjson` for existing operators
-   who set neither** (back-compat — see Migration below). Same partition
+   `OPENZRO_FLOW_ARCHIVE_FORMAT` env knob (`ndjson` | `parquet`). Empty or
+   unrecognized values resolve to **`ndjson` for back-compat**; operators
+   must set **`OPENZRO_FLOW_ARCHIVE_FORMAT=parquet`** to make the dashboard's
+   federated read path query the bucket. Same partition
    layout the sinks already write today (Hive-style for Athena / Glue
    / DuckDB-friendly):
 
@@ -126,34 +127,38 @@ Two concrete pieces:
 
 ### 1. Format default and migration
 
-* **New installs** default to Parquet. Operators bringing up a fresh
-  cluster after this ADR ships get the federated read for free.
-* **Existing installs** keep NDJSON until they flip
-  `OPENZRO_FLOW_ARCHIVE_FORMAT=parquet`. The flip is one-way for the
-  archive (you can keep producing both formats during a transition by
-  running two sinks, but the federated read recognises only Parquet).
+* **Unset or unrecognized format values keep writing NDJSON.** This is
+  deliberately conservative: changing the default object format would
+  surprise existing operators and downstream tools that consume
+  `*.ndjson.gz` directly.
+* **Operators must explicitly flip**
+  `OPENZRO_FLOW_ARCHIVE_FORMAT=parquet` to enable dashboard reads from the
+  archive. The flip is one-way for the archive (you can keep producing both
+  formats during a transition by running two sinks, but the federated read
+  recognizes only Parquet).
 * The federated read **does not** transparently bridge NDJSON → Parquet.
   A separate one-shot tool (a follow-up ADR — out of scope for this
   one) will re-emit historical NDJSON as Parquet when an operator wants
   contiguous history.
 
 This back-compat keeps the upgrade path frictionless: deploy the new
-management binary, observe that Parquet writes start happening for new
-events, optionally run the tool against old prefixes once it ships.
+management binary, leave existing NDJSON consumers untouched, then opt into
+Parquet when dashboard access to cold history is wanted. Optionally run the
+tool against old prefixes once it ships.
 
 ### 2. CGo dependency
 
 `go-duckdb` requires CGo. We accept that cost for the management binary
 because:
 
-* Linux + macOS CGo cross-compile is well-trodden via [goreleaser][gor]
-  matrices that already exist in the repo (`.goreleaser*.yaml`).
+* Linux CGo cross-compile is supported by the release workflow's
+  [goreleaser][gor] matrix and cross-compilers.
 * Windows CGo for management is the riskiest target. We **gate the
-  archive store behind a build tag** `archive_duckdb`. Linux and macOS
-  builds turn it on by default; the Windows binary ships without the
-  archive read store until smoke tests on a Windows runner clear it.
+  archive store behind a build tag** `archive_duckdb`. Linux builds turn it
+  on by default; macOS and Windows management binaries ship without the
+  archive read store until smoke tests on those runners clear it.
   When that build tag is off, the federated layer detects the absent
-  archive store and falls back silently to hot-only — same behaviour as
+  archive store and falls back silently to hot-only — same behavior as
   today.
 * No CGo on the dashboard, signal, relay, or client binaries. Only
   management.

--- a/docs/adr/0012-flow-archive-read-path.md
+++ b/docs/adr/0012-flow-archive-read-path.md
@@ -131,11 +131,11 @@ Two concrete pieces:
   deliberately conservative: changing the default object format would
   surprise existing operators and downstream tools that consume
   `*.ndjson.gz` directly.
-* **Operators must explicitly flip**
-  `OPENZRO_FLOW_ARCHIVE_FORMAT=parquet` to enable dashboard reads from the
-  archive. The flip is one-way for the archive (you can keep producing both
-  formats during a transition by running two sinks, but the federated read
-  recognizes only Parquet).
+* **Operators must explicitly choose Parquet** to enable dashboard reads from
+  the archive. Env-configured archives do that with
+  `OPENZRO_FLOW_ARCHIVE_FORMAT=parquet`; dashboard-configured flow exports can
+  do it on the row itself. Row-level format overrides the env default, and the
+  federated reader follows the same precedence.
 * The federated read **does not** transparently bridge NDJSON → Parquet.
   A separate one-shot tool (a follow-up ADR — out of scope for this
   one) will re-emit historical NDJSON as Parquet when an operator wants

--- a/docs/operator/upgrade-notes.md
+++ b/docs/operator/upgrade-notes.md
@@ -71,6 +71,13 @@ No pre-upgrade action is required for the route validation change.
   `OPENZRO_FLOW_ARCHIVE_GCS_BUCKET`. For dashboard-configured exports,
   set that export's Format to `parquet`; a row-level format overrides
   the env default, and the dashboard reader uses the same precedence.
+  The reader is assembled only when management starts. Saving or
+  editing a dashboard export starts writing with the new format
+  immediately, but archive reads from that export require a management
+  restart. If more than one enabled S3/GCS export resolves to Parquet,
+  the dashboard reader uses the first row by ID and logs the selected
+  export; the other Parquet exports keep writing normally but are not
+  queried by the UI.
   Archives written with the default NDJSON format remain available in
   the bucket for external tools, but the dashboard does not query them.
 

--- a/docs/operator/upgrade-notes.md
+++ b/docs/operator/upgrade-notes.md
@@ -62,6 +62,14 @@ No pre-upgrade action is required for the route validation change.
   the JWT group to the intended policies after it appears; ship the
   dashboard group-origin labels with this change so operators can tell
   the two groups apart.
+- **Linux management releases can read Parquet flow archives from the
+  dashboard.** To make network traffic events older than
+  `OPENZRO_FLOW_RETENTION` visible in the UI, set
+  `OPENZRO_FLOW_ARCHIVE_FORMAT=parquet` on the same deployment that
+  writes `OPENZRO_FLOW_ARCHIVE_S3_BUCKET` or
+  `OPENZRO_FLOW_ARCHIVE_GCS_BUCKET`. Archives written with the default
+  NDJSON format remain available in the bucket for external tools, but
+  the dashboard does not query them.
 
 ## v0.53.1-alpha.89
 

--- a/docs/operator/upgrade-notes.md
+++ b/docs/operator/upgrade-notes.md
@@ -64,12 +64,15 @@ No pre-upgrade action is required for the route validation change.
   the two groups apart.
 - **Linux management releases can read Parquet flow archives from the
   dashboard.** To make network traffic events older than
-  `OPENZRO_FLOW_RETENTION` visible in the UI, set
-  `OPENZRO_FLOW_ARCHIVE_FORMAT=parquet` on the same deployment that
-  writes `OPENZRO_FLOW_ARCHIVE_S3_BUCKET` or
-  `OPENZRO_FLOW_ARCHIVE_GCS_BUCKET`. Archives written with the default
-  NDJSON format remain available in the bucket for external tools, but
-  the dashboard does not query them.
+  `OPENZRO_FLOW_RETENTION` visible in the UI, the archive that writes
+  the bucket must have effective format `parquet`. For env-configured
+  archives, set `OPENZRO_FLOW_ARCHIVE_FORMAT=parquet` on the same
+  deployment that writes `OPENZRO_FLOW_ARCHIVE_S3_BUCKET` or
+  `OPENZRO_FLOW_ARCHIVE_GCS_BUCKET`. For dashboard-configured exports,
+  set that export's Format to `parquet`; a row-level format overrides
+  the env default, and the dashboard reader uses the same precedence.
+  Archives written with the default NDJSON format remain available in
+  the bucket for external tools, but the dashboard does not query them.
 
 ## v0.53.1-alpha.89
 

--- a/flow/store/archive/factory.go
+++ b/flow/store/archive/factory.go
@@ -83,6 +83,14 @@ func NewFromEnv() (store.Store, error) {
 		return nil, nil
 	}
 
+	return NewParquet(cfg)
+}
+
+// NewParquet constructs an archive reader for a source whose effective
+// write format is already known to be Parquet. It applies the same
+// runtime bounds as NewFromEnv so env-configured and dashboard-
+// configured archives share timeout, memory and concurrency behavior.
+func NewParquet(cfg Config) (store.Store, error) {
 	cfg.QueryTimeout = parseTimeout(os.Getenv(envQueryTimeout))
 	cfg.MemoryLimit = os.Getenv(envMemoryLimit)
 	cfg.Threads = parseInt(os.Getenv(envThreads))

--- a/flow/store/archive/factory.go
+++ b/flow/store/archive/factory.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/openzro/openzro/flow/store"
 )
 
@@ -48,8 +50,10 @@ const (
 //     built with `archive_duckdb` AND the format is "parquet".
 //   - (nil, nil) when the bucket is not configured at all (operator
 //     opted out — federated falls back to hot-only).
-//   - (nil, nil) when the format is "ndjson" (read path doesn't
-//     support that yet — log it and operate as if no archive).
+//   - (nil, nil) when the format is empty, "ndjson", or otherwise not
+//     "parquet" (the sink defaults those values to NDJSON, and the read
+//     path doesn't support NDJSON yet — log it and operate as if no
+//     archive).
 //   - (nil, ErrUnavailable) when the binary was built without
 //     archive_duckdb. Caller should fall back to hot-only with a
 //     warning rather than fail.
@@ -60,18 +64,22 @@ const (
 // In practice an operator picks one, so the precedence rarely
 // matters.
 func NewFromEnv() (store.Store, error) {
-	format := os.Getenv(envFormat)
-	if format != "" && format != "parquet" {
-		// NDJSON archives exist but the read path does not target
-		// them yet. Treat as "no archive" so the federated wrapper
-		// stays on hot-only and the operator gets a clear log line
-		// rather than a spurious error during boot.
-		return nil, nil
-	}
-
 	cfg, ok := configFromEnv()
 	if !ok {
 		// No bucket configured → operator opted out, not a failure.
+		return nil, nil
+	}
+
+	format := os.Getenv(envFormat)
+	if format != "parquet" {
+		// NDJSON archives exist but the read path does not target them
+		// yet. Treat as "no archive" so the federated wrapper stays on
+		// hot-only; enabling the DuckDB store here would query
+		// *.parquet while the sink is writing *.ndjson.gz.
+		log.Warnf(
+			"flow archive: bucket configured but %s=%q resolves to ndjson; "+
+				"dashboard archive reads require %s=parquet, so older events remain hot-store only",
+			envFormat, format, envFormat)
 		return nil, nil
 	}
 

--- a/flow/store/archive/factory_stub_test.go
+++ b/flow/store/archive/factory_stub_test.go
@@ -1,0 +1,70 @@
+//go:build !archive_duckdb
+
+package archive
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFromEnvSkipsNonParquetArchiveFormats(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		format string
+	}{
+		{name: "empty format defaults to ndjson on the sink", format: ""},
+		{name: "explicit ndjson", format: "ndjson"},
+		{name: "unknown format also resolves to ndjson on the sink", format: "csv"},
+		{name: "uppercase parquet still resolves to ndjson on the sink", format: "PARQUET"},
+		{name: "spaced parquet still resolves to ndjson on the sink", format: " parquet "},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clearArchiveEnv(t)
+			t.Setenv(envS3Bucket, "flow-archive")
+			t.Setenv(envFormat, tc.format)
+
+			st, err := NewFromEnv()
+			require.NoError(t, err)
+			assert.Nil(t, st)
+		})
+	}
+}
+
+func TestNewFromEnvParquetRequiresDuckDBBuild(t *testing.T) {
+	clearArchiveEnv(t)
+	t.Setenv(envS3Bucket, "flow-archive")
+	t.Setenv(envFormat, "parquet")
+
+	st, err := NewFromEnv()
+	assert.Nil(t, st)
+	assert.True(t, errors.Is(err, ErrUnavailable), "expected ErrUnavailable, got %v", err)
+}
+
+func clearArchiveEnv(t *testing.T) {
+	t.Helper()
+
+	for _, key := range []string{
+		envS3Bucket,
+		envS3Region,
+		envS3Endpoint,
+		envS3AccessKey,
+		envS3SecretKey,
+		envS3Prefix,
+		envGCSBucket,
+		envGCSPrefix,
+		envGCSCredentialsFile,
+		envGCSCredentialsJSON,
+		envGCSProjectID,
+		envGCSEndpoint,
+		envFormat,
+		envQueryTimeout,
+		envMemoryLimit,
+		envThreads,
+		envMaxConcurrentQueries,
+	} {
+		t.Setenv(key, "")
+	}
+}

--- a/management/Dockerfile
+++ b/management/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:24.04
-RUN apt update && apt install -y ca-certificates && rm -fr /var/cache/apt
+RUN apt update && apt install -y ca-certificates libstdc++6 && rm -fr /var/cache/apt
 ENTRYPOINT [ "/go/bin/openzro-mgmt","management"]
 CMD ["--log-file", "console"]
 COPY openzro-mgmt /go/bin/openzro-mgmt

--- a/management/Dockerfile.debug
+++ b/management/Dockerfile.debug
@@ -1,5 +1,5 @@
 FROM ubuntu:24.04
-RUN apt update && apt install -y ca-certificates && rm -fr /var/cache/apt
+RUN apt update && apt install -y ca-certificates libstdc++6 && rm -fr /var/cache/apt
 ENTRYPOINT [ "/go/bin/openzro-mgmt","management","--log-level","debug"]
 CMD ["--log-file", "console"]
 COPY openzro-mgmt /go/bin/openzro-mgmt

--- a/management/cmd/management.go
+++ b/management/cmd/management.go
@@ -1050,7 +1050,7 @@ func flowArchiveFromConfig(
 	if flowExportsStore == nil {
 		return nil, "", nil
 	}
-	cfg, ok, err := flowExports.ArchiveConfigFromRows(ctx, flowExportsStore)
+	cfg, source, ok, err := flowExports.ArchiveConfigFromRows(ctx, flowExportsStore)
 	if err != nil {
 		return nil, "", fmt.Errorf("flow_exports archive config: %w", err)
 	}
@@ -1058,7 +1058,7 @@ func flowArchiveFromConfig(
 		return nil, "", nil
 	}
 	archiveStore, err = flowArchive.NewParquet(cfg)
-	return archiveStore, "flow_exports", err
+	return archiveStore, source, err
 }
 
 func cpFile(src, dst string) error {

--- a/management/cmd/management.go
+++ b/management/cmd/management.go
@@ -382,32 +382,6 @@ var (
 			if flowBuilt != nil {
 				flowStore = flowBuilt.Store
 				defer func() { _ = flowBuilt.Close() }()
-
-				// Cold-archive read path (ADR-0012). When the operator has
-				// configured a Parquet archive (S3 or GCS) AND this binary
-				// was built with `-tags=archive_duckdb`, wrap the hot store
-				// in a federated layer that routes queries by date window.
-				// Otherwise — no archive configured, NDJSON-only archive,
-				// or non-DuckDB build — federated falls through to hot-only
-				// behavior.
-				archiveStore, archErr := flowArchive.NewFromEnv()
-				switch {
-				case errors.Is(archErr, flowArchive.ErrUnavailable):
-					log.WithContext(ctx).Warn(
-						"flow archive: configured but binary built without archive_duckdb — " +
-							"rebuild with `-tags=archive_duckdb` to enable federated reads")
-				case archErr != nil:
-					return fmt.Errorf("flow archive store: %w", archErr)
-				}
-				if archiveStore != nil {
-					fed, err := flowFederated.New(flowStore, archiveStore, flowBuilt.Retention)
-					if err != nil {
-						return fmt.Errorf("flow federated store: %w", err)
-					}
-					flowStore = fed
-					log.WithContext(ctx).Infof(
-						"flow archive: federated read enabled (hot retention=%s)", flowBuilt.Retention)
-				}
 			}
 
 			// flow_exports: runtime-configurable destinations. The store
@@ -537,6 +511,39 @@ var (
 					return st.Compliant, st.Reason, nil
 				})
 				defer func() { _ = mdmManager.Close() }()
+			}
+
+			if flowStore != nil {
+				// Cold-archive read path (ADR-0012). When the operator has
+				// configured a Parquet archive (S3 or GCS) AND this binary
+				// was built with `-tags=archive_duckdb`, wrap the hot store
+				// in a federated layer that routes queries by date window.
+				// Environment configuration keeps its old precedence; when
+				// that does not yield a reader, fall back to the first
+				// enabled dashboard flow export whose effective format is
+				// Parquet. Otherwise — no archive configured, NDJSON-only
+				// archive, or non-DuckDB build — federated falls through to
+				// hot-only behavior.
+				archiveStore, archiveSource, archErr := flowArchiveFromConfig(ctx, flowExportsStore)
+				switch {
+				case errors.Is(archErr, flowArchive.ErrUnavailable):
+					log.WithContext(ctx).Warnf(
+						"flow archive: %s configured but binary built without archive_duckdb — "+
+							"rebuild with `-tags=archive_duckdb` to enable federated reads",
+						archiveSource)
+				case archErr != nil:
+					return fmt.Errorf("flow archive store: %w", archErr)
+				}
+				if archiveStore != nil {
+					fed, err := flowFederated.New(flowStore, archiveStore, flowBuilt.Retention)
+					if err != nil {
+						return fmt.Errorf("flow federated store: %w", err)
+					}
+					flowStore = fed
+					log.WithContext(ctx).Infof(
+						"flow archive: federated read enabled (source=%s, hot retention=%s)",
+						archiveSource, flowBuilt.Retention)
+				}
 			}
 
 			// Build FlowService + flow_exports.Manager BEFORE
@@ -1029,6 +1036,29 @@ func handleRebrand(cmd *cobra.Command) error {
 		}
 	}
 	return nil
+}
+
+func flowArchiveFromConfig(
+	ctx context.Context,
+	flowExportsStore *flowExports.Store,
+) (flowstore.Store, string, error) {
+	archiveStore, err := flowArchive.NewFromEnv()
+	if archiveStore != nil || err != nil {
+		return archiveStore, "environment", err
+	}
+
+	if flowExportsStore == nil {
+		return nil, "", nil
+	}
+	cfg, ok, err := flowExports.ArchiveConfigFromRows(ctx, flowExportsStore)
+	if err != nil {
+		return nil, "", fmt.Errorf("flow_exports archive config: %w", err)
+	}
+	if !ok {
+		return nil, "", nil
+	}
+	archiveStore, err = flowArchive.NewParquet(cfg)
+	return archiveStore, "flow_exports", err
 }
 
 func cpFile(src, dst string) error {

--- a/management/server/flow_exports/archive_config.go
+++ b/management/server/flow_exports/archive_config.go
@@ -2,6 +2,7 @@ package flow_exports
 
 import (
 	"context"
+	"fmt"
 
 	log "github.com/sirupsen/logrus"
 
@@ -12,15 +13,15 @@ import (
 // effective format is Parquet. List() sorts by ID, so the choice is
 // deterministic when an operator has configured more than one archive.
 //
-// Decrypt/build errors are logged and skipped, matching Manager.ApplyAll:
+// Decrypt/type errors are logged and skipped, matching Manager.ApplyAll:
 // one malformed export row must not prevent management from starting.
-func ArchiveConfigFromRows(ctx context.Context, cfgStore *Store) (flowArchive.Config, bool, error) {
+func ArchiveConfigFromRows(ctx context.Context, cfgStore *Store) (flowArchive.Config, string, bool, error) {
 	if cfgStore == nil {
-		return flowArchive.Config{}, false, nil
+		return flowArchive.Config{}, "", false, nil
 	}
 	rows, err := cfgStore.List(ctx)
 	if err != nil {
-		return flowArchive.Config{}, false, err
+		return flowArchive.Config{}, "", false, err
 	}
 	for _, row := range rows {
 		if !row.Enabled {
@@ -60,7 +61,7 @@ func ArchiveConfigFromRows(ctx context.Context, cfgStore *Store) (flowArchive.Co
 				Region:          c.Region,
 				AccessKeyID:     c.AccessKey,
 				SecretAccessKey: c.SecretKey,
-			}, true, nil
+			}, archiveReaderSource(row), true, nil
 		case TypeGCS:
 			c, ok := plain.(*GCSDestConfig)
 			if !ok || c == nil {
@@ -80,8 +81,12 @@ func ArchiveConfigFromRows(ctx context.Context, cfgStore *Store) (flowArchive.Co
 				ProjectID:       c.ProjectID,
 				CredentialsFile: c.CredentialsFile,
 				CredentialsJSON: []byte(c.CredentialsJSON),
-			}, true, nil
+			}, archiveReaderSource(row), true, nil
 		}
 	}
-	return flowArchive.Config{}, false, nil
+	return flowArchive.Config{}, "", false, nil
+}
+
+func archiveReaderSource(row FlowExport) string {
+	return fmt.Sprintf("flow_exports#%d %s/%s", row.ID, row.Type, row.Name)
 }

--- a/management/server/flow_exports/archive_config.go
+++ b/management/server/flow_exports/archive_config.go
@@ -1,0 +1,87 @@
+package flow_exports
+
+import (
+	"context"
+
+	log "github.com/sirupsen/logrus"
+
+	flowArchive "github.com/openzro/openzro/flow/store/archive"
+)
+
+// ArchiveConfigFromRows returns the first enabled S3/GCS export whose
+// effective format is Parquet. List() sorts by ID, so the choice is
+// deterministic when an operator has configured more than one archive.
+//
+// Decrypt/build errors are logged and skipped, matching Manager.ApplyAll:
+// one malformed export row must not prevent management from starting.
+func ArchiveConfigFromRows(ctx context.Context, cfgStore *Store) (flowArchive.Config, bool, error) {
+	if cfgStore == nil {
+		return flowArchive.Config{}, false, nil
+	}
+	rows, err := cfgStore.List(ctx)
+	if err != nil {
+		return flowArchive.Config{}, false, err
+	}
+	for _, row := range rows {
+		if !row.Enabled {
+			continue
+		}
+		switch row.Type {
+		case TypeS3, TypeGCS:
+		default:
+			continue
+		}
+
+		plain, err := cfgStore.Decrypt(&row)
+		if err != nil {
+			log.WithContext(ctx).Errorf(
+				"flow_exports: skipping archive reader candidate #%d (%s/%s): %v",
+				row.ID, row.Type, row.Name, err)
+			continue
+		}
+
+		switch row.Type {
+		case TypeS3:
+			c, ok := plain.(*S3DestConfig)
+			if !ok || c == nil {
+				log.WithContext(ctx).Errorf(
+					"flow_exports: skipping archive reader candidate #%d (%s/%s): decrypted config has unexpected type",
+					row.ID, row.Type, row.Name)
+				continue
+			}
+			if archiveFormatFor(c.Format) != "parquet" {
+				continue
+			}
+			return flowArchive.Config{
+				Provider:        "s3",
+				Bucket:          c.Bucket,
+				Prefix:          c.Prefix,
+				Endpoint:        c.Endpoint,
+				Region:          c.Region,
+				AccessKeyID:     c.AccessKey,
+				SecretAccessKey: c.SecretKey,
+			}, true, nil
+		case TypeGCS:
+			c, ok := plain.(*GCSDestConfig)
+			if !ok || c == nil {
+				log.WithContext(ctx).Errorf(
+					"flow_exports: skipping archive reader candidate #%d (%s/%s): decrypted config has unexpected type",
+					row.ID, row.Type, row.Name)
+				continue
+			}
+			if archiveFormatFor(c.Format) != "parquet" {
+				continue
+			}
+			return flowArchive.Config{
+				Provider:        "gcs",
+				Bucket:          c.Bucket,
+				Prefix:          c.Prefix,
+				Endpoint:        c.Endpoint,
+				ProjectID:       c.ProjectID,
+				CredentialsFile: c.CredentialsFile,
+				CredentialsJSON: []byte(c.CredentialsJSON),
+			}, true, nil
+		}
+	}
+	return flowArchive.Config{}, false, nil
+}

--- a/management/server/flow_exports/manager_test.go
+++ b/management/server/flow_exports/manager_test.go
@@ -61,9 +61,11 @@ func TestArchiveConfigFromRowsUsesRowParquetWhenEnvIsEmpty(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	cfg, ok, err := ArchiveConfigFromRows(context.Background(), s)
+	cfg, source, ok, err := ArchiveConfigFromRows(context.Background(), s)
 	require.NoError(t, err)
 	require.True(t, ok, "row-level parquet archive must enable the read path even when env format is empty")
+	assert.Equal(t, "flow_exports#1 s3/dashboard-s3", source)
+	assert.NotContains(t, source, "secret")
 	assert.Equal(t, "s3", cfg.Provider)
 	assert.Equal(t, "flow-archive", cfg.Bucket)
 	assert.Equal(t, "tenant-a", cfg.Prefix)
@@ -90,7 +92,7 @@ func TestArchiveConfigFromRowsHonorsRowFormatOverride(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, ok, err := ArchiveConfigFromRows(context.Background(), s)
+	_, _, ok, err := ArchiveConfigFromRows(context.Background(), s)
 	require.NoError(t, err)
 	assert.False(t, ok, "row-level ndjson must not inherit env parquet")
 }
@@ -112,12 +114,45 @@ func TestArchiveConfigFromRowsInheritsEnvWhenRowFormatIsEmpty(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	cfg, ok, err := ArchiveConfigFromRows(context.Background(), s)
+	cfg, source, ok, err := ArchiveConfigFromRows(context.Background(), s)
 	require.NoError(t, err)
 	require.True(t, ok, "empty row format should inherit env parquet")
+	assert.Equal(t, "flow_exports#1 gcs/dashboard-gcs", source)
 	assert.Equal(t, "gcs", cfg.Provider)
 	assert.Equal(t, "flow-archive", cfg.Bucket)
 	assert.Equal(t, "tenant-b", cfg.Prefix)
 	assert.Equal(t, "project", cfg.ProjectID)
 	assert.Equal(t, []byte(`{"type":"service_account"}`), cfg.CredentialsJSON)
+}
+
+func TestArchiveConfigFromRowsUsesFirstEnabledParquetExport(t *testing.T) {
+	t.Setenv(envArchiveFormat, "")
+	s := newTestStore(t)
+
+	_, err := s.Save(context.Background(), SaveInput{
+		Name:    "first-parquet",
+		Type:    TypeS3,
+		Enabled: true,
+		S3: &S3DestConfig{
+			Bucket: "first-archive",
+			Format: "parquet",
+		},
+	})
+	require.NoError(t, err)
+	_, err = s.Save(context.Background(), SaveInput{
+		Name:    "second-parquet",
+		Type:    TypeGCS,
+		Enabled: true,
+		GCS: &GCSDestConfig{
+			Bucket: "second-archive",
+			Format: "parquet",
+		},
+	})
+	require.NoError(t, err)
+
+	cfg, source, ok, err := ArchiveConfigFromRows(context.Background(), s)
+	require.NoError(t, err)
+	require.True(t, ok)
+	assert.Equal(t, "flow_exports#1 s3/first-parquet", source)
+	assert.Equal(t, "first-archive", cfg.Bucket)
 }

--- a/management/server/flow_exports/manager_test.go
+++ b/management/server/flow_exports/manager_test.go
@@ -1,9 +1,11 @@
 package flow_exports
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestArchiveFormatFor_RowOverride pins the contract: when a row
@@ -37,4 +39,85 @@ func TestArchiveFormatFor_EmptyEnvReturnsEmpty(t *testing.T) {
 	t.Setenv(envArchiveFormat, "")
 	assert.Empty(t, archiveFormatFor(""),
 		"no override anywhere → caller (sink constructor) decides")
+}
+
+func TestArchiveConfigFromRowsUsesRowParquetWhenEnvIsEmpty(t *testing.T) {
+	t.Setenv(envArchiveFormat, "")
+	s := newTestStore(t)
+
+	_, err := s.Save(context.Background(), SaveInput{
+		Name:    "dashboard-s3",
+		Type:    TypeS3,
+		Enabled: true,
+		S3: &S3DestConfig{
+			Bucket:    "flow-archive",
+			Region:    "auto",
+			Endpoint:  "https://r2.example",
+			Prefix:    "tenant-a",
+			AccessKey: "access",
+			SecretKey: "secret",
+			Format:    "parquet",
+		},
+	})
+	require.NoError(t, err)
+
+	cfg, ok, err := ArchiveConfigFromRows(context.Background(), s)
+	require.NoError(t, err)
+	require.True(t, ok, "row-level parquet archive must enable the read path even when env format is empty")
+	assert.Equal(t, "s3", cfg.Provider)
+	assert.Equal(t, "flow-archive", cfg.Bucket)
+	assert.Equal(t, "tenant-a", cfg.Prefix)
+	assert.Equal(t, "https://r2.example", cfg.Endpoint)
+	assert.Equal(t, "auto", cfg.Region)
+	assert.Equal(t, "access", cfg.AccessKeyID)
+	assert.Equal(t, "secret", cfg.SecretAccessKey)
+}
+
+func TestArchiveConfigFromRowsHonorsRowFormatOverride(t *testing.T) {
+	t.Setenv(envArchiveFormat, "parquet")
+	s := newTestStore(t)
+
+	_, err := s.Save(context.Background(), SaveInput{
+		Name:    "legacy-ndjson",
+		Type:    TypeGCS,
+		Enabled: true,
+		GCS: &GCSDestConfig{
+			Bucket:          "flow-archive",
+			ProjectID:       "project",
+			CredentialsFile: "/var/run/gcp.json",
+			Format:          "ndjson",
+		},
+	})
+	require.NoError(t, err)
+
+	_, ok, err := ArchiveConfigFromRows(context.Background(), s)
+	require.NoError(t, err)
+	assert.False(t, ok, "row-level ndjson must not inherit env parquet")
+}
+
+func TestArchiveConfigFromRowsInheritsEnvWhenRowFormatIsEmpty(t *testing.T) {
+	t.Setenv(envArchiveFormat, "parquet")
+	s := newTestStore(t)
+
+	_, err := s.Save(context.Background(), SaveInput{
+		Name:    "dashboard-gcs",
+		Type:    TypeGCS,
+		Enabled: true,
+		GCS: &GCSDestConfig{
+			Bucket:          "flow-archive",
+			Prefix:          "tenant-b",
+			ProjectID:       "project",
+			CredentialsJSON: `{"type":"service_account"}`,
+		},
+	})
+	require.NoError(t, err)
+
+	cfg, ok, err := ArchiveConfigFromRows(context.Background(), s)
+	require.NoError(t, err)
+	require.True(t, ok, "empty row format should inherit env parquet")
+	assert.Equal(t, "gcs", cfg.Provider)
+	assert.Equal(t, "flow-archive", cfg.Bucket)
+	assert.Equal(t, "tenant-b", cfg.Prefix)
+	assert.Equal(t, "project", cfg.ProjectID)
+	assert.Equal(t, []byte(`{"type":"service_account"}`), cfg.CredentialsJSON)
 }


### PR DESCRIPTION
## Summary

Fixes the cold flow archive read path used by the Network Traffic Events page after hot-store retention expires.

Three independent gaps were present:

- the real release config (`.goreleaser.binaries.yaml`) built `openzro-mgmt` with `CGO_ENABLED=0` and without `archive_duckdb`, so published Linux management binaries/images could only fall back to hot-store reads even when a Parquet archive bucket was configured
- `flow/store/archive.NewFromEnv` accepted an empty `OPENZRO_FLOW_ARCHIVE_FORMAT`, but the write-side sinks resolve empty/unknown values to NDJSON; the reader would then look for `*.parquet` while the bucket contained `*.ndjson.gz`
- dashboard-created S3/GCS exports can set their own row-level `format`; the sink lets the row override the env default, but the reader only looked at env, so `row=format: parquet` with env empty wrote Parquet while the dashboard still had no archive reader

This PR enables `archive_duckdb` for Linux management release artifacts, keeps the Darwin management binary CGo-free, installs `libstdc++6` in the management images, and declares the equivalent bare-metal package dependency for each Linux package format (`libstdc++6` deb, `libstdc++` rpm, `gcc-libs` archlinux).

The archive reader now opts in only when the archive's effective write format is Parquet. Environment configuration keeps its old precedence; if env does not yield a reader, management falls back to the first enabled dashboard flow export whose effective row/env format is `parquet`.

## Operator impact

- Existing NDJSON archives are not rewritten and are still available to external tools.
- The dashboard still does not query NDJSON archives; operators who want UI access to cold history must use Parquet going forward.
- For env-configured archives, set `OPENZRO_FLOW_ARCHIVE_FORMAT=parquet` next to the bucket env vars. For dashboard-configured S3/GCS exports, set that export's Format to `parquet`; row-level format overrides env, and the reader follows the same precedence.
- The archive reader is assembled only at management startup. Saving or editing a dashboard export starts writing with the new format immediately, but Network Traffic archive reads from that export require a management restart.
- If more than one enabled S3/GCS export resolves to Parquet, the dashboard reader uses the first row by ID and logs the selected non-secret source (`flow_exports#ID type/name`). The other Parquet exports continue writing normally, but are not queried by the UI in this release.
- Linux management images/packages gain the DuckDB-backed reader. macOS/Windows management binaries still fall back to hot-only until they have their own CGo smoke coverage.
- Bare-metal Linux packages now depend on the platform's C++ runtime package required by the DuckDB-enabled management binary.

## Construction vs query failures

`archive.NewParquet` validates only the local shape needed to build a store: bucket, provider, and resource bounds. It does not open DuckDB, load `httpfs`, create secrets, authenticate to the bucket, or list objects at startup. Bad object-store credentials therefore do not prevent management from starting; the first archive query reports the read failure.

That matches the existing cold-archive model: write-side export rows may be malformed without taking down management, and bucket outages should degrade archive reads rather than block the hot path.

## Verification

- `go test ./management/server/flow_exports -count=1`
- `go test ./flow/store/archive ./management/cmd -count=1`
- `go test ./flow/... ./management/cmd ./management/server/flow_exports -count=1`
- `GOCACHE=/tmp/openzro-gocache CGO_ENABLED=1 go build -tags=archive_duckdb .` from `management/` (exit 0; Go printed the existing read-only module-cache stat warning)
- `go test ./flow/store/archive ./flow/store/federated ./flow/sinks`
- `go test ./management/... -count=1`
- `CGO_ENABLED=1 go test -tags=archive_duckdb ./flow/store/archive`
- `goreleaser build --snapshot --clean --single-target --id openzro-mgmt --config .goreleaser.binaries.yaml`
- `goreleaser check --config .goreleaser.binaries.yaml`

Note: `goreleaser check --config .goreleaser.binaries.yaml` reports the config as valid but exits non-zero because of pre-existing GoReleaser deprecation warnings (`archives.builds`, `nfpms.builds`, `dockers`).
