### PR TITLE
fix(dashboard): hold the flow events request until the range is decided

### DIFF
--- a/dashboard/src/modules/network-traffic/v2/NetworkTrafficV2.tsx
+++ b/dashboard/src/modules/network-traffic/v2/NetworkTrafficV2.tsx
@@ -248,7 +248,7 @@ export default function NetworkTrafficV2() {
   // unbounded query — that is the setting working, not the bug.
   const {
     data,
-    isLoading,
+    isLoading: eventsLoading,
     mutate: mutateFlows,
   } = useFetchApi<NetworkTrafficEventsResponse>(
     queryUrl,
@@ -256,6 +256,14 @@ export default function NetworkTrafficV2() {
     true,
     defaultApplied,
   );
+
+  // Holding the request makes SWR's key null, and a null key reports
+  // isLoading: false — the page is not loading, it simply has not asked
+  // yet. Every consumer below reads that flag as "there is nothing to
+  // show", so without folding the hold into it the mount renders the
+  // cold-start panel over an empty groups array and then replaces it
+  // with the table a moment later.
+  const isLoading = eventsLoading || !defaultApplied;
 
   const groups = useMemo(
     () =>
@@ -336,9 +344,9 @@ export default function NetworkTrafficV2() {
           Flow Traffic
         </h1>
         <p className="mt-1 max-w-2xl text-[14px] text-oz2-text-muted">
-          Per-flow records reported by your peers — connection starts, ends,
-          and drops. Useful for forensics, capacity planning, and validating
-          that your access policies match traffic in the wild.
+          Per-flow records reported by your peers — connection starts, ends, and
+          drops. Useful for forensics, capacity planning, and validating that
+          your access policies match traffic in the wild.
         </p>
       </header>
 
@@ -670,7 +678,9 @@ function EventCell({ row }: { row: Row }) {
       <div className="relative flex w-6 shrink-0 flex-col items-center justify-center">
         <span
           aria-label={meta.label}
-          className={`relative z-10 grid h-6 w-6 shrink-0 place-items-center rounded-full border-2 bg-oz2-surface ${dotToneClasses[meta.tone]}`}
+          className={`relative z-10 grid h-6 w-6 shrink-0 place-items-center rounded-full border-2 bg-oz2-surface ${
+            dotToneClasses[meta.tone]
+          }`}
         >
           {meta.icon}
         </span>
@@ -736,11 +746,7 @@ function PeerCell({
   // the hostname is one of many sharing the IP. IP subtitle stays
   // unconditional so the operator always has the raw datapoint to
   // cross-check against the ingress access log.
-  const label = peer
-    ? peer.name
-    : isAmbiguous
-      ? ip
-      : (fallback ?? ip);
+  const label = peer ? peer.name : isAmbiguous ? ip : fallback ?? ip;
   const sub = label !== ip ? ip : null;
 
   return (
@@ -772,8 +778,8 @@ function PeerCell({
                   </ul>
                   <p className="mt-2 text-[10.5px] leading-[1.45] text-oz2-text-faint">
                     The agent can&apos;t distinguish between them at the
-                    dataplane layer — HTTP Host header decides at L7. Check
-                    the ingress access log to see what was actually requested.
+                    dataplane layer — HTTP Host header decides at L7. Check the
+                    ingress access log to see what was actually requested.
                   </p>
                 </div>
               }
@@ -782,7 +788,9 @@ function PeerCell({
             >
               <span
                 className="inline-flex cursor-help items-center gap-1 rounded-md border border-oz2-warn/40 bg-oz2-warn/10 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-oz2-warn"
-                aria-label={`Shared IP with ${ambiguousResources!.length} hosts`}
+                aria-label={`Shared IP with ${
+                  ambiguousResources!.length
+                } hosts`}
               >
                 <AlertTriangleIcon size={9} />
                 {ambiguousResources!.length}
@@ -841,10 +849,7 @@ function TrafficCell({ flow }: { flow: FlowGroup }) {
           className="flex h-1 w-[120px] overflow-hidden rounded-full bg-oz2-border-soft"
         >
           <span className="bg-oz2-acc" style={{ width: `${rxPct}%` }} />
-          <span
-            className="bg-oz2-acc-soft-2"
-            style={{ width: `${txPct}%` }}
-          />
+          <span className="bg-oz2-acc-soft-2" style={{ width: `${txPct}%` }} />
         </div>
       )}
       <span className="font-mono text-[10.5px] text-oz2-text-faint">

--- a/dashboard/src/modules/network-traffic/v2/NetworkTrafficV2.tsx
+++ b/dashboard/src/modules/network-traffic/v2/NetworkTrafficV2.tsx
@@ -176,7 +176,8 @@ export default function NetworkTrafficV2() {
   // hence the [0]. Initial render before the fetch resolves uses no
   // filter; once the value lands, defaultRangeFromSetting may flip
   // `range` to a windowed shape.
-  const { data: accounts } = useFetchApi<Account[]>("/accounts");
+  const { data: accounts, isLoading: accountsLoading } =
+    useFetchApi<Account[]>("/accounts");
 
   const [search, setSearch] = useState("");
   const [range, setRange] = useState<DateRange | undefined>();
@@ -198,14 +199,26 @@ export default function NetworkTrafficV2() {
   const [userPickedRange, setUserPickedRange] = useState(false);
 
   // Apply the operator's default range exactly once per page mount.
+  //
+  // defaultApplied flips as soon as /accounts settles, whether or not a
+  // preference came back, because it also gates the events request
+  // below. Returning early without flipping it — the previous shape —
+  // left "no preference" indistinguishable from "still loading", and
+  // the page fired an unbounded query on mount that it then repeated
+  // with the real window.
+  //
+  // That first query is not merely wasted. An absent `since` makes the
+  // federated store read the whole cold archive, which is a full scan,
+  // so opening the page cost two archive-wide reads and returned 504.
   useEffect(() => {
     if (defaultApplied) return;
+    if (accountsLoading) return;
+    setDefaultApplied(true);
     const pref = accounts?.[0]?.settings?.extra?.network_traffic_default_range;
     if (!pref) return;
-    setDefaultApplied(true);
     const windowed = defaultRangeFromSetting(pref);
     if (windowed) setRange(windowed);
-  }, [accounts, defaultApplied]);
+  }, [accounts, accountsLoading, defaultApplied]);
 
   useEffect(() => {
     setPageSize(PAGE_SIZE);
@@ -229,11 +242,20 @@ export default function NetworkTrafficV2() {
     return `/network-traffic-events?${qs}`;
   }, [range]);
 
+  // Held until the default range has been decided, so the page issues
+  // one request with the operator's window rather than an unbounded one
+  // followed by the real one. An operator who chose "all" still gets an
+  // unbounded query — that is the setting working, not the bug.
   const {
     data,
     isLoading,
     mutate: mutateFlows,
-  } = useFetchApi<NetworkTrafficEventsResponse>(queryUrl);
+  } = useFetchApi<NetworkTrafficEventsResponse>(
+    queryUrl,
+    false,
+    true,
+    defaultApplied,
+  );
 
   const groups = useMemo(
     () =>


### PR DESCRIPTION
Opening Flow Traffic fired **two** requests, and the first had no date range. Confirmed in DevTools:

```
GET /api/network-traffic-events?limit=10000            504 Gateway Timeout
GET /api/network-traffic-events?since=...&until=...    200
```

The component mounts with `range` undefined and fetches immediately. Only afterwards does the effect read `network_traffic_default_range` and set the window, firing the real request.

## Why the speculative request is expensive

Easy to miss from the dashboard side: an absent `since` makes the federated store treat the **whole cold archive** as in range, and the archive query has no partition pruning, so it opens every Parquet file for the account. Opening the page cost two archive-wide scans, ran past the ingress timeout, and returned 504 both times.

## The fix

The fetch waits on `defaultApplied`, which now flips as soon as `/accounts` settles rather than only when a preference exists. The old shape returned early without flipping it, so "no preference" was indistinguishable from "still loading" and the flag could not be used as a gate.

**An unbounded query stays possible and stays correct.** It is what the `"all"` setting means, and `defaultRangeFromSetting` returns undefined for it deliberately. What changes is that the page no longer guesses at it before knowing which the operator chose.

## No automated guard

The dashboard has Cypress and no unit test runner, and the E2E harness is still open work (#52), so nothing here would catch a regression. Saying so rather than implying coverage that does not exist.

Verified by hand: `npx tsc --noEmit` clean, `npm run build` green.

## Not the whole story

This removes the unbounded query the UI issues by accident. It does **not** make archived queries viable — a correctly ranged June filter still scans four months, because the query filters on `received_at` instead of the `year`/`month`/`day` partitions. That is the next fix, and neither covers the other: a query with no date bounds cannot be pruned at all.

Refs #178.