### PR TITLE
docs: stop telling macOS users to disable Gatekeeper on a notarized pkg

### DIFF
--- a/.goreleaser.binaries.yaml
+++ b/.goreleaser.binaries.yaml
@@ -697,11 +697,14 @@ release:
 
     - **Windows binaries are unsigned** in this release stream. Windows
       SmartScreen will warn — click "More info" → "Run anyway".
-    - **macOS binaries are not notarized** in this release stream. Run
-      `xattr -d com.apple.quarantine <path-to-binary>` to remove the
-      Gatekeeper quarantine flag.
-    - For signed builds, use a tagged release from the upstream
-      goreleaser pipeline (TODO: SignPath integration).
+    - **The macOS installer is signed and notarized.**
+      `openzro_<version>_darwin_universal.pkg` is submitted to Apple's
+      notary service and stapled during the release, so it opens without
+      a Gatekeeper prompt and needs no `xattr` workaround.
+    - **The macOS tarballs are not.** The `*_darwin_*.tar.gz` archives
+      hold plain binaries that skip signing, so Gatekeeper quarantines
+      them on first run. Prefer the installer; if you need a raw binary,
+      `xattr -d com.apple.quarantine <path-to-binary>` clears the flag.
 
 snapshot:
   version_template: "{{ .Tag }}-snapshot-{{ .ShortCommit }}"

--- a/README.md
+++ b/README.md
@@ -168,9 +168,10 @@ sudo brew services start openzro
 #   openzro_<version>_darwin_universal.pkg
 ```
 
-The `.pkg` is unsigned; first run may need `xattr -d com.apple.quarantine`
-or right-click → *Open*. Apple Developer ID notarization is tracked as
-[issue #2](https://github.com/openzro/openzro/issues/2).
+The `.pkg` is signed with an Apple Developer ID and notarized, so it
+installs without a Gatekeeper prompt. The raw `*_darwin_*.tar.gz`
+binaries are not signed — those still need
+`xattr -d com.apple.quarantine` or right-click → *Open* on first run.
 
 ### Self-hosted control plane on Kubernetes
 


### PR DESCRIPTION
The release notes and the README both said macOS artifacts were unsigned. That stopped being true when Developer ID signing and notarization landed (#2, closed), and the alpha.90 release confirms it — `notarytool` returned `status: "Accepted"`, followed by `stapler staple` and `stapler validate`.

## Why this is worth a change

The claim was **half true**, which is worse than wrong:

| artifact | signed / notarized |
| --- | --- |
| `openzro_<version>_darwin_universal.pkg` | **yes** |
| `*_darwin_*.tar.gz` | no — `.goreleaser.binaries.yaml` has no `signs:` or `notarize:` section |

Someone downloading the installer — the path most macOS users take — was told to run `xattr -d com.apple.quarantine` on a file that does not need it. That is an instruction to strip a Gatekeeper protection for no reason, in the release notes of a zero-trust product.

## What changed

- The release-note template now names both artifacts and points at the installer first.
- The README no longer claims the `.pkg` is unsigned, and no longer points at #2 as pending work.
- Dropped "For signed builds, use a tagged release from the upstream goreleaser pipeline (TODO: SignPath integration)" — this *is* a tagged release and its pkg *is* signed, so the line sent readers elsewhere to find what was already in front of them.

No build or artifact changes: release-note template and README text only. YAML validated.

Refs #2.