### PR TITLE
fix(flow): authenticate GCS archive reads with HMAC

### DIFF
--- a/docs/adr/0012-flow-archive-read-path.md
+++ b/docs/adr/0012-flow-archive-read-path.md
@@ -181,14 +181,19 @@ the credential model the sinks already use:
   connection (DuckDB has [`SECRET` objects][duckdb-secret] for this
   pattern). Pod-level IAM (IRSA / Workload Identity) works because the
   underlying SDK reads the same env vars.
-* **GCS**: read `GOOGLE_APPLICATION_CREDENTIALS` (path to the service
-  account JSON) and pass through DuckDB's gcs extension when present,
-  fall back to S3-compatible mode (`storage.googleapis.com` HMAC
-  endpoint) otherwise. The chart's flow sink config already supports
-  both; the archive store reuses the resolved values.
-
-No new env vars introduced — the archive store reads what is already
-configured.
+* **GCS**: DuckDB serves `gcs://` through `httpfs` and its GCS secret
+  accepts HMAC interoperability keys (`KEY_ID` / `SECRET`). It does not
+  accept service-account JSON (`CREDENTIAL_CHAIN` is rejected by the
+  binder), and there is no separate `gcs` extension to install. The
+  write-side sink can continue using service-account JSON or Workload
+  Identity, but dashboard reads require
+  `OPENZRO_FLOW_ARCHIVE_GCS_HMAC_KEY_ID` and
+  `OPENZRO_FLOW_ARCHIVE_GCS_HMAC_SECRET` on management. Dashboard
+  exports still store the write-side GCS settings in the database; the
+  read-side HMAC keys remain process env so they are not added as a new
+  persisted secret surface. Missing HMAC keys disable the archive
+  reader with a startup warning rather than preventing management from
+  serving hot-store flow events.
 
 ### 4. Schema evolution discipline
 

--- a/docs/operator/upgrade-notes.md
+++ b/docs/operator/upgrade-notes.md
@@ -79,6 +79,17 @@ serialization changes.
   `OPENZRO_FLOW_ARCHIVE_GCS_BUCKET`. For dashboard-configured exports,
   set that export's Format to `parquet`; a row-level format overrides
   the env default, and the dashboard reader uses the same precedence.
+  GCS archive reads also require DuckDB-compatible HMAC interoperability
+  credentials: set `OPENZRO_FLOW_ARCHIVE_GCS_HMAC_KEY_ID` and
+  `OPENZRO_FLOW_ARCHIVE_GCS_HMAC_SECRET` on management. The existing
+  service account JSON/file settings can continue writing the archive,
+  but DuckDB cannot read GCS with them; create the HMAC keys in Google
+  Cloud Console under Cloud Storage -> Interoperability. A GCS Parquet
+  reader configured without those two variables is disabled at
+  management startup with a warning naming the missing variables; the
+  dashboard keeps serving hot-store flow events, and archived GCS
+  history becomes readable after the variables are set and management
+  is restarted.
   The reader is assembled only when management starts. Saving or
   editing a dashboard export starts writing with the new format
   immediately, but archive reads from that export require a management

--- a/flow/store/archive/archive.go
+++ b/flow/store/archive/archive.go
@@ -34,14 +34,21 @@ var ErrUnavailable = errors.New(
 	"flow archive store: built without archive_duckdb tag — " +
 		"rebuild with `go build -tags=archive_duckdb` to enable")
 
