### PR TITLE
Fix group name races per issuer

### DIFF
--- a/docs/operator/upgrade-notes.md
+++ b/docs/operator/upgrade-notes.md
@@ -34,7 +34,8 @@ another reason to take the backup below before starting.
 
 ### Before upgrading
 
-No pre-upgrade action is required for the route validation change.
+No pre-upgrade action is required for the route validation and group
+serialization changes.
 
 ### After upgrading
 
@@ -62,6 +63,13 @@ No pre-upgrade action is required for the route validation change.
   the JWT group to the intended policies after it appears; ship the
   dashboard group-origin labels with this change so operators can tell
   the two groups apart.
+- **Group display names are serialized per account and issuer/source.**
+  Creating or renaming a group to a name already used by another group
+  from the same source now returns a conflict across multi-replica
+  management deployments instead of relying on process-local locking or
+  database deadlocks. The source boundary is intentional: API, JWT and
+  SCIM groups may still share the same display name, and IdP-managed
+  groups never attach to API groups by name alone.
 - **Linux management releases can read Parquet flow archives from the
   dashboard.** To make network traffic events older than
   `OPENZRO_FLOW_RETENTION` visible in the UI, the archive that writes
@@ -208,24 +216,6 @@ one. Often, not always. Confirm rather than assume.
   now returns a clear rejection on PostgreSQL** instead of an internal
   error. On MySQL this case still returns an internal error — see the
   limitation below.
