### PR TITLE
ci(release): install the arm64 C++ standard library for the duckdb build

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -79,7 +79,13 @@ jobs:
       - name: Install OS build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y -q gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu
+          # g++-aarch64-linux-gnu, not just gcc: the management binary is
+          # built with -tags=archive_duckdb, and go-duckdb links a prebuilt
+          # static library that needs libstdc++. The cross compiler alone
+          # gives us aarch64-linux-gnu-gcc but no arm64 libstdc++, so the
+          # arm64 link fails with `cannot find -lstdc++` while amd64 passes
+          # on the runner's native library. See #178.
+          sudo apt-get install -y -q gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
       - name: Decide goreleaser flags
         id: flags


### PR DESCRIPTION
The alpha.90 release failed to build:

```
failed to build for linux_arm64: exit status 1
ld: cannot find -lstdc++: No such file or directory
```

#178 built the Linux management binary with `-tags=archive_duckdb`. go-duckdb links a prebuilt static library that needs libstdc++, and the workflow installed `gcc-aarch64-linux-gnu` — the cross compiler, but not the C++ standard library for that target. amd64 linked against the runner's native libstdc++ and passed; arm64 had nothing to link.

`g++-aarch64-linux-gnu` brings `libstdc++-*-dev-arm64-cross` with it, which provides what the arm64 link is missing.

## Why the usual checks would not have caught it

Only the release pipeline cross-compiles, and only on a tag. Pull request CI builds amd64, and a local build uses the host toolchain — both pass.

## Verification

Validated with a snapshot run (`workflow_dispatch`, `snapshot=true`) on this branch, which exercises the same GoReleaser matrix without publishing: [run 33590189587](https://github.com/openzro/openzro/actions/runs/33590189587). It built `dist/openzro-mgmt_linux_arm64/openzro-mgmt` and produced `openzro-mgmt_..._linux_arm64.tar.gz` — the target that failed on alpha.90.

Refs #178.