+// ErrMissingCredentials is returned when the archive reader is
+// configured but lacks the credentials DuckDB needs to authenticate.
+// The archive read path is optional, so management treats this like
+// ErrUnavailable and keeps serving hot-store flow events.
+var ErrMissingCredentials = errors.New("flow archive store: missing credentials")
+
 // Config configures the DuckDB-backed archive Store. The fields
 // mirror the env-var contract used by flow/sinks so the operator
 // configures the bucket once and the read + write paths share it.
 type Config struct {
 	// Provider is the object-store family DuckDB will read from.
 	// "s3" covers AWS S3, MinIO, Cloudflare R2, Backblaze B2 — any
-	// S3-compatible service. "gcs" covers Google Cloud Storage native
-	// auth (HMAC interop falls back to "s3").
+	// S3-compatible service. "gcs" covers Google Cloud Storage buckets
+	// written by the native GCS sink, but DuckDB still requires HMAC
+	// interoperability keys for reads.
 	Provider string
 
 	// Bucket is the destination bucket name. Required.
@@ -68,9 +75,9 @@ type Config struct {
 	SecretAccessKey string
 	SessionToken    string
 
-	// CredentialsJSON / CredentialsFile / ProjectID are the GCS
-	// equivalents. Set whichever the operator already has wired into
-	// the matching sink.
+	// CredentialsJSON / CredentialsFile / ProjectID mirror the GCS
+	// sink config, but DuckDB's read path does not use them; GCS reads
+	// require AccessKeyID / SecretAccessKey interoperability keys.
 	CredentialsJSON []byte
 	CredentialsFile string
 	ProjectID       string

--- a/flow/store/archive/duckdb.go
+++ b/flow/store/archive/duckdb.go
@@ -70,6 +70,9 @@ func New(cfg Config) (store.Store, error) {
 	default:
 		return nil, fmt.Errorf("flow archive store: unsupported provider %q (want s3 | gcs)", cfg.Provider)
 	}
+	if cfg.Provider == "gcs" && (cfg.AccessKeyID == "" || cfg.SecretAccessKey == "") {
+		return nil, newGCSHMACCredentialsError()
+	}
 	if cfg.QueryTimeout <= 0 {
 		cfg.QueryTimeout = defaultQueryTimeout
 	}
@@ -245,27 +248,44 @@ func (d *duckdbStore) applyAuthS3(ctx context.Context, conn *sql.DB) error {
 }
 
 func (d *duckdbStore) applyAuthGCS(ctx context.Context, conn *sql.DB) error {
-	// DuckDB's native GCS support uses the gcs extension when
-	// available, otherwise the S3-compat path. We prefer the native
-	// extension because it consumes service-account JSON the same way
-	// the GCS sink does — no HMAC dance, no re-issuing keys.
-	if _, err := conn.ExecContext(ctx, "INSTALL gcs"); err != nil {
-		return fmt.Errorf("flow archive store: install gcs: %w", err)
+	// No INSTALL gcs here, and this is not an omission. DuckDB has no
+	// gcs extension — the request 404s against extensions.duckdb.org
+	// for every version — and GCS is served by httpfs, which
+	// bootstrapConn already loaded.
+	//
+	// The secret takes an HMAC key pair and nothing else. Service
+	// account JSON is rejected outright:
+	//
+	//   Binder Error: Unknown parameter 'credential_chain' for secret
+	//   type 'gcs' with default provider 'config'
+	//
+	// So the read path needs interoperability keys even where the sink
+	// writes with a service account. Refuse during store construction so
+	// management can disable the optional archive reader with one warning
+	// instead of building a secret that cannot authenticate and failing
+	// once per dashboard query.
+	if d.cfg.AccessKeyID == "" || d.cfg.SecretAccessKey == "" {
+		return newGCSHMACCredentialsError()
 	}
-	if _, err := conn.ExecContext(ctx, "LOAD gcs"); err != nil {
-		return fmt.Errorf("flow archive store: load gcs: %w", err)
-	}
-	parts := []string{"TYPE GCS"}
-	if len(d.cfg.CredentialsJSON) > 0 {
-		// JSON is multi-line; quoteString doubles single quotes which
-		// is what DuckDB needs.
-		parts = append(parts, fmt.Sprintf("CREDENTIAL_CHAIN %s", quoteString(string(d.cfg.CredentialsJSON))))
+
+	parts := []string{
+		"TYPE GCS",
+		fmt.Sprintf("KEY_ID %s", quoteString(d.cfg.AccessKeyID)),
+		fmt.Sprintf("SECRET %s", quoteString(d.cfg.SecretAccessKey)),
 	}
 	stmt := fmt.Sprintf("CREATE OR REPLACE SECRET archive_secret (%s)", strings.Join(parts, ", "))
 	if _, err := conn.ExecContext(ctx, stmt); err != nil {
 		return fmt.Errorf("flow archive store: configure gcs secret: %w", err)
 	}
 	return nil
+}
+
+func newGCSHMACCredentialsError() error {
+	return fmt.Errorf(
+		"%w: GCS archive reads need HMAC credentials — set %s and %s "+
+			"(Cloud Storage → Interoperability). Service account JSON writes the archive "+
+			"but DuckDB cannot read with it",
+		ErrMissingCredentials, envGCSHMACKeyID, envGCSHMACSecret)
 }
 
 // parquetURL builds the read_parquet glob for an account. The

--- a/flow/store/archive/duckdb_test.go
+++ b/flow/store/archive/duckdb_test.go
@@ -3,6 +3,7 @@
 package archive
 
 import (
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -31,7 +32,31 @@ func TestNew_RequiresBucketAndProvider(t *testing.T) {
 	assert.NoError(t, err, "valid s3 config should succeed")
 
 	_, err = New(Config{Provider: "gcs", Bucket: "b"})
+	assert.ErrorContains(t, err, envGCSHMACKeyID, "gcs reads require HMAC credentials")
+	assert.True(t, errors.Is(err, ErrMissingCredentials), "missing GCS HMAC keys must be typed")
+
+	_, err = New(Config{Provider: "gcs", Bucket: "b", AccessKeyID: "k", SecretAccessKey: "s"})
 	assert.NoError(t, err, "valid gcs config should succeed")
+}
+
+func TestNewParquet_GCSUsesHMACEnv(t *testing.T) {
+	t.Setenv(envGCSHMACKeyID, "hmac-key")
+	t.Setenv(envGCSHMACSecret, "hmac-secret")
+
+	st, err := NewParquet(Config{
+		Provider:        "gcs",
+		Bucket:          "flow-archive",
+		CredentialsJSON: []byte(`{"type":"service_account"}`),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, st)
+
+	d, ok := st.(*duckdbStore)
+	require.True(t, ok)
+	assert.Equal(t, "hmac-key", d.cfg.AccessKeyID)
+	assert.Equal(t, "hmac-secret", d.cfg.SecretAccessKey)
+	assert.Equal(t, []byte(`{"type":"service_account"}`), d.cfg.CredentialsJSON,
+		"the write-side credential can remain on the config, but DuckDB reads with HMAC")
 }
 
 // TestBuildQuery_AccountIDOnly produces the simplest viable query —

--- a/flow/store/archive/factory.go
+++ b/flow/store/archive/factory.go
@@ -12,9 +12,10 @@ import (
 
 // Env-var contract — mirrors flow/sinks/factory.go so an operator
 // configures the bucket once and both write + read paths read the
-// same values. Only OPENZRO_FLOW_ARCHIVE_S3_BUCKET (or its GCS
-// counterpart) is required to enable the archive store; the rest
-// inherit defaults.
+// same bucket/prefix values. S3 can rely on provider defaults when no
+// explicit key is supplied; GCS reads additionally require HMAC
+// interoperability keys because DuckDB cannot authenticate with the
+// service-account JSON used by the write-side sink.
 const (
 	envS3Bucket    = "OPENZRO_FLOW_ARCHIVE_S3_BUCKET"
 	envS3Region    = "OPENZRO_FLOW_ARCHIVE_S3_REGION"
@@ -28,7 +29,15 @@ const (
 	envGCSCredentialsFile = "OPENZRO_FLOW_ARCHIVE_GCS_CREDENTIALS_FILE"
 	envGCSCredentialsJSON = "OPENZRO_FLOW_ARCHIVE_GCS_CREDENTIALS_JSON"
 	envGCSProjectID       = "OPENZRO_FLOW_ARCHIVE_GCS_PROJECT_ID"
-	envGCSEndpoint        = "OPENZRO_FLOW_ARCHIVE_GCS_ENDPOINT"
+	// DuckDB reads GCS through httpfs, whose GCS secret takes an HMAC
+	// key pair and nothing else — service account JSON is rejected with
+	// "Unknown parameter 'credential_chain' for secret type 'gcs'". The
+	// sink keeps using the JSON to *write*; only the read path needs
+	// these. Create them in the console under Cloud Storage →
+	// Interoperability.
+	envGCSHMACKeyID  = "OPENZRO_FLOW_ARCHIVE_GCS_HMAC_KEY_ID"
+	envGCSHMACSecret = "OPENZRO_FLOW_ARCHIVE_GCS_HMAC_SECRET"
+	envGCSEndpoint   = "OPENZRO_FLOW_ARCHIVE_GCS_ENDPOINT"
 
 	envFormat       = "OPENZRO_FLOW_ARCHIVE_FORMAT"
 	envQueryTimeout = "OPENZRO_FLOW_ARCHIVE_QUERY_TIMEOUT"
@@ -90,11 +99,21 @@ func NewFromEnv() (store.Store, error) {
 // write format is already known to be Parquet. It applies the same
 // runtime bounds as NewFromEnv so env-configured and dashboard-
 // configured archives share timeout, memory and concurrency behavior.
+// GCS dashboard rows still write through service-account credentials;
+// the DuckDB reader takes its HMAC interoperability pair from env.
 func NewParquet(cfg Config) (store.Store, error) {
 	cfg.QueryTimeout = parseTimeout(os.Getenv(envQueryTimeout))
 	cfg.MemoryLimit = os.Getenv(envMemoryLimit)
 	cfg.Threads = parseInt(os.Getenv(envThreads))
 	cfg.MaxConcurrentQueries = parseInt(os.Getenv(envMaxConcurrentQueries))
+	if cfg.Provider == "gcs" {
+		if cfg.AccessKeyID == "" {
+			cfg.AccessKeyID = os.Getenv(envGCSHMACKeyID)
+		}
+		if cfg.SecretAccessKey == "" {
+			cfg.SecretAccessKey = os.Getenv(envGCSHMACSecret)
+		}
+	}
 	return New(cfg)
 }
 
@@ -126,6 +145,8 @@ func configFromEnv() (Config, bool) {
 			Endpoint:        os.Getenv(envGCSEndpoint),
 			ProjectID:       os.Getenv(envGCSProjectID),
 			CredentialsFile: os.Getenv(envGCSCredentialsFile),
+			AccessKeyID:     os.Getenv(envGCSHMACKeyID),
+			SecretAccessKey: os.Getenv(envGCSHMACSecret),
 		}
 		if v := os.Getenv(envGCSCredentialsJSON); v != "" {
 			cfg.CredentialsJSON = []byte(v)

--- a/flow/store/archive/factory_stub_test.go
+++ b/flow/store/archive/factory_stub_test.go
@@ -58,6 +58,8 @@ func clearArchiveEnv(t *testing.T) {
 		envGCSCredentialsFile,
 		envGCSCredentialsJSON,
 		envGCSProjectID,
+		envGCSHMACKeyID,
+		envGCSHMACSecret,
 		envGCSEndpoint,
 		envFormat,
 		envQueryTimeout,

--- a/flow/store/archive/gcs_auth_test.go
+++ b/flow/store/archive/gcs_auth_test.go
@@ -1,0 +1,76 @@
+//go:build archive_duckdb
+
+package archive
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The GCS read path shipped asking DuckDB to `INSTALL gcs`, an extension
+// that does not exist. Every dashboard query for archived flow events
+// failed with:
+//
+//	install gcs: HTTP Error: Failed to download extension "gcs" at
+//	http://extensions.duckdb.org/v1.1.3/linux_amd64/gcs.duckdb_extension.gz (404)
+//
+// GCS is served by httpfs, and its secret takes an HMAC key pair —
+// service account JSON is rejected by the binder. Both halves are pinned
+// here against a real DuckDB, because both were assumptions in the code
+// that no test contradicted.
+func TestGCSSecretAcceptsOnlyHMAC(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.ExecContext(ctx, "INSTALL httpfs")
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, "LOAD httpfs")
+	require.NoError(t, err, "httpfs is what serves gcs:// — if this fails the read path has no transport")
+
+	t.Run("there is no gcs extension to install", func(t *testing.T) {
+		_, err := db.ExecContext(ctx, "INSTALL gcs")
+		require.Error(t, err, "if DuckDB ever ships a gcs extension, revisit applyAuthGCS")
+		require.ErrorContains(t, err, "gcs")
+	})
+
+	t.Run("httpfs alone accepts an HMAC gcs secret", func(t *testing.T) {
+		_, err := db.ExecContext(ctx,
+			`CREATE OR REPLACE SECRET probe_hmac (TYPE GCS, KEY_ID 'k', SECRET 's')`)
+		require.NoError(t, err)
+	})
+
+	t.Run("service account json is rejected", func(t *testing.T) {
+		_, err := db.ExecContext(ctx,
+			`CREATE OR REPLACE SECRET probe_json (TYPE GCS, CREDENTIAL_CHAIN '{"type":"service_account"}')`)
+		require.Error(t, err, "the old code built this statement on every query")
+		require.ErrorContains(t, err, "credential_chain")
+	})
+}
+
+// An operator who configured the bucket but not the interoperability
+// keys should be told which variables to set before a dashboard query
+// gets as far as building a broken DuckDB secret.
+func TestGCSAuthRefusesWithoutHMACCredentials(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := &duckdbStore{cfg: Config{
+		Provider:        "gcs",
+		Bucket:          "example-bucket",
+		CredentialsJSON: []byte(`{"type":"service_account"}`),
+	}}
+
+	err = store.applyAuthGCS(ctx, db)
+	require.Error(t, err, "service account JSON cannot authenticate a read; saying so is the whole point")
+	require.True(t, errors.Is(err, ErrMissingCredentials), "management downgrades this typed error to hot-only")
+	require.ErrorContains(t, err, "OPENZRO_FLOW_ARCHIVE_GCS_HMAC_KEY_ID")
+	require.ErrorContains(t, err, "OPENZRO_FLOW_ARCHIVE_GCS_HMAC_SECRET")
+}

--- a/management/cmd/management.go
+++ b/management/cmd/management.go
@@ -531,7 +531,12 @@ var (
 						"flow archive: %s configured but binary built without archive_duckdb — "+
 							"rebuild with `-tags=archive_duckdb` to enable federated reads",
 						archiveSource)
-				case archErr != nil:
+				case errors.Is(archErr, flowArchive.ErrMissingCredentials):
+					log.WithContext(ctx).Warnf(
+						"flow archive: %s configured but archive credentials are incomplete: %v; "+
+							"continuing with hot-store flow events only",
+						archiveSource, archErr)
+				case flowArchiveConfigErrorIsFatal(archErr):
 					return fmt.Errorf("flow archive store: %w", archErr)
 				}
 				if archiveStore != nil {
@@ -1059,6 +1064,12 @@ func flowArchiveFromConfig(
 	}
 	archiveStore, err = flowArchive.NewParquet(cfg)
 	return archiveStore, source, err
+}
+
+func flowArchiveConfigErrorIsFatal(err error) bool {
+	return err != nil &&
+		!errors.Is(err, flowArchive.ErrUnavailable) &&
+		!errors.Is(err, flowArchive.ErrMissingCredentials)
 }
 
 func cpFile(src, dst string) error {

--- a/management/cmd/management_test.go
+++ b/management/cmd/management_test.go
@@ -2,8 +2,12 @@ package cmd
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"testing"
+
+	flowArchive "github.com/openzro/openzro/flow/store/archive"
 )
 
 const (
@@ -39,6 +43,26 @@ func Test_loadMgmtConfig(t *testing.T) {
 	}
 	if len(cfg.Relay.Addresses) == 0 {
 		t.Fatalf("relay address is empty")
+	}
+}
+
+func TestFlowArchiveConfigErrorIsFatal(t *testing.T) {
+	if flowArchiveConfigErrorIsFatal(nil) {
+		t.Fatal("nil archive config error should not be fatal")
+	}
+	for _, err := range []error{
+		flowArchive.ErrUnavailable,
+		fmt.Errorf("wrapped: %w", flowArchive.ErrUnavailable),
+		flowArchive.ErrMissingCredentials,
+		fmt.Errorf("wrapped: %w", flowArchive.ErrMissingCredentials),
+	} {
+		if flowArchiveConfigErrorIsFatal(err) {
+			t.Fatalf("optional archive error should not be fatal: %v", err)
+		}
+	}
+
+	if !flowArchiveConfigErrorIsFatal(errors.New("bad archive config")) {
+		t.Fatal("unexpected archive config error should remain fatal")
 	}
 }
 


### PR DESCRIPTION
## Summary

- remove the nonexistent DuckDB `gcs` extension path; GCS archive reads use `httpfs`
- configure DuckDB `TYPE GCS` secrets with HMAC interoperability keys: `OPENZRO_FLOW_ARCHIVE_GCS_HMAC_KEY_ID` and `OPENZRO_FLOW_ARCHIVE_GCS_HMAC_SECRET`
- disable the optional archive reader when a GCS Parquet reader is configured without those keys, with a startup warning naming the variables, instead of failing every dashboard query
- document the upgrade impact in `docs/operator/upgrade-notes.md` and ADR-0012

## Operator impact

Existing GCS service account JSON/file settings can continue writing flow archives. DuckDB cannot read GCS with those credentials, so management deployments that need dashboard reads for GCS Parquet archives must add the two HMAC env vars. Dashboard-created GCS exports still keep write-side credentials in the database; the read-side HMAC keys remain process env and are not persisted as a new secret surface.

If the variables are missing, management keeps serving hot-store flow events and logs a warning that names the variables. Archived GCS history becomes readable after the variables are set and management is restarted. This preserves availability for the existing deployment while making the missing reader credential visible.

## Verification

- `go test ./management/cmd ./flow/store/archive -count=1`
- `go test -tags=archive_duckdb ./management/cmd ./flow/store/archive -count=1`
- `go test ./flow/... ./management/... -count=1`
- `go test -tags=archive_duckdb ./flow/... ./management/... -count=1`
- `go test -tags=archive_duckdb ./flow/store/archive -count=1`
- `git diff --check`