-
-## Known limitations
-
-### Multi-replica: one known invariant is still enforced only in-process
-
-A management deployment running **more than one replica** can still
-produce duplicates for one known case, because the check is a read
-followed by a write protected by a lock that lives inside one process:
-
-- group names issued through the API
-
-DNS zone overlap is **not** in that list. It is enforced on both
-engines by validation under the account-row serialization point, and a
-concurrent loser receives an actionable overlap error.
-
-Single-replica deployments are unaffected by any of this — the
-in-process lock is sufficient there. Progress is tracked in
-[#143](https://github.com/openzro/openzro/issues/143).
 
 ## Earlier releases
 

--- a/management/server/account.go
+++ b/management/server/account.go
@@ -1709,6 +1709,20 @@ func (am *DefaultAccountManager) SyncUserJWTGroups(ctx context.Context, userAuth
 	var hasChanges bool
 	var user *types.User
 	err = am.Store.ExecuteInTransaction(ctx, func(transaction store.Store) error {
+		if settings.GroupsPropagationEnabled {
+			// Propagation can update existing Group.Peers later in this
+			// transaction. Lock group rows before the account row so this path
+			// does not invert against route/DNS validators that read groups
+			// before serializing on the account.
+			if _, err := transaction.GetAccountGroups(ctx, store.LockingStrengthUpdate, userAuth.AccountId); err != nil {
+				return fmt.Errorf("error locking account groups: %w", err)
+			}
+		}
+
+		if err := transaction.LockAccount(ctx, store.LockingStrengthUpdate, userAuth.AccountId); err != nil {
+			return err
+		}
+
 		user, err = transaction.GetUserByUserID(ctx, store.LockingStrengthShare, userAuth.UserId)
 		if err != nil {
 			return fmt.Errorf("error getting user: %w", err)

--- a/management/server/account_test.go
+++ b/management/server/account_test.go
@@ -1299,7 +1299,7 @@ func TestAccountManager_NetworkUpdates_SaveGroup(t *testing.T) {
 	}()
 
 	group.Peers = []string{peer1.ID, peer2.ID, peer3.ID}
-	if err := manager.SaveGroup(context.Background(), account.Id, userID, &group, true); err != nil {
+	if err := manager.SaveGroup(context.Background(), account.Id, userID, &group, false); err != nil {
 		t.Errorf("save group: %v", err)
 		return
 	}

--- a/management/server/dns_test.go
+++ b/management/server/dns_test.go
@@ -566,7 +566,7 @@ func TestDNSAccountPeersUpdate(t *testing.T) {
 			ID:    "groupA",
 			Name:  "GroupA",
 			Peers: []string{peer1.ID, peer2.ID, peer3.ID},
-		}, true)
+		}, false)
 		assert.NoError(t, err)
 
 		done := make(chan struct{})

--- a/management/server/dns_zones_test.go
+++ b/management/server/dns_zones_test.go
@@ -471,7 +471,7 @@ func TestNetworkMap_CustomZonesComposition(t *testing.T) {
 	// this is the operator's natural flow and exercises the group
 	// membership wiring end-to-end.
 	g := &types.Group{ID: dnsZoneTestGroupID, Name: "test-group", Peers: []string{peer1.ID}}
-	require.NoError(t, am.SaveGroup(ctx, dnsZoneTestAccountID, dnsZoneTestUserID, g, true))
+	require.NoError(t, am.SaveGroup(ctx, dnsZoneTestAccountID, dnsZoneTestUserID, g, false))
 
 	// Three zones distributed to dnsZoneTestGroupID:
 	//   - "ok": enabled with a record -> peer1 must see, peer2 must not

--- a/management/server/group.go
+++ b/management/server/group.go
@@ -72,9 +72,14 @@ func (am *DefaultAccountManager) SaveGroup(ctx context.Context, accountID, userI
 	return am.SaveGroups(ctx, accountID, userID, []*types.Group{newGroup}, create)
 }
 
-// SaveGroups adds new groups to the account.
-// Note: This function does not acquire the global lock.
-// It is the caller's responsibility to ensure proper locking is in place before invoking this method.
+// SaveGroups adds or updates groups in the account.
+//
+// The process-local wrapper lock in SaveGroup is intentionally not required
+// here. Creates take the account row before proving the same-source name absent;
+// updates take the affected group rows first, then the account row. Peer
+// references are checked before either lock family, while the same-source name
+// proof stays non-locking under the account row; taking group locks after the
+// account row would invert against group-first writers.
 func (am *DefaultAccountManager) SaveGroups(ctx context.Context, accountID, userID string, groups []*types.Group, create bool) error {
 	operation := operations.Create
 	if !create {
@@ -93,9 +98,36 @@ func (am *DefaultAccountManager) SaveGroups(ctx context.Context, accountID, user
 	var updateAccountPeers bool
 
 	err = am.Store.ExecuteInTransaction(ctx, func(transaction store.Store) error {
+		for _, newGroup := range groups {
+			if err = prepareGroupSave(ctx, transaction, accountID, newGroup); err != nil {
+				return err
+			}
+		}
+
+		lockedGroups := make(map[string]*types.Group, len(groups))
+		if !create {
+			groupIDsToLock := make([]string, 0, len(groups))
+			for _, newGroup := range groups {
+				groupIDsToLock = append(groupIDsToLock, newGroup.ID)
+			}
+			slices.Sort(groupIDsToLock)
+
+			for _, groupID := range groupIDsToLock {
+				oldGroup, err := transaction.GetGroupByID(ctx, store.LockingStrengthUpdate, accountID, groupID)
+				if err != nil {
+					return err
+				}
+				lockedGroups[groupID] = oldGroup
+			}
+		}
+
+		if err = transaction.LockAccount(ctx, store.LockingStrengthUpdate, accountID); err != nil {
+			return err
+		}
+
 		groupIDs := make([]string, 0, len(groups))
 		for _, newGroup := range groups {
-			if err = validateNewGroup(ctx, transaction, accountID, newGroup); err != nil {
+			if err = validateGroupSave(ctx, transaction, accountID, newGroup, create, lockedGroups[newGroup.ID]); err != nil {
 				return err
 			}
 
@@ -140,7 +172,7 @@ func (am *DefaultAccountManager) prepareGroupEvents(ctx context.Context, transac
 	addedPeers := make([]string, 0)
 	removedPeers := make([]string, 0)
 
-	oldGroup, err := transaction.GetGroupByID(ctx, store.LockingStrengthShare, accountID, newGroup.ID)
+	oldGroup, err := transaction.GetGroupByID(ctx, store.LockingStrengthNone, accountID, newGroup.ID)
 	if err == nil && oldGroup != nil {
 		addedPeers = util.Difference(newGroup.Peers, oldGroup.Peers)
 		removedPeers = util.Difference(oldGroup.Peers, newGroup.Peers)
@@ -152,7 +184,7 @@ func (am *DefaultAccountManager) prepareGroupEvents(ctx context.Context, transac
 	}
 
 	modifiedPeers := slices.Concat(addedPeers, removedPeers)
-	peers, err := transaction.GetPeersByIDs(ctx, store.LockingStrengthShare, accountID, modifiedPeers)
+	peers, err := transaction.GetPeersByIDs(ctx, store.LockingStrengthNone, accountID, modifiedPeers)
 	if err != nil {
 		log.WithContext(ctx).Debugf("failed to get peers for group events: %v", err)
 		return nil
@@ -228,10 +260,25 @@ func (am *DefaultAccountManager) DeleteGroups(ctx context.Context, accountID, us
 	var updateAccountPeers bool
 
 	err = am.Store.ExecuteInTransaction(ctx, func(transaction store.Store) error {
-		for _, groupID := range groupIDs {
+		lockedGroups := make(map[string]*types.Group, len(groupIDs))
+		groupIDsToLock := slices.Clone(groupIDs)
+		slices.Sort(groupIDsToLock)
+		for _, groupID := range groupIDsToLock {
 			group, err := transaction.GetGroupByID(ctx, store.LockingStrengthUpdate, accountID, groupID)
 			if err != nil {
 				allErrors = errors.Join(allErrors, err)
+				continue
+			}
+			lockedGroups[groupID] = group
+		}
+
+		if err = transaction.LockAccount(ctx, store.LockingStrengthUpdate, accountID); err != nil {
+			return err
+		}
+
+		for _, groupID := range groupIDs {
+			group, ok := lockedGroups[groupID]
+			if !ok {
 				continue
 			}
 
@@ -288,13 +335,17 @@ func (am *DefaultAccountManager) GroupAddPeer(ctx context.Context, accountID, gr
 	var err error
 
 	err = am.Store.ExecuteInTransaction(ctx, func(transaction store.Store) error {
-		group, err = transaction.GetGroupByID(context.Background(), store.LockingStrengthUpdate, accountID, groupID)
+		group, err = transaction.GetGroupByID(ctx, store.LockingStrengthUpdate, accountID, groupID)
 		if err != nil {
 			return err
 		}
 
 		if updated := group.AddPeer(peerID); !updated {
 			return nil
+		}
+
+		if err = transaction.LockAccount(ctx, store.LockingStrengthUpdate, accountID); err != nil {
+			return err
 		}
 
 		updateAccountPeers, err = areGroupChangesAffectPeers(ctx, transaction, accountID, []string{groupID})
@@ -329,13 +380,17 @@ func (am *DefaultAccountManager) GroupAddResource(ctx context.Context, accountID
 	var err error
 
 	err = am.Store.ExecuteInTransaction(ctx, func(transaction store.Store) error {
-		group, err = transaction.GetGroupByID(context.Background(), store.LockingStrengthUpdate, accountID, groupID)
+		group, err = transaction.GetGroupByID(ctx, store.LockingStrengthUpdate, accountID, groupID)
 		if err != nil {
 			return err
 		}
 
 		if updated := group.AddResource(resource); !updated {
 			return nil
+		}
+
+		if err = transaction.LockAccount(ctx, store.LockingStrengthUpdate, accountID); err != nil {
+			return err
 		}
 
 		updateAccountPeers, err = areGroupChangesAffectPeers(ctx, transaction, accountID, []string{groupID})
@@ -370,13 +425,17 @@ func (am *DefaultAccountManager) GroupDeletePeer(ctx context.Context, accountID,
 	var err error
 
 	err = am.Store.ExecuteInTransaction(ctx, func(transaction store.Store) error {
-		group, err = transaction.GetGroupByID(context.Background(), store.LockingStrengthUpdate, accountID, groupID)
+		group, err = transaction.GetGroupByID(ctx, store.LockingStrengthUpdate, accountID, groupID)
 		if err != nil {
 			return err
 		}
 
 		if updated := group.RemovePeer(peerID); !updated {
 			return nil
+		}
+
+		if err = transaction.LockAccount(ctx, store.LockingStrengthUpdate, accountID); err != nil {
+			return err
 		}
 
 		updateAccountPeers, err = areGroupChangesAffectPeers(ctx, transaction, accountID, []string{groupID})
@@ -411,13 +470,17 @@ func (am *DefaultAccountManager) GroupDeleteResource(ctx context.Context, accoun
 	var err error
 
 	err = am.Store.ExecuteInTransaction(ctx, func(transaction store.Store) error {
-		group, err = transaction.GetGroupByID(context.Background(), store.LockingStrengthUpdate, accountID, groupID)
+		group, err = transaction.GetGroupByID(ctx, store.LockingStrengthUpdate, accountID, groupID)
 		if err != nil {
 			return err
 		}
 
 		if updated := group.RemoveResource(resource); !updated {
 			return nil
+		}
+
+		if err = transaction.LockAccount(ctx, store.LockingStrengthUpdate, accountID); err != nil {
+			return err
 		}
 
 		updateAccountPeers, err = areGroupChangesAffectPeers(ctx, transaction, accountID, []string{groupID})
@@ -442,25 +505,15 @@ func (am *DefaultAccountManager) GroupDeleteResource(ctx context.Context, accoun
 	return nil
 }
 
-// validateNewGroup validates the new group for existence and required fields.
-func validateNewGroup(ctx context.Context, transaction store.Store, accountID string, newGroup *types.Group) error {
+// prepareGroupSave checks fields and references that must happen before
+// SaveGroups takes group/account locks. Peer existence uses a locking read so a
+// concurrent peer delete cannot commit between validation and the group save.
+func prepareGroupSave(ctx context.Context, transaction store.Store, accountID string, newGroup *types.Group) error {
 	if newGroup.ID == "" && newGroup.Issued != types.GroupIssuedAPI {
 		return status.Errorf(status.InvalidArgument, "%s group without ID set", newGroup.Issued)
 	}
 
 	if newGroup.ID == "" && newGroup.Issued == types.GroupIssuedAPI {
-		existingGroupIDs, err := transaction.GetGroupIDsByNameAndIssued(ctx, store.LockingStrengthShare, accountID, newGroup.Name, types.GroupIssuedAPI)
-		if err != nil {
-			return err
-		}
-
-		// Group display names are unique only within the same issuer.
-		// JWT and integration groups are owned by their IdP source and
-		// may intentionally share a display name with an API group.
-		if len(existingGroupIDs) > 0 {
-			return status.Errorf(status.AlreadyExists, "group with name %s already exists", newGroup.Name)
-		}
-
 		newGroup.ID = xid.New().String()
 	}
 
@@ -468,6 +521,55 @@ func validateNewGroup(ctx context.Context, transaction store.Store, accountID st
 		_, err := transaction.GetPeerByID(ctx, store.LockingStrengthShare, accountID, peerID)
 		if err != nil {
 			return status.Errorf(status.InvalidArgument, "peer with ID \"%s\" not found", peerID)
+		}
+	}
+
+	return nil
+}
+
+// validateGroupSave validates a group create or update.
+//
+// Group display names are unique only within the same issuer. JWT and
+// integration groups are owned by their IdP source and may intentionally share
+// a display name with an API group. Updates with an unchanged name are allowed
+// even when legacy duplicate rows already exist, so operators can still edit
+// or remove old data without this validation making every duplicate row
+// unmanageable.
+func validateGroupSave(ctx context.Context, transaction store.Store, accountID string, newGroup *types.Group, create bool, oldGroup *types.Group) error {
+	if create && newGroup.ID != "" {
+		// The caller already holds the account row. Keep probes non-locking
+		// here; taking group locks after the account row would deadlock against
+		// group-first update/delete transactions.
+		existingGroup, err := transaction.GetGroupByID(ctx, store.LockingStrengthNone, accountID, newGroup.ID)
+		if err == nil && existingGroup != nil {
+			return status.Errorf(status.AlreadyExists, "group with ID %s already exists", newGroup.ID)
+		}
+		if err != nil {
+			s, ok := status.FromError(err)
+			if !ok || s.Type() != status.NotFound {
+				return err
+			}
+		}
+	}
+
+	checkName := create
+	if !create {
+		if oldGroup == nil {
+			return status.Errorf(status.Internal, "existing group %s was not locked before validation", newGroup.ID)
+		}
+		checkName = oldGroup.Name != newGroup.Name || oldGroup.Issued != newGroup.Issued
+	}
+
+	if checkName {
+		existingGroupIDs, err := transaction.GetGroupIDsByNameAndIssued(ctx, store.LockingStrengthNone, accountID, newGroup.Name, newGroup.Issued)
+		if err != nil {
+			return err
+		}
+		for _, groupID := range existingGroupIDs {
+			if !create && groupID == newGroup.ID {
+				continue
+			}
+			return status.Errorf(status.AlreadyExists, "group with name %s already exists", newGroup.Name)
 		}
 	}
 

--- a/management/server/group_name_concurrency_test.go
+++ b/management/server/group_name_concurrency_test.go
@@ -1,0 +1,341 @@
+package server
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	nbcontext "github.com/openzro/openzro/management/server/context"
+	"github.com/openzro/openzro/management/server/status"
+	"github.com/openzro/openzro/management/server/store"
+	"github.com/openzro/openzro/management/server/types"
+)
+
+// API group names are unique within the API issuer. The old protection was
+// accidental: two replicas could both prove the name absent, and the loser only
+// failed because the transaction later upgraded the account row from shared to
+// exclusive while bumping the network serial. That left the database with one
+// row, but reported an internal deadlock instead of a conflict the caller can
+// act on.
+func TestGroups_ConcurrentAPICreateAcrossReplicas(t *testing.T) {
+	const (
+		accountID = "group-race-account"
+		userID    = "group-race-user"
+		groupName = "contested-api-group"
+	)
+
+	r := newTwoReplicas(t)
+	ctx := context.Background()
+
+	account := newAccountWithId(ctx, accountID, userID, "", false)
+	require.NoError(t, r.A.Store.SaveAccount(ctx, account))
+
+	// Warm each replica. The barrier aligns calls, not the first statement
+	// inside the transaction.
+	for _, am := range []*DefaultAccountManager{r.A, r.B} {
+		_, err := am.GetAllGroups(ctx, accountID, userID)
+		require.NoError(t, err)
+	}
+
+	align := newBarrier()
+	create := func(am *DefaultAccountManager) <-chan error {
+		errCh := make(chan error, 1)
+		go func() {
+			align.wait(t)
+			err := am.SaveGroup(ctx, accountID, userID, &types.Group{
+				Name:   groupName,
+				Issued: types.GroupIssuedAPI,
+				Peers:  []string{},
+			}, true)
+			errCh <- err
+		}()
+		return errCh
+	}
+
+	errA, errB := create(r.A), create(r.B)
+
+	join := func(name string, ch <-chan error) error {
+		t.Helper()
+		select {
+		case err := <-ch:
+			return err
+		case <-time.After(30 * time.Second):
+			t.Fatalf("replica %s never returned from SaveGroup", name)
+			return nil
+		}
+	}
+	resultA, resultB := join("A", errA), join("B", errB)
+
+	groups := accountGroupsByNameAndIssued(t, r.B, accountID, groupName, types.GroupIssuedAPI)
+	require.Len(t, groups, 1, "the account must hold exactly one API group named %q (A=%v, B=%v)", groupName, resultA, resultB)
+
+	accepted := 0
+	for _, err := range []error{resultA, resultB} {
+		if err == nil {
+			accepted++
+		}
+	}
+	require.Equal(t, 1, accepted, "exactly one API create must be accepted")
+
+	loser := resultA
+	if loser == nil {
+		loser = resultB
+	}
+	require.ErrorContains(t, loser, "already exists")
+	s, ok := status.FromError(loser)
+	require.True(t, ok && s.Type() == status.AlreadyExists,
+		"the losing create must be an actionable conflict, not an internal deadlock: %v", loser)
+}
+
+// JWT sync has the same name invariant, but a different user-facing contract:
+// losing the create race must not fail login. The second replica should wait
+// for the first, re-read the JWT-owned group, and add its user to that group.
+// A same-name API group must remain untouched; joining it by display name would
+// let a manual group grant access through an IdP claim collision.
+func TestGroups_ConcurrentJWTCreateAcrossReplicas(t *testing.T) {
+	const (
+		accountID    = "jwt-group-race-account"
+		firstUserID  = "jwt-user-a"
+		secondUserID = "jwt-user-b"
+		groupName    = "Engineering"
+	)
+
+	r := newTwoReplicas(t)
+	ctx := context.Background()
+
+	account := newAccountWithId(ctx, accountID, firstUserID, "", false)
+	account.Users[secondUserID] = types.NewUser(secondUserID, types.UserRoleUser, false, false, "", nil, types.UserIssuedAPI)
+	account.Users[secondUserID].AccountID = accountID
+	account.Settings.JWTGroupsEnabled = true
+	account.Settings.JWTGroupsClaimName = "groups"
+	account.Groups["api-same-name"] = &types.Group{
+		ID:        "api-same-name",
+		AccountID: accountID,
+		Name:      groupName,
+		Issued:    types.GroupIssuedAPI,
+		Peers:     []string{},
+	}
+	require.NoError(t, r.A.Store.SaveAccount(ctx, account))
+
+	for _, am := range []*DefaultAccountManager{r.A, r.B} {
+		_, err := am.GetAllGroups(ctx, accountID, firstUserID)
+		require.NoError(t, err)
+	}
+
+	align := newBarrier()
+	sync := func(am *DefaultAccountManager, userID string) <-chan error {
+		errCh := make(chan error, 1)
+		go func() {
+			align.wait(t)
+			errCh <- am.SyncUserJWTGroups(ctx, nbcontext.UserAuth{
+				AccountId: accountID,
+				UserId:    userID,
+				Groups:    []string{groupName},
+			})
+		}()
+		return errCh
+	}
+
+	errA, errB := sync(r.A, firstUserID), sync(r.B, secondUserID)
+
+	join := func(name string, ch <-chan error) error {
+		t.Helper()
+		select {
+		case err := <-ch:
+			return err
+		case <-time.After(30 * time.Second):
+			t.Fatalf("replica %s never returned from SyncUserJWTGroups", name)
+			return nil
+		}
+	}
+	resultA, resultB := join("A", errA), join("B", errB)
+	require.NoError(t, resultA, "JWT sync must not fail the first login")
+	require.NoError(t, resultB, "JWT sync must not fail the second login")
+
+	apiGroups := accountGroupsByNameAndIssued(t, r.B, accountID, groupName, types.GroupIssuedAPI)
+	require.Len(t, apiGroups, 1, "the API group must remain a separate same-name group")
+
+	jwtGroups := accountGroupsByNameAndIssued(t, r.B, accountID, groupName, types.GroupIssuedJWT)
+	require.Len(t, jwtGroups, 1, "the account must hold exactly one JWT group named %q", groupName)
+	jwtGroupID := jwtGroups[0].ID
+
+	for _, userID := range []string{firstUserID, secondUserID} {
+		user, err := r.B.Store.GetUserByUserID(ctx, store.LockingStrengthNone, userID)
+		require.NoError(t, err)
+		require.Contains(t, user.AutoGroups, jwtGroupID, "%s must join the JWT-owned group", userID)
+		require.NotContains(t, user.AutoGroups, apiGroups[0].ID, "%s must not join the API group by name collision", userID)
+	}
+}
+
+// Group create validates same-source name uniqueness after taking the account
+// row. That validation must not take a group lock: update/delete transactions
+// hold the group row first and only then serialize on the account row. This
+// test pins the create-side direction, which is the inverse of
+// TestGroups_UpdateAgainstGroupFirstValidator_NoDeadlock.
+func TestGroups_CreateValidationAgainstGroupFirstWriter_NoDeadlock(t *testing.T) {
+	const (
+		accountID = "group-create-order-account"
+		userID    = "group-create-order-user"
+		groupID   = "group-create-order-group"
+		groupName = "create-order-group"
+	)
+
+	r := newTwoReplicas(t)
+	ctx := context.Background()
+
+	account := newAccountWithId(ctx, accountID, userID, "", false)
+	require.NoError(t, r.A.Store.SaveAccount(ctx, account))
+	require.NoError(t, r.A.SaveGroup(ctx, accountID, userID, &types.Group{
+		ID:     groupID,
+		Name:   groupName,
+		Issued: types.GroupIssuedAPI,
+		Peers:  []string{},
+	}, true))
+
+	groupUpdateHeld := make(chan struct{})
+	releaseGroupFirstWriter := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseWriter := func() {
+		releaseOnce.Do(func() {
+			close(releaseGroupFirstWriter)
+		})
+	}
+	defer releaseWriter()
+
+	groupFirstErrCh := make(chan error, 1)
+	go func() {
+		groupFirstErrCh <- r.A.Store.ExecuteInTransaction(ctx, func(tx store.Store) error {
+			if _, err := tx.GetGroupByID(ctx, store.LockingStrengthUpdate, accountID, groupID); err != nil {
+				return err
+			}
+			close(groupUpdateHeld)
+			<-releaseGroupFirstWriter
+			return tx.IncrementNetworkSerial(ctx, store.LockingStrengthUpdate, accountID)
+		})
+	}()
+
+	select {
+	case <-groupUpdateHeld:
+	case <-time.After(10 * time.Second):
+		t.Fatal("group-first writer never took the group update lock")
+	}
+
+	accountLockHeld := make(chan struct{})
+	createValidationErrCh := make(chan error, 1)
+	go func() {
+		createValidationErrCh <- r.B.Store.ExecuteInTransaction(ctx, func(tx store.Store) error {
+			if err := tx.LockAccount(ctx, store.LockingStrengthUpdate, accountID); err != nil {
+				return err
+			}
+			close(accountLockHeld)
+			return validateGroupSave(ctx, tx, accountID, &types.Group{
+				ID:     "new-api-group",
+				Name:   groupName,
+				Issued: types.GroupIssuedAPI,
+				Peers:  []string{},
+			}, true, nil)
+		})
+	}()
+
+	select {
+	case <-accountLockHeld:
+	case <-time.After(10 * time.Second):
+		t.Fatal("create validation never took the account update lock")
+	}
+	releaseWriter()
+
+	join := func(name string, ch <-chan error) error {
+		t.Helper()
+		select {
+		case err := <-ch:
+			return err
+		case <-time.After(30 * time.Second):
+			t.Fatalf("%s never returned; it is blocked, which is the failure this test watches for", name)
+			return nil
+		}
+	}
+
+	createErr := join("create validation", createValidationErrCh)
+	groupFirstErr := join("group-first writer", groupFirstErrCh)
+
+	require.NoError(t, groupFirstErr, "the group-first writer must not become the deadlock victim")
+	require.ErrorContains(t, createErr, "already exists")
+	s, ok := status.FromError(createErr)
+	require.True(t, ok && s.Type() == status.AlreadyExists,
+		"the losing create must be a same-source name conflict, not an internal deadlock: %v", createErr)
+}
+
+// Group membership updates must keep the group-before-account lock order.
+// Route and DNS validators already read group rows before they serialize on
+// the account row, so taking the account row before updating the group would
+// create a cycle: route-like writer holds group(Share) and waits for account,
+// group writer holds account(Update) and waits for group(Update).
+func TestGroups_UpdateAgainstGroupFirstValidator_NoDeadlock(t *testing.T) {
+	const (
+		accountID = "group-order-account"
+		userID    = "group-order-user"
+		groupID   = "group-order-group"
+	)
+
+	r := newTwoReplicas(t)
+	ctx := context.Background()
+
+	account := newAccountWithId(ctx, accountID, userID, "", false)
+	require.NoError(t, r.A.Store.SaveAccount(ctx, account))
+	require.NoError(t, r.A.SaveGroup(ctx, accountID, userID, &types.Group{
+		ID:     groupID,
+		Name:   "route-like-group",
+		Issued: types.GroupIssuedAPI,
+		Peers:  []string{},
+	}, true))
+
+	groupShareHeld := make(chan struct{})
+	releaseRouteLikeWriter := make(chan struct{})
+	routeLikeErrCh := make(chan error, 1)
+	go func() {
+		routeLikeErrCh <- r.A.Store.ExecuteInTransaction(ctx, func(tx store.Store) error {
+			if _, err := tx.GetGroupsByIDs(ctx, store.LockingStrengthShare, accountID, []string{groupID}); err != nil {
+				return err
+			}
+			close(groupShareHeld)
+			<-releaseRouteLikeWriter
+			return tx.IncrementNetworkSerial(ctx, store.LockingStrengthUpdate, accountID)
+		})
+	}()
+
+	select {
+	case <-groupShareHeld:
+	case <-time.After(10 * time.Second):
+		t.Fatal("route-like writer never took the shared group lock")
+	}
+
+	groupErrCh := make(chan error, 1)
+	go func() {
+		groupErrCh <- r.B.GroupAddPeer(ctx, accountID, groupID, "peer-id")
+	}()
+
+	// Give a regressed account-before-group implementation enough room to take
+	// the account row before it blocks on the group row. The current order
+	// blocks on the group row first, holding no account lock.
+	time.Sleep(200 * time.Millisecond)
+	close(releaseRouteLikeWriter)
+
+	join := func(name string, ch <-chan error) error {
+		t.Helper()
+		select {
+		case err := <-ch:
+			return err
+		case <-time.After(30 * time.Second):
+			t.Fatalf("%s never returned; it is blocked, which is the failure this test watches for", name)
+			return nil
+		}
+	}
+
+	routeLikeErr := join("route-like writer", routeLikeErrCh)
+	groupErr := join("GroupAddPeer", groupErrCh)
+	require.NoError(t, routeLikeErr, "the route-like writer must not be the deadlock victim")
+	require.NoError(t, groupErr, "GroupAddPeer must queue behind the group reader, not deadlock")
+}

--- a/management/server/group_scim.go
+++ b/management/server/group_scim.go
@@ -45,6 +45,9 @@ func (am *DefaultAccountManager) SCIMCreateGroup(ctx context.Context, accountID,
 		Peers:     []string{},
 	}
 	if err := am.SaveGroups(ctx, accountID, callerID, []*types.Group{group}, true); err != nil {
+		if isGroupAlreadyExists(err) {
+			return nil, ErrSCIMGroupAlreadyExists
+		}
 		return nil, err
 	}
 	propagated, err := am.applySCIMGroupMembers(ctx, accountID, group.ID, memberUserIDs, nil)
@@ -83,6 +86,9 @@ func (am *DefaultAccountManager) SCIMReplaceGroup(ctx context.Context, accountID
 		group.Name = displayName
 	}
 	if err := am.SaveGroups(ctx, accountID, callerID, []*types.Group{group}, false); err != nil {
+		if isGroupAlreadyExists(err) {
+			return nil, ErrSCIMGroupAlreadyExists
+		}
 		return nil, err
 	}
 	prev, err := am.usersInGroup(ctx, accountID, groupID)
@@ -138,6 +144,13 @@ func (am *DefaultAccountManager) scimSingleUserMembership(ctx context.Context, a
 	var propagated bool
 	err := am.Store.ExecuteInTransaction(ctx, func(tx store.Store) error {
 		ctx := ctx
+		if err := lockSCIMGroupInTx(ctx, tx, accountID, groupID); err != nil {
+			return err
+		}
+		if err := tx.LockAccount(ctx, store.LockingStrengthUpdate, accountID); err != nil {
+			return err
+		}
+
 		settings, err := tx.GetAccountSettings(ctx, store.LockingStrengthShare, accountID)
 		if err != nil {
 			return err
@@ -180,6 +193,9 @@ func (am *DefaultAccountManager) SCIMRenameGroup(ctx context.Context, accountID,
 		group.Name = newName
 	}
 	if err := am.SaveGroups(ctx, accountID, callerID, []*types.Group{group}, false); err != nil {
+		if isGroupAlreadyExists(err) {
+			return nil, ErrSCIMGroupAlreadyExists
+		}
 		return nil, err
 	}
 	return group, nil
@@ -206,6 +222,13 @@ func (am *DefaultAccountManager) SCIMDeleteGroup(ctx context.Context, accountID,
 	var propagated bool
 	err = am.Store.ExecuteInTransaction(ctx, func(tx store.Store) error {
 		ctx := ctx
+		if err := lockSCIMGroupInTx(ctx, tx, accountID, groupID); err != nil {
+			return err
+		}
+		if err := tx.LockAccount(ctx, store.LockingStrengthUpdate, accountID); err != nil {
+			return err
+		}
+
 		settings, err := tx.GetAccountSettings(ctx, store.LockingStrengthShare, accountID)
 		if err != nil {
 			return err
@@ -317,6 +340,13 @@ func (am *DefaultAccountManager) applySCIMGroupMembers(ctx context.Context, acco
 	var propagated bool
 	err := am.Store.ExecuteInTransaction(ctx, func(tx store.Store) error {
 		ctx := ctx
+		if err := lockSCIMGroupInTx(ctx, tx, accountID, groupID); err != nil {
+			return err
+		}
+		if err := tx.LockAccount(ctx, store.LockingStrengthUpdate, accountID); err != nil {
+			return err
+		}
+
 		settings, err := tx.GetAccountSettings(ctx, store.LockingStrengthShare, accountID)
 		if err != nil {
 			return err
@@ -523,6 +553,18 @@ func stringSet(xs []string) map[string]struct{} {
 		out[s] = struct{}{}
 	}
 	return out
+}
+
+func isGroupAlreadyExists(err error) bool {
+	s, ok := status.FromError(err)
+	return ok && s.Type() == status.AlreadyExists
+}
+
+func lockSCIMGroupInTx(ctx context.Context, tx store.Store, accountID, groupID string) error {
+	if _, err := tx.GetGroupByID(ctx, store.LockingStrengthUpdate, accountID, groupID); err != nil {
+		return ErrSCIMGroupNotFound
+	}
+	return nil
 }
 
 // _ ensures account package is referenced so the import linter does

--- a/management/server/group_test.go
+++ b/management/server/group_test.go
@@ -317,7 +317,7 @@ func initTestGroupAccount(am *DefaultAccountManager) (*DefaultAccountManager, *t
 	groupForRoute2 := &types.Group{
 		ID:        "grp-for-route2",
 		AccountID: "account-id",
-		Name:      "Group for route",
+		Name:      "Group for route peer groups",
 		Issued:    types.GroupIssuedAPI,
 		Peers:     make([]string, 0),
 	}
@@ -410,13 +410,19 @@ func initTestGroupAccount(am *DefaultAccountManager) (*DefaultAccountManager, *t
 		return nil, nil, err
 	}
 
-	_ = am.SaveGroup(context.Background(), accountID, groupAdminUserID, groupForRoute, true)
-	_ = am.SaveGroup(context.Background(), accountID, groupAdminUserID, groupForRoute2, true)
-	_ = am.SaveGroup(context.Background(), accountID, groupAdminUserID, groupForNameServerGroups, true)
-	_ = am.SaveGroup(context.Background(), accountID, groupAdminUserID, groupForPolicies, true)
-	_ = am.SaveGroup(context.Background(), accountID, groupAdminUserID, groupForSetupKeys, true)
-	_ = am.SaveGroup(context.Background(), accountID, groupAdminUserID, groupForUsers, true)
-	_ = am.SaveGroup(context.Background(), accountID, groupAdminUserID, groupForIntegration, true)
+	for _, group := range []*types.Group{
+		groupForRoute,
+		groupForRoute2,
+		groupForNameServerGroups,
+		groupForPolicies,
+		groupForSetupKeys,
+		groupForUsers,
+		groupForIntegration,
+	} {
+		if err := am.SaveGroup(context.Background(), accountID, groupAdminUserID, group, true); err != nil {
+			return nil, nil, err
+		}
+	}
 
 	acc, err := am.Store.GetAccount(context.Background(), account.Id)
 	if err != nil {
@@ -474,7 +480,7 @@ func TestGroupAccountPeersUpdate(t *testing.T) {
 			ID:    "groupB",
 			Name:  "GroupB",
 			Peers: []string{peer1.ID, peer2.ID},
-		}, true)
+		}, false)
 		assert.NoError(t, err)
 
 		select {
@@ -567,7 +573,7 @@ func TestGroupAccountPeersUpdate(t *testing.T) {
 			ID:    "groupA",
 			Name:  "GroupA",
 			Peers: []string{peer1.ID, peer2.ID},
-		}, true)
+		}, false)
 		assert.NoError(t, err)
 
 		select {
@@ -636,7 +642,7 @@ func TestGroupAccountPeersUpdate(t *testing.T) {
 			ID:    "groupC",
 			Name:  "GroupC",
 			Peers: []string{peer1.ID, peer3.ID},
-		}, true)
+		}, false)
 		assert.NoError(t, err)
 
 		select {
@@ -677,7 +683,7 @@ func TestGroupAccountPeersUpdate(t *testing.T) {
 			ID:    "groupA",
 			Name:  "GroupA",
 			Peers: []string{peer1.ID, peer2.ID, peer3.ID},
-		}, true)
+		}, false)
 		assert.NoError(t, err)
 
 		select {
@@ -704,7 +710,7 @@ func TestGroupAccountPeersUpdate(t *testing.T) {
 			ID:    "groupD",
 			Name:  "GroupD",
 			Peers: []string{peer1.ID},
-		}, true)
+		}, false)
 		assert.NoError(t, err)
 
 		select {
@@ -751,7 +757,7 @@ func TestGroupAccountPeersUpdate(t *testing.T) {
 			ID:    "groupE",
 			Name:  "GroupE",
 			Peers: []string{peer2.ID, peer3.ID},
-		}, true)
+		}, false)
 		assert.NoError(t, err)
 
 		select {

--- a/management/server/route_test.go
+++ b/management/server/route_test.go
@@ -2153,7 +2153,7 @@ func TestRouteAccountPeersUpdate(t *testing.T) {
 			ID:    "groupB",
 			Name:  "GroupB",
 			Peers: []string{peer1ID},
-		}, true)
+		}, false)
 		assert.NoError(t, err)
 
 		select {
@@ -2193,7 +2193,7 @@ func TestRouteAccountPeersUpdate(t *testing.T) {
 			ID:    "groupC",
 			Name:  "GroupC",
 			Peers: []string{peer1ID},
-		}, true)
+		}, false)
 		assert.NoError(t, err)
 
 		select {

--- a/management/server/store/sql_store.go
+++ b/management/server/store/sql_store.go
@@ -1235,6 +1235,25 @@ func (s *SqlStore) GetAccountSettings(ctx context.Context, lockStrength LockingS
 	return accountSettings.Settings, nil
 }
 
+// LockAccount locks only the account row. Callers use it as a transaction
+// serialization point when they need account-wide exclusion without loading the
+// account tree or mutating the network serial.
+func (s *SqlStore) LockAccount(ctx context.Context, lockStrength LockingStrength, accountID string) error {
+	tx := s.db
+	if lockStrength != LockingStrengthNone {
+		tx = tx.Clauses(clause.Locking{Strength: string(lockStrength)})
+	}
+
+	var account types.Account
+	if err := tx.Model(&types.Account{}).Select("id").Where(idQueryCondition, accountID).First(&account).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return status.NewAccountNotFoundError(accountID)
+		}
+		return status.Errorf(status.Internal, "issue locking account in store: %s", err)
+	}
+	return nil
+}
+
 func (s *SqlStore) GetAccountCreatedBy(ctx context.Context, lockStrength LockingStrength, accountID string) (string, error) {
 	tx := s.db
 	if lockStrength != LockingStrengthNone {

--- a/management/server/store/store.go
+++ b/management/server/store/store.go
@@ -87,6 +87,7 @@ type Store interface {
 	GetAccountSettings(ctx context.Context, lockStrength LockingStrength, accountID string) (*types.Settings, error)
 	GetAccountDNSSettings(ctx context.Context, lockStrength LockingStrength, accountID string) (*types.DNSSettings, error)
 	GetAccountCreatedBy(ctx context.Context, lockStrength LockingStrength, accountID string) (string, error)
+	LockAccount(ctx context.Context, lockStrength LockingStrength, accountID string) error
 	SaveAccount(ctx context.Context, account *types.Account) error
 	// CreateAccount inserts a new account without upsert semantics, so a
 	// unique-index violation is reported instead of silently absorbed.


### PR DESCRIPTION
## Summary

- serialize group name creates by account row and scope duplicate checks to the same issuer/source
- preserve same-name API/JWT/SCIM groups so IdP claims never attach to manually managed groups by display name alone
- keep group update/delete lock order as group -> account to avoid inverting against route/DNS validators
- keep same-source name/ID probes non-locking after the account row; peer references are validated before group/account locks so peer deletes cannot slip through
- map same-source SCIM duplicate names back to the existing SCIM duplicate-group error
- update operator notes: no pre-upgrade action, visible behavior is an actionable conflict instead of deadlock/internal error for same-source duplicates

## Safety / compatibility

- No schema or migration change; legacy duplicates are not rewritten.
- Cross-source name collisions remain allowed by design.
- Updates that do not change a group name/source remain allowed, even when legacy duplicates exist, so old data stays manageable.
- The added account-row lock only affects group writes; reads are unchanged.
- Duplicate-name probes intentionally avoid `FOR SHARE` under the account lock; a locking read there deadlocks against group-first update/delete writers.

## Verification

- go test ./management/... -count=1
- OPENZRO_STORE_ENGINE=postgres go test ./management/server -run 'TestGroups_' -count=3
- OPENZRO_STORE_ENGINE=mysql go test ./management/server -run 'TestGroups_' -count=3
- OPENZRO_STORE_ENGINE=postgres go test ./management/server -race -run 'TestGroups_' -count=1
- OPENZRO_STORE_ENGINE=mysql go test ./management/server -race -run 'TestGroups_' -count=1
- negative control: changing `GetGroupIDsByNameAndIssued` back to `LockingStrengthShare` makes `TestGroups_CreateValidationAgainstGroupFirstWriter_NoDeadlock` fail with Postgres SQLSTATE 40P01