### PR TITLE
fix(flow): interpolate the parquet glob instead of binding it

### DIFF
--- a/flow/store/archive/duckdb.go
+++ b/flow/store/archive/duckdb.go
@@ -311,8 +311,19 @@ func buildQuery(url string, f store.Filter) (string, []any) {
 	)
 	sb.WriteString("SELECT ")
 	sb.WriteString(strings.Join(selectColumns, ", "))
-	sb.WriteString(" FROM read_parquet(?, hive_partitioning=true) WHERE 1=1")
-	args = append(args, url)
+	// The glob is interpolated, not bound, and that is forced rather than
+	// chosen. DuckDB resolves the file list while binding the statement,
+	// so a parameter in that position leaves the binder with nothing to
+	// expand — and it fails the whole prepare with "could not bind
+	// parameter" as soon as any *other* parameter is present. A query
+	// with only the path bound happens to work, which is why this
+	// survived until a dashboard request arrived carrying a time window.
+	//
+	// url is built from the operator's bucket and prefix, never from
+	// request input, and quoteString doubles any single quote.
+	sb.WriteString(" FROM read_parquet(")
+	sb.WriteString(quoteString(url))
+	sb.WriteString(", hive_partitioning=true) WHERE 1=1")
 
 	if f.PeerID != "" {
 		sb.WriteString(" AND peer_id = ?")

--- a/flow/store/archive/duckdb_test.go
+++ b/flow/store/archive/duckdb_test.go
@@ -63,14 +63,17 @@ func TestNewParquet_GCSUsesHMACEnv(t *testing.T) {
 // just `WHERE 1=1 ORDER BY ... LIMIT MaxRowsPerQuery`. Verifies the
 // glob URL and the safety-net LIMIT both land in the SQL.
 func TestBuildQuery_AccountIDOnly(t *testing.T) {
-	q, args := buildQuery("s3://b/year=*/month=*/day=*/account=acct-1/*.parquet", store.Filter{})
-	assert.Contains(t, q, "FROM read_parquet(?, hive_partitioning=true)")
+	glob := "s3://b/year=*/month=*/day=*/account=acct-1/*.parquet"
+	q, args := buildQuery(glob, store.Filter{})
+	// Interpolated, not bound: DuckDB expands the file list while binding,
+	// so a parameter here breaks the prepare as soon as a second parameter
+	// exists. See TestBuildQueryPreparesWithFilters, which runs it.
+	assert.Contains(t, q, "FROM read_parquet('"+glob+"', hive_partitioning=true)")
 	assert.Contains(t, q, "WHERE 1=1")
 	assert.Contains(t, q, "ORDER BY received_at DESC")
 	assert.Contains(t, q, "LIMIT ?")
-	require.Len(t, args, 2)
-	assert.Equal(t, "s3://b/year=*/month=*/day=*/account=acct-1/*.parquet", args[0])
-	assert.Equal(t, MaxRowsPerQuery, args[1].(int))
+	require.Len(t, args, 1)
+	assert.Equal(t, MaxRowsPerQuery, args[0].(int))
 }
 
 // TestBuildQuery_AllFilters exercises every Filter field. Catches
@@ -113,7 +116,9 @@ func TestBuildQuery_AllFilters(t *testing.T) {
 		assert.Contains(t, q, want)
 	}
 	// 12 args: url + 9 filters + limit + offset
-	assert.Len(t, args, 12)
+	// Eleven, not twelve: the parquet glob is interpolated into the SQL
+	// rather than bound, so it is no longer an argument.
+	assert.Len(t, args, 11)
 }
 
 // TestBuildQuery_LimitClamping ensures a caller asking for "give me
@@ -134,8 +139,9 @@ func TestBuildQuery_LimitClamping(t *testing.T) {
 // column and silently match nothing.
 func TestBuildQuery_RuleIDIsHexEncoded(t *testing.T) {
 	_, args := buildQuery("u", store.Filter{RuleID: []byte{0xab, 0xcd}})
-	// args = [url, rule_id, limit] — find rule_id at index 1
-	assert.Equal(t, "abcd", args[1].(string))
+	// args = [rule_id, limit] — the glob is interpolated, not bound, so it
+	// no longer occupies index 0.
+	assert.Equal(t, "abcd", args[0].(string))
 }
 
 // TestParquetURL_HivePartition checks the URL template lines up with

--- a/flow/store/archive/query_bind_test.go
+++ b/flow/store/archive/query_bind_test.go
@@ -1,0 +1,82 @@
+//go:build archive_duckdb
+
+package archive
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openzro/openzro/flow/store"
+)
+
+// buildQuery interpolates the parquet glob rather than binding it, and that
+// is not a style choice. DuckDB resolves the file list while binding the
+// statement, so a parameter in that position leaves the binder nothing to
+// expand.
+//
+// The failure is conditional, which is why it reached production: a query
+// whose only parameter is the path prepares fine. Add any other parameter —
+// a time window, which every dashboard request carries — and the whole
+// prepare fails with "could not bind parameter". No test had ever run a real
+// query with both, so the archive read path shipped broken twice: first the
+// non-existent gcs extension, then this.
+func TestBuildQueryPreparesWithFilters(t *testing.T) {
+	ctx := context.Background()
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	// Every column the reader selects, so the failure under test is the
+	// bind and not a missing column.
+	path := filepath.Join(t.TempDir(), "events.parquet")
+	_, err = db.ExecContext(ctx, "COPY (SELECT "+
+		"TIMESTAMP '2026-05-12 10:00:00' AS received_at, "+
+		"TIMESTAMP '2026-05-12 10:00:00' AS occurred_at, "+
+		"'acct-1' AS account_id, 'peer-a' AS peer_id, "+
+		"'ev-1' AS event_id, 'fl-1' AS flow_id, "+
+		"1::UTINYINT AS type, 1::UTINYINT AS direction, "+
+		"6::USMALLINT AS protocol, "+
+		"'10.0.0.1' AS source_ip, '10.0.0.2' AS dest_ip, "+
+		"1024::UINTEGER AS source_port, 443::UINTEGER AS dest_port, "+
+		"0::UTINYINT AS icmp_type, 0::UTINYINT AS icmp_code, "+
+		"true AS is_initiator, "+
+		"1::UBIGINT AS rx_packets, 2::UBIGINT AS tx_packets, "+
+		"10::UBIGINT AS rx_bytes, 20::UBIGINT AS tx_bytes, "+
+		"'' AS rule_id, '' AS source_resource_id, '' AS dest_resource_id"+
+		") TO '"+path+"' (FORMAT PARQUET)")
+	require.NoError(t, err)
+
+	since := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	until := time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
+	port := uint32(443)
+	proto := uint16(6)
+
+	// The shape a dashboard request produces: a window plus predicates.
+	q, args := buildQuery(path, store.Filter{
+		PeerID:   "peer-a",
+		DestPort: &port,
+		Protocol: &proto,
+		Since:    since,
+		Until:    until,
+	})
+
+	rows, err := db.QueryContext(ctx, q, args...)
+	require.NoError(t, err, "the query must prepare; binding the glob fails here as soon as a second parameter exists")
+	t.Cleanup(func() { _ = rows.Close() })
+	require.True(t, rows.Next(), "the seeded row is inside the window and matches every predicate")
+	require.NoError(t, rows.Err())
+}
+
+// A path holding a single quote must not break the statement, since the glob
+// is now interpolated. Bucket and prefix come from operator configuration
+// rather than request input, so this is defence in depth, not a live hole.
+func TestBuildQueryQuotesTheGlob(t *testing.T) {
+	q, args := buildQuery("gcs://bucket/it's/**/*.parquet", store.Filter{})
+	require.Contains(t, q, "it''s", "a single quote has to be doubled for DuckDB")
+	require.NotContains(t, args, "gcs://bucket/it's/**/*.parquet", "the glob must not be an argument")
+}


### PR DESCRIPTION
Every dashboard query for archived flow events fails in production on alpha.91:

```
flow archive store: query: could not bind parameter
```

DuckDB expands the file list while *binding* the statement, so a parameter in the `read_parquet()` path leaves the binder with nothing to resolve. The glob is now written into the SQL, quoted.

## Why it survived three releases

**The failure is conditional.** A query whose only parameter is the path prepares fine; add any second parameter and the whole prepare fails. Every dashboard request carries a time window, so in practice it never worked — but a probe that binds only the path reports success, which is how I first misread it and discarded the correct hypothesis.

**The existing tests asserted the broken form.** Three tests already covered `buildQuery`, and one of them pinned this as the expected output:

```go
assert.Contains(t, q, "FROM read_parquet(?, hive_partitioning=true)")
```

They checked the SQL as a string and never executed it, so they locked in a query that cannot run. That is the part worth fixing beyond the one-line change.

## What changed

- The glob is interpolated through `quoteString`. It comes from the operator's bucket and prefix, never from request input.
- The three existing tests now assert the working form, with the reason inline.
- `TestBuildQueryPreparesWithFilters` prepares **and runs** the statement against a real DuckDB, seeded with every column the reader selects and the parameter mix a dashboard request produces.

Verified by mutation: restoring the bound glob fails the new test with the production error text.

## Third defect in the same path

A non-existent `gcs` extension (#182), a credential model DuckDB rejects (#182), and now the bind. All three shipped because nothing exercised an end-to-end query — the tests covered construction, configuration and SQL text, and stopped short of execution. The new test closes that gap.

## Impact today

Non-degrading. The federated store runs hot and archive in parallel and only propagates an error when both fail, so the dashboard keeps serving hot-store events. Archived history stays invisible, as it has been since the feature shipped.

Verification: `go test ./flow/... ./management/...` green with and without `-tags=archive_duckdb`.

Refs #178, #182.