### PR TITLE
fix(flow): make an archived object's path describe its contents, then prune on it

### DIFF
--- a/docs/operator/upgrade-notes.md
+++ b/docs/operator/upgrade-notes.md
@@ -37,6 +37,10 @@ another reason to take the backup below before starting.
 No pre-upgrade action is required for the route validation and group
 serialization changes.
 
+If you archive flow events to S3 or GCS in Parquet, see **Flow archive**
+below before upgrading. Nothing breaks if you skip this, but the check is
+easier to interpret before the reader's behaviour changes.
+
 ### After upgrading
 
 - **MySQL management transactions now run at READ COMMITTED.** This
@@ -99,6 +103,83 @@ serialization changes.
   queried by the UI.
   Archives written with the default NDJSON format remain available in
   the bucket for external tools, but the dashboard does not query them.
+
+### Flow archive (S3 / GCS, Parquet)
+
+Three changes ship together. The first two are improvements with no
+action required; the third describes a gap you may need to decide about.
+
+**Archive queries now skip files instead of reading every one.** The
+reader filtered only on `received_at`, a column inside the Parquet files,
+so any question opened every object for the account. Wide windows could
+exceed the ingress timeout and return 504. Queries now also constrain the
+`year`/`month`/`day` partition columns. No action required.
+
+**`type` and `direction` filters now apply to archived events.** They
+were accepted by the API and applied by the hot store, but ignored by the
+archive reader — so a filtered query returned correctly filtered results
+inside the retention window and unfiltered ones outside it. Expect a
+filtered query spanning the archive to return **fewer** rows than before
+the upgrade. That is the filter starting to work, not data loss.
+
+**Objects are now written one per account and UTC date.** Both sinks
+buffer into a queue shared by every account and flush on a timer, and
+they used to name the whole object after the first event in the batch. A
+batch that mixed accounts was filed entirely under one of them, and a
+batch crossing midnight was filed under the earlier day.
+
+Objects written before this release can therefore disagree with their own
+path. The reader now compares `account_id` as well, so those rows are no
+longer served to the wrong account. It cannot recover them for the right
+one: the path is what selects which objects are opened, and a misfiled
+object is still under the wrong prefix.
+
+| | before upgrade | after upgrade |
+| --- | --- | --- |
+| wrong account sees the rows | yes | no |
+| right account sees the rows | no | no |
+
+**To find out whether you are affected**, run these against your archive
+with the DuckDB CLI. Substitute your bucket, prefix and scheme (`s3://`
+or `gs://`), and configure credentials as your DuckDB install expects.
+
+```sql
+-- Events filed under the wrong account.
+SELECT account AS path_account, account_id AS row_account, count(*)
+FROM read_parquet('s3://BUCKET/PREFIX/year=*/month=*/day=*/account=*/*.parquet',
+                  hive_partitioning=true)
+WHERE account_id <> account
+GROUP BY 1, 2
+ORDER BY 3 DESC;
+```
+
+```sql
+-- Events filed under the wrong day.
+SELECT count(*)
+FROM read_parquet('s3://BUCKET/PREFIX/year=*/month=*/day=*/account=*/*.parquet',
+                  hive_partitioning=true)
+WHERE date_trunc('day', received_at)
+      <> make_date(year::INT, month::INT, day::INT);
+```
+
+Both read the whole archive, so run them off-hours on a large bucket.
+
+**If either returns rows**, decide by what the cold archive is for:
+
+- **Dashboard history only.** No action. The exposure is closed, queries
+  are faster, and the affected events are older than your hot retention.
+- **Audit or compliance.** The gap matters: those events are unreachable
+  from the account that owns them. Repartitioning — rewriting the
+  affected objects grouped by account and date — is the only fix, and it
+  is not automated. Open an issue if you need it.
+
+**If you raised the sink's flush interval** above the 15m default via
+`OPENZRO_FLOW_ARCHIVE_{S3,GCS}_FLUSH_INTERVAL` or in the dashboard, keep
+it set. The reader now reads that value to size how far its partition
+filter reaches back, because a long flush is exactly what produced
+objects whose contents predate their own name. Lowering or unsetting it
+after the fact can hide older events written under the previous setting.
+
 
 ## v0.53.1-alpha.89
 

--- a/flow/sinks/gcs.go
+++ b/flow/sinks/gcs.go
@@ -293,6 +293,8 @@ func (g *GCS) encodeForFormat(batch []*store.Event) (body []byte, contentType, c
 
 // objectKey mirrors the S3 sink's path layout so an operator can run
 // both archives in parallel and have a stable schema in either tool.
+// Like its counterpart, it takes any event from a group prepared by
+// partitionBatch, not a raw flush batch.
 func (g *GCS) objectKey(first *store.Event) string {
 	t := first.ReceivedAt.UTC()
 	prefix := g.cfg.Prefix

--- a/flow/sinks/gcs.go
+++ b/flow/sinks/gcs.go
@@ -244,6 +244,17 @@ func (g *GCS) loop() {
 // the S3 sink: durability comes from the streaming pipeline
 // (Datadog / Elastic), not from a single archive.
 func (g *GCS) upload(ctx context.Context, batch []*store.Event) {
+	// One object per (account, UTC date): the path names both, so a
+	// batch that mixes them cannot go out as a single file. See
+	// partitionBatch.
+	for _, group := range partitionBatch(batch) {
+		g.uploadGroup(ctx, group)
+	}
+}
+
+// uploadGroup writes one group, whose events all agree on the account
+// and date the object key asserts.
+func (g *GCS) uploadGroup(ctx context.Context, batch []*store.Event) {
 	body, contentType, contentEncoding, err := g.encodeForFormat(batch)
 	if err != nil {
 		log.Errorf("flow sink GCS: encode batch (%d events): %v", len(batch), err)

--- a/flow/sinks/partition.go
+++ b/flow/sinks/partition.go
@@ -1,0 +1,83 @@
+package sinks
+
+import (
+	"sort"
+
+	"github.com/openzro/openzro/flow/store"
+)
+
+// partitionKey is everything an object's path asserts about the events
+// inside it: the account and the UTC date. Both sinks lay objects out as
+// year=/month=/day=/account=, so two events that disagree on either
+// cannot honestly share a file.
+type partitionKey struct {
+	accountID string
+	year      int
+	month     int
+	day       int
+}
+
+func keyFor(ev *store.Event) partitionKey {
+	t := ev.ReceivedAt.UTC()
+	return partitionKey{
+		accountID: ev.AccountID,
+		year:      t.Year(),
+		month:     int(t.Month()),
+		day:       t.Day(),
+	}
+}
+
+// partitionBatch splits a flush batch into groups that each belong under
+// exactly one path.
+//
+// The sinks buffer into a single queue shared by every account and drain
+// it on a timer, so a batch routinely mixes accounts and can straddle
+// midnight. Both sinks then derived the whole object's path from
+// batch[0] alone, which made the path a claim about one event and a
+// guess about the rest:
+//
+//   - Events for other accounts were filed under batch[0]'s account.
+//     The archive query carries no account_id predicate — isolation
+//     rests entirely on the path — so those events both leaked into the
+//     wrong account's results and vanished from their own.
+//   - Events on the other side of midnight were filed under batch[0]'s
+//     day. Reading by date could not find them without scanning
+//     everything, which is what partition pruning stops doing.
+//   - Neither followed from ordering, because nothing orders the queue.
+//     batch[0] is the first event dequeued, not the earliest.
+//
+// Grouping makes the path describe the file's contents, which is what a
+// partition column means. The groups are returned in a stable order so
+// the uploads, and the tests over them, are deterministic.
+func partitionBatch(batch []*store.Event) [][]*store.Event {
+	if len(batch) == 0 {
+		return nil
+	}
+	byKey := make(map[partitionKey][]*store.Event)
+	order := make([]partitionKey, 0, 4)
+	for _, ev := range batch {
+		k := keyFor(ev)
+		if _, seen := byKey[k]; !seen {
+			order = append(order, k)
+		}
+		byKey[k] = append(byKey[k], ev)
+	}
+	sort.Slice(order, func(i, j int) bool {
+		a, b := order[i], order[j]
+		if a.accountID != b.accountID {
+			return a.accountID < b.accountID
+		}
+		if a.year != b.year {
+			return a.year < b.year
+		}
+		if a.month != b.month {
+			return a.month < b.month
+		}
+		return a.day < b.day
+	})
+	groups := make([][]*store.Event, 0, len(order))
+	for _, k := range order {
+		groups = append(groups, byKey[k])
+	}
+	return groups
+}

--- a/flow/sinks/partition.go
+++ b/flow/sinks/partition.go
@@ -36,10 +36,15 @@ func keyFor(ev *store.Event) partitionKey {
 // batch[0] alone, which made the path a claim about one event and a
 // guess about the rest:
 //
-//   - Events for other accounts were filed under batch[0]'s account.
-//     The archive query carries no account_id predicate — isolation
-//     rests entirely on the path — so those events both leaked into the
-//     wrong account's results and vanished from their own.
+//   - Events for other accounts were filed under batch[0]'s account,
+//     where the reader served them to that account: the archive query
+//     restricted by the path alone. It now also compares account_id, so
+//     the leak is closed for objects already written. Being unreadable
+//     by the wrong account does not make them readable by the right one,
+//     though — the path is what selects which objects are opened at all,
+//     and a misfiled object is still under the wrong prefix. Legacy
+//     objects stay invisible to their own account until they are
+//     repartitioned.
 //   - Events on the other side of midnight were filed under batch[0]'s
 //     day. Reading by date could not find them without scanning
 //     everything, which is what partition pruning stops doing.

--- a/flow/sinks/partition_test.go
+++ b/flow/sinks/partition_test.go
@@ -47,9 +47,10 @@ func TestPartitionBatchGroupsAgreeWithTheirObjectKey(t *testing.T) {
 }
 
 // The account half, on its own, because it is not a pruning concern.
-// The archive query carries no account_id predicate: isolation rests
-// entirely on the path. An event filed under the wrong account leaks
-// into that account's results and disappears from its own.
+// The reader now compares account_id as well as the path, so a misfiled
+// event is no longer served to the wrong account — but the path is what
+// decides which objects are opened, so it is still lost to the right
+// one. Only the writer can put it somewhere both halves agree on.
 func TestPartitionBatchNeverMixesAccountsInOneObject(t *testing.T) {
 	batch := []*store.Event{
 		ev("acct-A", time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)),

--- a/flow/sinks/partition_test.go
+++ b/flow/sinks/partition_test.go
@@ -1,0 +1,102 @@
+package sinks
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openzro/openzro/flow/store"
+)
+
+func ev(account string, t time.Time) *store.Event {
+	return &store.Event{AccountID: account, EventID: []byte{1, 2, 3, 4}, ReceivedAt: t}
+}
+
+// The invariant the object layout has always claimed and never held:
+// every event in a file agrees with the account and date in that file's
+// path. Stated over both sinks, because they build the key
+// independently and have to stay in step.
+func TestPartitionBatchGroupsAgreeWithTheirObjectKey(t *testing.T) {
+	s3 := &S3{cfg: S3Config{Bucket: "b"}, format: formatParquet}
+	gcs := &GCS{cfg: GCSConfig{Bucket: "b"}, format: formatParquet}
+
+	batch := []*store.Event{
+		ev("acct-A", time.Date(2026, 6, 10, 23, 59, 0, 0, time.UTC)),
+		ev("acct-B", time.Date(2026, 6, 11, 0, 1, 0, 0, time.UTC)),
+		ev("acct-A", time.Date(2026, 6, 11, 0, 2, 0, 0, time.UTC)),
+		ev("acct-A", time.Date(2026, 6, 10, 22, 0, 0, 0, time.UTC)),
+	}
+
+	groups := partitionBatch(batch)
+	require.Len(t, groups, 3,
+		"two accounts across two days is three partitions, whatever order they arrived in")
+
+	for _, group := range groups {
+		for _, key := range []string{s3.objectKey(group[0]), gcs.objectKey(group[0])} {
+			for _, e := range group {
+				u := e.ReceivedAt.UTC()
+				require.Contains(t, key, "account="+e.AccountID,
+					"an event was filed under another account's partition")
+				require.Contains(t, key,
+					u.Format("year=2006/month=01/day=02"),
+					"an event was filed under another day's partition")
+			}
+		}
+	}
+}
+
+// The account half, on its own, because it is not a pruning concern.
+// The archive query carries no account_id predicate: isolation rests
+// entirely on the path. An event filed under the wrong account leaks
+// into that account's results and disappears from its own.
+func TestPartitionBatchNeverMixesAccountsInOneObject(t *testing.T) {
+	batch := []*store.Event{
+		ev("acct-A", time.Date(2026, 6, 10, 12, 0, 0, 0, time.UTC)),
+		ev("acct-B", time.Date(2026, 6, 10, 12, 0, 1, 0, time.UTC)),
+	}
+	groups := partitionBatch(batch)
+	require.Len(t, groups, 2, "one object may not carry two accounts")
+	for _, group := range groups {
+		for _, e := range group {
+			require.Equal(t, group[0].AccountID, e.AccountID)
+		}
+	}
+}
+
+// Nothing orders the queue, so batch[0] is the first event dequeued and
+// not the earliest. The old key derived the whole path from it, which
+// meant an out-of-order batch filed earlier events under a later day.
+func TestPartitionBatchDoesNotDependOnArrivalOrder(t *testing.T) {
+	early := time.Date(2026, 6, 10, 1, 0, 0, 0, time.UTC)
+	late := time.Date(2026, 6, 12, 1, 0, 0, 0, time.UTC)
+
+	forward := partitionBatch([]*store.Event{ev("acct-A", early), ev("acct-A", late)})
+	backward := partitionBatch([]*store.Event{ev("acct-A", late), ev("acct-A", early)})
+
+	require.Len(t, forward, 2)
+	require.Len(t, backward, 2)
+	for i := range forward {
+		require.Equal(t, keyFor(forward[i][0]), keyFor(backward[i][0]),
+			"the same events must land in the same partitions regardless of dequeue order")
+	}
+}
+
+// A batch that already belongs to one partition must stay one object.
+// Splitting it would multiply small files across the archive for no
+// gain, and small files are what MaxEventsPerFile exists to avoid.
+func TestPartitionBatchKeepsAHomogeneousBatchWhole(t *testing.T) {
+	day := time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC)
+	batch := make([]*store.Event, 0, 50)
+	for i := range 50 {
+		batch = append(batch, ev("acct-A", day.Add(time.Duration(i)*time.Minute)))
+	}
+	groups := partitionBatch(batch)
+	require.Len(t, groups, 1)
+	require.Len(t, groups[0], 50)
+}
+
+func TestPartitionBatchEmpty(t *testing.T) {
+	require.Nil(t, partitionBatch(nil))
+	require.Nil(t, partitionBatch([]*store.Event{}))
+}

--- a/flow/sinks/s3.go
+++ b/flow/sinks/s3.go
@@ -272,12 +272,21 @@ func (s *S3) encodeForFormat(batch []*store.Event) (body []byte, contentType, co
 	}
 }
 
-// objectKey builds the partitioned object path. Dates are taken from
-// the first event's ReceivedAt — within a single batch they are
-// nanoseconds apart, so partitioning by the head is fine and avoids
-// fragmenting batches across day boundaries (which would produce many
-// tiny files). Extension reflects the archive format so DuckDB / S3
-// listing can filter by suffix without sniffing magic bytes.
+// objectKey builds the partitioned object path from any event in the
+// group, which is only safe because partitionBatch has already made
+// every event in that group agree on the account and the UTC date the
+// path names. Call it with a group, never with a raw flush batch.
+//
+// It used to be called with the batch, on the reasoning that events
+// within one batch are nanoseconds apart. They are not: the queue is
+// shared by every account and drained on a timer, so a batch mixes
+// accounts and can straddle midnight, and nothing orders it either. The
+// fear that motivated the shortcut -- fragmenting batches into many tiny
+// files -- is real but narrower than it looked, since a batch that
+// already belongs to one partition still goes out as one object.
+//
+// Extension reflects the archive format so DuckDB / S3 listing can
+// filter by suffix without sniffing magic bytes.
 func (s *S3) objectKey(first *store.Event) string {
 	t := first.ReceivedAt.UTC()
 	prefix := s.cfg.Prefix

--- a/flow/sinks/s3.go
+++ b/flow/sinks/s3.go
@@ -222,6 +222,17 @@ func (s *S3) loop() {
 // best-effort, mirrored by the streaming exporter for durability
 // needs.
 func (s *S3) upload(ctx context.Context, batch []*store.Event) {
+	// One object per (account, UTC date): the path names both, so a
+	// batch that mixes them cannot go out as a single file. See
+	// partitionBatch.
+	for _, group := range partitionBatch(batch) {
+		s.uploadGroup(ctx, group)
+	}
+}
+
+// uploadGroup writes one group, whose events all agree on the account
+// and date the object key asserts.
+func (s *S3) uploadGroup(ctx context.Context, batch []*store.Event) {
 	body, contentType, contentEncoding, err := s.encodeForFormat(batch)
 	if err != nil {
 		log.Errorf("flow sink S3: encode batch (%d events): %v", len(batch), err)

--- a/flow/store/archive/archive.go
+++ b/flow/store/archive/archive.go
@@ -82,6 +82,23 @@ type Config struct {
 	CredentialsFile string
 	ProjectID       string
 
+	// MaxBatchSpan is how far apart the events inside one archived
+	// object can be. It exists only to size the partition-pruning
+	// margin: an object is named after a date, and the pruning
+	// predicate has to reach far enough back to catch an object whose
+	// name predates the events it holds.
+	//
+	// The sinks now write one object per (account, UTC date), so
+	// anything written by this version needs no margin at all. Objects
+	// written earlier took their whole path from the first event
+	// dequeued, and so could span the sink's entire flush interval,
+	// which is operator-configurable with no upper bound. This is
+	// populated from that same interval so the reader's margin matches
+	// what the writer could actually have produced.
+	//
+	// Zero means the default one-day margin.
+	MaxBatchSpan time.Duration
+
 	// QueryTimeout bounds a single archive query — DuckDB will cancel
 	// the underlying httpfs reads when the context fires. Default
 	// 60s; bump it for large-window forensics if 60s is not enough.

--- a/flow/store/archive/detect_test.go
+++ b/flow/store/archive/detect_test.go
@@ -1,0 +1,51 @@
+//go:build archive_duckdb
+
+package archive
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The detection queries published in docs/operator/upgrade-notes.md.
+// They go in a test because an unverified query in operator docs is how
+// this whole read path got into production broken.
+func TestOperatorDetectionQueries(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	root := t.TempDir()
+	// Correctly filed.
+	seedEventParquetAs(t, db, partitionPath(root, "2026", "06", "10", "ok.parquet"),
+		"2026-06-10 12:00:00", testAccount)
+	// Misfiled account: path says acct-1, row says acct-B.
+	seedEventParquetAs(t, db, partitionPath(root, "2026", "06", "10", "bad-acct.parquet"),
+		"2026-06-10 12:00:00", "acct-B")
+	// Misfiled day: path says 06-10, row is 06-12.
+	seedEventParquetAs(t, db, partitionPath(root, "2026", "06", "10", "bad-day.parquet"),
+		"2026-06-12 12:00:00", testAccount)
+
+	glob := filepath.Join(root, "year=*", "month=*", "day=*", "account=*", "*.parquet")
+
+	t.Run("misfiled accounts", func(t *testing.T) {
+		var n int
+		require.NoError(t, db.QueryRowContext(context.Background(),
+			`SELECT count(*) FROM read_parquet('`+glob+`', hive_partitioning=true)
+			 WHERE account_id <> account`).Scan(&n))
+		require.Equal(t, 1, n)
+	})
+
+	t.Run("misfiled days", func(t *testing.T) {
+		var n int
+		require.NoError(t, db.QueryRowContext(context.Background(),
+			`SELECT count(*) FROM read_parquet('`+glob+`', hive_partitioning=true)
+			 WHERE date_trunc('day', received_at)
+			       <> make_date(year::INT, month::INT, day::INT)`).Scan(&n))
+		require.Equal(t, 1, n)
+	})
+}

--- a/flow/store/archive/duckdb.go
+++ b/flow/store/archive/duckdb.go
@@ -395,6 +395,20 @@ func buildQuery(url string, f store.Filter, marginDays int) (string, []any) {
 	sb.WriteString(quoteString(url))
 	sb.WriteString(", hive_partitioning=true) WHERE 1=1")
 
+	// The account is already in the glob, and this predicate does not
+	// prune -- account_id lives inside the files, so every object the
+	// path selects is still opened. It is here because the path is a
+	// claim about a file's contents that the writer, until #186, did not
+	// keep: a batch mixing accounts was filed whole under the first
+	// event's account, and those objects are on disk now. Restricting on
+	// the path alone hands one account another's events.
+	//
+	// Query() rejects an empty AccountID before reaching here, so this
+	// is unconditional on purpose: a filter that somehow arrived without
+	// one must produce no rows, not every row.
+	sb.WriteString(" AND account_id = ?")
+	args = append(args, f.AccountID)
+
 	if f.PeerID != "" {
 		sb.WriteString(" AND peer_id = ?")
 		args = append(args, f.PeerID)

--- a/flow/store/archive/duckdb.go
+++ b/flow/store/archive/duckdb.go
@@ -147,7 +147,7 @@ func (d *duckdbStore) Query(ctx context.Context, f store.Filter) ([]*store.Event
 	}
 
 	url := d.parquetURL(f.AccountID)
-	q, args := buildQuery(url, f)
+	q, args := buildQuery(url, f, d.marginDays())
 	rows, err := conn.QueryContext(ctx, q, args...)
 	if err != nil {
 		return nil, fmt.Errorf("flow archive store: query: %w", err)
@@ -301,6 +301,33 @@ func (d *duckdbStore) parquetURL(accountID string) string {
 	return fmt.Sprintf(readParquetURL, d.cfg.Provider, d.cfg.Bucket, prefix, accountID)
 }
 
+// marginDays is the pruning margin this store reads with. It is a
+// method rather than an inline call so the wiring from configuration to
+// query has somewhere to be asserted: a reader that computes the right
+// margin and then queries with the default is the same outage as one
+// that computes it wrong.
+func (d *duckdbStore) marginDays() int {
+	return marginDaysFor(d.cfg.MaxBatchSpan)
+}
+
+// marginDaysFor turns the sink's worst-case batch span into the number
+// of days the pruning predicate must reach beyond the requested window.
+//
+// One day is the floor, not the answer: an object written by a sink that
+// buffers for 48h can carry events two days newer than the date in its
+// own name, and a predicate that stopped at the requested day would skip
+// it without saying so. Rounding up rather than down, because the cost
+// of an extra directory is a directory and the cost of one too few is a
+// missing row.
+func marginDaysFor(span time.Duration) int {
+	const day = 24 * time.Hour
+	days := 1
+	if span > 0 {
+		days += int((span + day - 1) / day)
+	}
+	return days
+}
+
 // writePartitionBounds narrows the file list before any file is opened.
 //
 // Without it the reader filters only on received_at, a column that lives
@@ -326,15 +353,18 @@ func (d *duckdbStore) parquetURL(accountID string) string {
 // is numeric order. Written as nested comparisons on the bare columns
 // rather than arithmetic over them, because that is the shape DuckDB
 // prunes on.
-func writePartitionBounds(sb *strings.Builder, since, until time.Time) {
+func writePartitionBounds(sb *strings.Builder, since, until time.Time, marginDays int) {
+	if marginDays < 1 {
+		marginDays = 1
+	}
 	if !since.IsZero() {
-		lo := since.UTC().AddDate(0, 0, -1)
+		lo := since.UTC().AddDate(0, 0, -marginDays)
 		fmt.Fprintf(sb,
 			" AND (year > '%04d' OR (year = '%04d' AND (month > '%02d' OR (month = '%02d' AND day >= '%02d'))))",
 			lo.Year(), lo.Year(), int(lo.Month()), int(lo.Month()), lo.Day())
 	}
 	if !until.IsZero() {
-		hi := until.UTC().AddDate(0, 0, 1)
+		hi := until.UTC().AddDate(0, 0, marginDays)
 		fmt.Fprintf(sb,
 			" AND (year < '%04d' OR (year = '%04d' AND (month < '%02d' OR (month = '%02d' AND day <= '%02d'))))",
 			hi.Year(), hi.Year(), int(hi.Month()), int(hi.Month()), hi.Day())
@@ -344,7 +374,7 @@ func writePartitionBounds(sb *strings.Builder, since, until time.Time) {
 // buildQuery produces the parameterised SELECT. Filters that the
 // caller did not set degenerate to TRUE so the query plan stays
 // uniform regardless of how many fields are constrained.
-func buildQuery(url string, f store.Filter) (string, []any) {
+func buildQuery(url string, f store.Filter, marginDays int) (string, []any) {
 	var (
 		sb   strings.Builder
 		args []any
@@ -389,7 +419,7 @@ func buildQuery(url string, f store.Filter) (string, []any) {
 		sb.WriteString(" AND protocol = ?")
 		args = append(args, *f.Protocol)
 	}
-	writePartitionBounds(&sb, f.Since, f.Until)
+	writePartitionBounds(&sb, f.Since, f.Until, marginDays)
 
 	if !f.Since.IsZero() {
 		sb.WriteString(" AND received_at >= ?")

--- a/flow/store/archive/duckdb.go
+++ b/flow/store/archive/duckdb.go
@@ -301,6 +301,46 @@ func (d *duckdbStore) parquetURL(accountID string) string {
 	return fmt.Sprintf(readParquetURL, d.cfg.Provider, d.cfg.Bucket, prefix, accountID)
 }
 
+// writePartitionBounds narrows the file list before any file is opened.
+//
+// Without it the reader filters only on received_at, a column that lives
+// *inside* the parquet files, so DuckDB opens every object under the
+// account to answer any question. The objects are laid out
+// year=/month=/day= precisely so most of them can be skipped, and
+// nothing was using it: a two-month window over a four-month archive
+// read all four, ran past the ingress timeout, and returned 504.
+//
+// The bounds are one day wider on each side, deliberately. The sink
+// names a file after the ReceivedAt of the *first* event in the batch
+// (flow/sinks/gcs.go), so a batch that crosses midnight files its later
+// events under the earlier day. These predicates only prune — the
+// received_at clauses below still decide the answer — so a widened
+// bound costs one extra directory while a tight one drops real rows and
+// says nothing.
+//
+// The literals are quoted because the partition columns do not share a
+// type: DuckDB infers year=2026 as BIGINT but leaves month=05 VARCHAR,
+// the leading zero defeating the cast, and comparing that VARCHAR
+// against an integer is a binder error. A string literal is accepted by
+// both, and the sink zero-pads every component, so lexicographic order
+// is numeric order. Written as nested comparisons on the bare columns
+// rather than arithmetic over them, because that is the shape DuckDB
+// prunes on.
+func writePartitionBounds(sb *strings.Builder, since, until time.Time) {
+	if !since.IsZero() {
+		lo := since.UTC().AddDate(0, 0, -1)
+		fmt.Fprintf(sb,
+			" AND (year > '%04d' OR (year = '%04d' AND (month > '%02d' OR (month = '%02d' AND day >= '%02d'))))",
+			lo.Year(), lo.Year(), int(lo.Month()), int(lo.Month()), lo.Day())
+	}
+	if !until.IsZero() {
+		hi := until.UTC().AddDate(0, 0, 1)
+		fmt.Fprintf(sb,
+			" AND (year < '%04d' OR (year = '%04d' AND (month < '%02d' OR (month = '%02d' AND day <= '%02d'))))",
+			hi.Year(), hi.Year(), int(hi.Month()), int(hi.Month()), hi.Day())
+	}
+}
+
 // buildQuery produces the parameterised SELECT. Filters that the
 // caller did not set degenerate to TRUE so the query plan stays
 // uniform regardless of how many fields are constrained.
@@ -349,6 +389,8 @@ func buildQuery(url string, f store.Filter) (string, []any) {
 		sb.WriteString(" AND protocol = ?")
 		args = append(args, *f.Protocol)
 	}
+	writePartitionBounds(&sb, f.Since, f.Until)
+
 	if !f.Since.IsZero() {
 		sb.WriteString(" AND received_at >= ?")
 		args = append(args, f.Since.UTC())

--- a/flow/store/archive/duckdb.go
+++ b/flow/store/archive/duckdb.go
@@ -433,6 +433,20 @@ func buildQuery(url string, f store.Filter, marginDays int) (string, []any) {
 		sb.WriteString(" AND protocol = ?")
 		args = append(args, *f.Protocol)
 	}
+	// The hot store keeps type and direction as integers and compares
+	// them as integers; the parquet writer encodes them as strings
+	// (flow/sinks/parquet.go). Same filter, two representations, so the
+	// comparison has to be encoded rather than passed through -- and the
+	// two encoders have to agree, which is what typeString/dirString
+	// below exist to state.
+	if f.Type != nil {
+		sb.WriteString(" AND type = ?")
+		args = append(args, typeString(*f.Type))
+	}
+	if f.Direction != nil {
+		sb.WriteString(" AND direction = ?")
+		args = append(args, dirString(*f.Direction))
+	}
 	writePartitionBounds(&sb, f.Since, f.Until, marginDays)
 
 	if !f.Since.IsZero() {
@@ -559,6 +573,33 @@ func scanEvent(rows *sql.Rows) (*store.Event, error) {
 		ev.DestResource = b
 	}
 	return &ev, nil
+}
+
+// typeString and dirString are the inverse of parseEventType and
+// parseDirection below, and must stay identical to the encoders in
+// flow/sinks/parquet.go: they are what the archived strings were written
+// with. A disagreement here does not fail, it silently matches nothing,
+// which is why the round-trip is asserted rather than assumed.
+func typeString(t store.EventType) string {
+	switch t {
+	case store.EventTypeStart:
+		return "start"
+	case store.EventTypeEnd:
+		return "end"
+	case store.EventTypeDrop:
+		return "drop"
+	}
+	return "unknown"
+}
+
+func dirString(d store.Direction) string {
+	switch d {
+	case store.DirectionIngress:
+		return "ingress"
+	case store.DirectionEgress:
+		return "egress"
+	}
+	return "unknown"
 }
 
 func parseEventType(s string) store.EventType {

--- a/flow/store/archive/duckdb_test.go
+++ b/flow/store/archive/duckdb_test.go
@@ -64,7 +64,7 @@ func TestNewParquet_GCSUsesHMACEnv(t *testing.T) {
 // glob URL and the safety-net LIMIT both land in the SQL.
 func TestBuildQuery_AccountIDOnly(t *testing.T) {
 	glob := "s3://b/year=*/month=*/day=*/account=acct-1/*.parquet"
-	q, args := buildQuery(glob, store.Filter{})
+	q, args := buildQuery(glob, store.Filter{}, 1)
 	// Interpolated, not bound: DuckDB expands the file list while binding,
 	// so a parameter here breaks the prepare as soon as a second parameter
 	// exists. See TestBuildQueryPreparesWithFilters, which runs it.
@@ -99,7 +99,7 @@ func TestBuildQuery_AllFilters(t *testing.T) {
 		Limit:      50,
 		Offset:     100,
 	}
-	q, args := buildQuery("s3://b/account=acct-1/*.parquet", f)
+	q, args := buildQuery("s3://b/account=acct-1/*.parquet", f, 1)
 	for _, want := range []string{
 		"peer_id = ?",
 		"source_ip = ?",
@@ -127,7 +127,7 @@ func TestBuildQuery_AllFilters(t *testing.T) {
 // year of archive into memory.
 func TestBuildQuery_LimitClamping(t *testing.T) {
 	for _, in := range []int{0, -1, MaxRowsPerQuery + 1, 1_000_000} {
-		_, args := buildQuery("u", store.Filter{Limit: in})
+		_, args := buildQuery("u", store.Filter{Limit: in}, 1)
 		assert.Equal(t, MaxRowsPerQuery, args[len(args)-1].(int),
 			"input limit=%d should clamp to %d", in, MaxRowsPerQuery)
 	}
@@ -138,7 +138,7 @@ func TestBuildQuery_LimitClamping(t *testing.T) {
 // encoding the SELECT would compare raw bytes against a string
 // column and silently match nothing.
 func TestBuildQuery_RuleIDIsHexEncoded(t *testing.T) {
-	_, args := buildQuery("u", store.Filter{RuleID: []byte{0xab, 0xcd}})
+	_, args := buildQuery("u", store.Filter{RuleID: []byte{0xab, 0xcd}}, 1)
 	// args = [rule_id, limit] — the glob is interpolated, not bound, so it
 	// no longer occupies index 0.
 	assert.Equal(t, "abcd", args[0].(string))

--- a/flow/store/archive/duckdb_test.go
+++ b/flow/store/archive/duckdb_test.go
@@ -64,7 +64,7 @@ func TestNewParquet_GCSUsesHMACEnv(t *testing.T) {
 // glob URL and the safety-net LIMIT both land in the SQL.
 func TestBuildQuery_AccountIDOnly(t *testing.T) {
 	glob := "s3://b/year=*/month=*/day=*/account=acct-1/*.parquet"
-	q, args := buildQuery(glob, store.Filter{}, 1)
+	q, args := buildQuery(glob, store.Filter{AccountID: "acct-1"}, 1)
 	// Interpolated, not bound: DuckDB expands the file list while binding,
 	// so a parameter here breaks the prepare as soon as a second parameter
 	// exists. See TestBuildQueryPreparesWithFilters, which runs it.
@@ -72,8 +72,12 @@ func TestBuildQuery_AccountIDOnly(t *testing.T) {
 	assert.Contains(t, q, "WHERE 1=1")
 	assert.Contains(t, q, "ORDER BY received_at DESC")
 	assert.Contains(t, q, "LIMIT ?")
-	require.Len(t, args, 1)
-	assert.Equal(t, MaxRowsPerQuery, args[0].(int))
+	// account_id is bound unconditionally and comes first: the archive
+	// path claims an account, and objects written before #186 do not
+	// always keep that claim.
+	require.Len(t, args, 2)
+	assert.Equal(t, "acct-1", args[0].(string))
+	assert.Equal(t, MaxRowsPerQuery, args[1].(int))
 }
 
 // TestBuildQuery_AllFilters exercises every Filter field. Catches
@@ -115,10 +119,11 @@ func TestBuildQuery_AllFilters(t *testing.T) {
 	} {
 		assert.Contains(t, q, want)
 	}
-	// 12 args: url + 9 filters + limit + offset
-	// Eleven, not twelve: the parquet glob is interpolated into the SQL
-	// rather than bound, so it is no longer an argument.
-	assert.Len(t, args, 11)
+	// Twelve: account_id + 9 filters + limit + offset. The parquet glob
+	// is interpolated into the SQL rather than bound, so it is not an
+	// argument; account_id is bound and always present.
+	assert.Len(t, args, 12)
+	assert.Equal(t, "acct-1", args[0].(string), "the account is bound first and unconditionally")
 }
 
 // TestBuildQuery_LimitClamping ensures a caller asking for "give me
@@ -127,7 +132,7 @@ func TestBuildQuery_AllFilters(t *testing.T) {
 // year of archive into memory.
 func TestBuildQuery_LimitClamping(t *testing.T) {
 	for _, in := range []int{0, -1, MaxRowsPerQuery + 1, 1_000_000} {
-		_, args := buildQuery("u", store.Filter{Limit: in}, 1)
+		_, args := buildQuery("u", store.Filter{AccountID: "acct-1", Limit: in}, 1)
 		assert.Equal(t, MaxRowsPerQuery, args[len(args)-1].(int),
 			"input limit=%d should clamp to %d", in, MaxRowsPerQuery)
 	}
@@ -138,10 +143,10 @@ func TestBuildQuery_LimitClamping(t *testing.T) {
 // encoding the SELECT would compare raw bytes against a string
 // column and silently match nothing.
 func TestBuildQuery_RuleIDIsHexEncoded(t *testing.T) {
-	_, args := buildQuery("u", store.Filter{RuleID: []byte{0xab, 0xcd}}, 1)
-	// args = [rule_id, limit] — the glob is interpolated, not bound, so it
-	// no longer occupies index 0.
-	assert.Equal(t, "abcd", args[0].(string))
+	_, args := buildQuery("u", store.Filter{AccountID: "acct-1", RuleID: []byte{0xab, 0xcd}}, 1)
+	// args = [account_id, rule_id, limit] — the glob is interpolated, not
+	// bound, and account_id is always the first argument.
+	assert.Equal(t, "abcd", args[1].(string))
 }
 
 // TestParquetURL_HivePartition checks the URL template lines up with

--- a/flow/store/archive/factory.go
+++ b/flow/store/archive/factory.go
@@ -23,6 +23,9 @@ const (
 	envS3AccessKey = "OPENZRO_FLOW_ARCHIVE_S3_ACCESS_KEY"
 	envS3SecretKey = "OPENZRO_FLOW_ARCHIVE_S3_SECRET_KEY"
 	envS3Prefix    = "OPENZRO_FLOW_ARCHIVE_S3_PREFIX"
+	// The sink's flush interval, read here only to size the
+	// partition-pruning margin. See Config.MaxBatchSpan.
+	envS3FlushInterval = "OPENZRO_FLOW_ARCHIVE_S3_FLUSH_INTERVAL"
 
 	envGCSBucket          = "OPENZRO_FLOW_ARCHIVE_GCS_BUCKET"
 	envGCSPrefix          = "OPENZRO_FLOW_ARCHIVE_GCS_PREFIX"
@@ -38,6 +41,9 @@ const (
 	envGCSHMACKeyID  = "OPENZRO_FLOW_ARCHIVE_GCS_HMAC_KEY_ID"
 	envGCSHMACSecret = "OPENZRO_FLOW_ARCHIVE_GCS_HMAC_SECRET"
 	envGCSEndpoint   = "OPENZRO_FLOW_ARCHIVE_GCS_ENDPOINT"
+	// As above: the pruning margin has to cover what the writer could
+	// have produced, not what it produces by default.
+	envGCSFlushInterval = "OPENZRO_FLOW_ARCHIVE_GCS_FLUSH_INTERVAL"
 
 	envFormat       = "OPENZRO_FLOW_ARCHIVE_FORMAT"
 	envQueryTimeout = "OPENZRO_FLOW_ARCHIVE_QUERY_TIMEOUT"
@@ -147,6 +153,7 @@ func configFromEnv() (Config, bool) {
 			CredentialsFile: os.Getenv(envGCSCredentialsFile),
 			AccessKeyID:     os.Getenv(envGCSHMACKeyID),
 			SecretAccessKey: os.Getenv(envGCSHMACSecret),
+			MaxBatchSpan:    parseTimeout(os.Getenv(envGCSFlushInterval)),
 		}
 		if v := os.Getenv(envGCSCredentialsJSON); v != "" {
 			cfg.CredentialsJSON = []byte(v)
@@ -162,6 +169,7 @@ func configFromEnv() (Config, bool) {
 			Region:          os.Getenv(envS3Region),
 			AccessKeyID:     os.Getenv(envS3AccessKey),
 			SecretAccessKey: os.Getenv(envS3SecretKey),
+			MaxBatchSpan:    parseTimeout(os.Getenv(envS3FlushInterval)),
 		}, true
 	}
 	return Config{}, false

--- a/flow/store/archive/partition_pruning_test.go
+++ b/flow/store/archive/partition_pruning_test.go
@@ -58,7 +58,7 @@ func TestPartitionPruningSkipsFilesOutsideTheWindow(t *testing.T) {
 		Until: time.Date(2026, 7, 31, 23, 59, 59, 0, time.UTC),
 	}
 
-	q, args := buildQuery(partitionGlob(root), f)
+	q, args := buildQuery(partitionGlob(root), f, 1)
 	n, err := countRows(t, db, q, args)
 	require.NoError(t, err,
 		"September holds a corrupt file; reaching it means the window was not pruned")
@@ -67,7 +67,7 @@ func TestPartitionPruningSkipsFilesOutsideTheWindow(t *testing.T) {
 	// The negative control: the same data, the same window, with the
 	// partition predicates stripped. If this also passed, the assertion
 	// above would be proving nothing about pruning.
-	stripped, args := buildQuery(partitionGlob(root), f)
+	stripped, args := buildQuery(partitionGlob(root), f, 1)
 	stripped = removePartitionBounds(t, stripped)
 	_, err = countRows(t, db, stripped, args)
 	require.Error(t, err,
@@ -121,7 +121,7 @@ func TestPartitionBoundsAreWidenedByADay(t *testing.T) {
 	q, args := buildQuery(partitionGlob(root), store.Filter{
 		Since: time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC),
 		Until: time.Date(2026, 6, 10, 23, 59, 59, 0, time.UTC),
-	})
+	}, 1)
 	n, err := countRows(t, db, q, args)
 	require.NoError(t, err)
 	require.Equal(t, 1, n, "an event filed under the previous day's partition must still be found")
@@ -142,7 +142,7 @@ func TestPartitionBoundsSpanYearBoundary(t *testing.T) {
 	q, args := buildQuery(partitionGlob(root), store.Filter{
 		Since: time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC),
 		Until: time.Date(2026, 1, 31, 0, 0, 0, 0, time.UTC),
-	})
+	}, 1)
 	n, err := countRows(t, db, q, args)
 	require.NoError(t, err)
 	require.Equal(t, 2, n, "both sides of the year boundary are inside the window")
@@ -163,7 +163,7 @@ func TestPartitionBoundsWideningCrossesMonthAndYear(t *testing.T) {
 	q, args := buildQuery(partitionGlob(root), store.Filter{
 		Since: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 		Until: time.Date(2026, 1, 31, 23, 59, 59, 0, time.UTC),
-	})
+	}, 1)
 	n, err := countRows(t, db, q, args)
 	require.NoError(t, err)
 	require.Equal(t, 2, n,
@@ -174,7 +174,111 @@ func TestPartitionBoundsWideningCrossesMonthAndYear(t *testing.T) {
 // there is nothing to bound, and a bound built from a zero time would
 // exclude the entire archive.
 func TestPartitionBoundsAbsentWithoutAWindow(t *testing.T) {
-	q, _ := buildQuery("gcs://b/year=*/month=*/day=*/account=acct-1/*.parquet", store.Filter{})
+	q, _ := buildQuery("gcs://b/year=*/month=*/day=*/account=acct-1/*.parquet", store.Filter{}, 1)
 	require.NotContains(t, q, " AND (year", "an unbounded query must read every partition")
 	require.Contains(t, q, "year=*", "the glob still spans them; it is the predicate that must be absent")
+}
+
+// The one-day margin is a floor, not a constant. Objects written before
+// the sinks split a batch by date took their whole path from the first
+// event dequeued, so an object could carry events as far past its own
+// name as the sink's flush interval — which is operator-configurable and
+// has no upper bound. A 48h flush can put an event two days after the
+// date in the path.
+//
+// A pruning predicate that stopped at one day would skip that object and
+// report nothing, which is worse than the slow scan it replaced.
+func TestMarginDaysForCoversTheConfiguredFlushInterval(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		span time.Duration
+		want int
+	}{
+		{"unset falls back to the floor", 0, 1},
+		{"the 15m default needs no extra day", 15 * time.Minute, 2},
+		{"just under a day still rounds up to one", 23 * time.Hour, 2},
+		{"exactly a day", 24 * time.Hour, 2},
+		{"48h spans two days", 48 * time.Hour, 3},
+		{"a week", 7 * 24 * time.Hour, 8},
+		{"a negative value cannot shrink the floor", -time.Hour, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, marginDaysFor(tc.span))
+		})
+	}
+}
+
+// The margin has to actually reach the file, not merely be computed.
+// This plants an object whose name predates its contents by two days —
+// what a 48h flush produced before the sinks were fixed — and requires
+// the configured reader to find it.
+func TestPruningFindsAnObjectOlderThanItsContents(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	root := t.TempDir()
+	seedEventParquet(t, db, partitionPath(root, "2026", "06", "08", "x.parquet"), "2026-06-10 12:00:00")
+
+	f := store.Filter{
+		Since: time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC),
+		Until: time.Date(2026, 6, 10, 23, 59, 59, 0, time.UTC),
+	}
+
+	q, args := buildQuery(partitionGlob(root), f, marginDaysFor(48*time.Hour))
+	n, err := countRows(t, db, q, args)
+	require.NoError(t, err)
+	require.Equal(t, 1, n,
+		"a reader configured for a 48h flush must reach the partition that flush could have written")
+
+	// The control: the default margin does not reach it, which is why
+	// MaxBatchSpan has to be configured rather than assumed.
+	q, args = buildQuery(partitionGlob(root), f, marginDaysFor(0))
+	n, err = countRows(t, db, q, args)
+	require.NoError(t, err)
+	require.Equal(t, 0, n)
+}
+
+// The margin has to travel from configuration to query. A store that
+// computes the right number and then reads with the default one is
+// indistinguishable, from the dashboard, from one that computes it
+// wrong.
+func TestStoreReadsWithTheConfiguredMargin(t *testing.T) {
+	for _, tc := range []struct {
+		span time.Duration
+		want int
+	}{
+		{0, 1},
+		{15 * time.Minute, 2},
+		{48 * time.Hour, 3},
+	} {
+		d := &duckdbStore{cfg: Config{Provider: "s3", Bucket: "b", MaxBatchSpan: tc.span}}
+		require.Equal(t, tc.want, d.marginDays(), "MaxBatchSpan=%s", tc.span)
+	}
+}
+
+// And it has to reach the config in the first place. The flush interval
+// is the writer's setting; the reader has to pick up the same value or
+// the margin is sized for a sink nobody configured.
+func TestConfigFromEnvCarriesTheFlushInterval(t *testing.T) {
+	t.Run("gcs", func(t *testing.T) {
+		t.Setenv(envGCSBucket, "b")
+		t.Setenv(envGCSFlushInterval, "48h")
+		cfg, ok := configFromEnv()
+		require.True(t, ok)
+		require.Equal(t, 48*time.Hour, cfg.MaxBatchSpan)
+	})
+	t.Run("s3", func(t *testing.T) {
+		t.Setenv(envS3Bucket, "b")
+		t.Setenv(envS3FlushInterval, "36h")
+		cfg, ok := configFromEnv()
+		require.True(t, ok)
+		require.Equal(t, 36*time.Hour, cfg.MaxBatchSpan)
+	})
+	t.Run("unset leaves the floor to the reader", func(t *testing.T) {
+		t.Setenv(envS3Bucket, "b")
+		cfg, ok := configFromEnv()
+		require.True(t, ok)
+		require.Zero(t, cfg.MaxBatchSpan)
+	})
 }

--- a/flow/store/archive/partition_pruning_test.go
+++ b/flow/store/archive/partition_pruning_test.go
@@ -1,0 +1,180 @@
+//go:build archive_duckdb
+
+package archive
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openzro/openzro/flow/store"
+)
+
+// countRows drains the result set, so a lazily-surfaced read error on a
+// file DuckDB opened during execution is reported rather than swallowed.
+func countRows(t *testing.T, db *sql.DB, q string, args []any) (int, error) {
+	t.Helper()
+	rows, err := db.QueryContext(context.Background(), q, args...)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = rows.Close() }()
+	n := 0
+	for rows.Next() {
+		n++
+	}
+	return n, rows.Err()
+}
+
+// The archive query used to filter only on received_at, a column inside
+// the files, so DuckDB opened every object under the account to answer
+// anything. A two-month window over a four-month archive read all four,
+// ran past the ingress timeout, and returned 504 to the dashboard.
+//
+// This asserts the skip rather than the speed, which is the only way to
+// state it as a property: the excluded partition holds a file that is
+// not parquet at all, so any query that reaches it fails. Passing means
+// it was never opened.
+func TestPartitionPruningSkipsFilesOutsideTheWindow(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	root := t.TempDir()
+	seedEventParquet(t, db, partitionPath(root, "2026", "06", "10", "x.parquet"), "2026-06-10 10:00:00")
+	seedEventParquet(t, db, partitionPath(root, "2026", "07", "20", "x.parquet"), "2026-07-20 10:00:00")
+
+	corrupt := partitionPath(root, "2026", "09", "05", "x.parquet")
+	require.NoError(t, os.MkdirAll(corrupt[:len(corrupt)-len("/x.parquet")], 0o755))
+	require.NoError(t, os.WriteFile(corrupt, []byte("not parquet"), 0o644))
+
+	f := store.Filter{
+		Since: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+		Until: time.Date(2026, 7, 31, 23, 59, 59, 0, time.UTC),
+	}
+
+	q, args := buildQuery(partitionGlob(root), f)
+	n, err := countRows(t, db, q, args)
+	require.NoError(t, err,
+		"September holds a corrupt file; reaching it means the window was not pruned")
+	require.Equal(t, 2, n, "both June and July rows are inside the window")
+
+	// The negative control: the same data, the same window, with the
+	// partition predicates stripped. If this also passed, the assertion
+	// above would be proving nothing about pruning.
+	stripped, args := buildQuery(partitionGlob(root), f)
+	stripped = removePartitionBounds(t, stripped)
+	_, err = countRows(t, db, stripped, args)
+	require.Error(t, err,
+		"without the partition predicates every file is opened, corrupt one included")
+}
+
+// removePartitionBounds rebuilds the pre-fix query: same select, same
+// received_at window, no year/month/day.
+func removePartitionBounds(t *testing.T, q string) string {
+	t.Helper()
+	out := q
+	for {
+		i := strings.Index(out, " AND (year")
+		if i < 0 {
+			return out
+		}
+		// The clause is one balanced parenthesised group after " AND ".
+		depth, j := 0, i+len(" AND ")
+		for ; j < len(out); j++ {
+			switch out[j] {
+			case '(':
+				depth++
+			case ')':
+				depth--
+			}
+			if depth == 0 {
+				break
+			}
+		}
+		require.Equal(t, 0, depth, "unbalanced partition clause in %q", q)
+		out = out[:i] + out[j+1:]
+	}
+}
+
+// The bounds are a day wider on each side on purpose: the sink names a
+// file after the ReceivedAt of the first event in the batch, so a batch
+// crossing midnight files its later events under the earlier day. An
+// event at 00:05 can therefore live in the previous day's partition, and
+// a bound that stopped at the exact day would drop it — without an
+// error, which is the failure mode that matters here.
+func TestPartitionBoundsAreWidenedByADay(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	// Filed under the 9th because its batch began there; the event
+	// itself is on the 10th.
+	root := t.TempDir()
+	seedEventParquet(t, db, partitionPath(root, "2026", "06", "09", "x.parquet"), "2026-06-10 00:05:00")
+
+	q, args := buildQuery(partitionGlob(root), store.Filter{
+		Since: time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC),
+		Until: time.Date(2026, 6, 10, 23, 59, 59, 0, time.UTC),
+	})
+	n, err := countRows(t, db, q, args)
+	require.NoError(t, err)
+	require.Equal(t, 1, n, "an event filed under the previous day's partition must still be found")
+}
+
+// A window spanning a year boundary must exclude neither side. Comparing
+// month independently of year would exclude both: December to January is
+// month >= 12 AND month <= 01, which matches nothing.
+func TestPartitionBoundsSpanYearBoundary(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	root := t.TempDir()
+	seedEventParquet(t, db, partitionPath(root, "2025", "12", "20", "x.parquet"), "2025-12-20 10:00:00")
+	seedEventParquet(t, db, partitionPath(root, "2026", "01", "15", "x.parquet"), "2026-01-15 10:00:00")
+
+	q, args := buildQuery(partitionGlob(root), store.Filter{
+		Since: time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC),
+		Until: time.Date(2026, 1, 31, 0, 0, 0, 0, time.UTC),
+	})
+	n, err := countRows(t, db, q, args)
+	require.NoError(t, err)
+	require.Equal(t, 2, n, "both sides of the year boundary are inside the window")
+}
+
+// The widening crosses month and year boundaries by date arithmetic, not
+// by decrementing a day number. A window starting on the 1st of January
+// must reach back into December of the previous year.
+func TestPartitionBoundsWideningCrossesMonthAndYear(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	root := t.TempDir()
+	seedEventParquet(t, db, partitionPath(root, "2025", "12", "31", "x.parquet"), "2026-01-01 00:05:00")
+	seedEventParquet(t, db, partitionPath(root, "2026", "02", "01", "x.parquet"), "2026-01-31 23:55:00")
+
+	q, args := buildQuery(partitionGlob(root), store.Filter{
+		Since: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Until: time.Date(2026, 1, 31, 23, 59, 59, 0, time.UTC),
+	})
+	n, err := countRows(t, db, q, args)
+	require.NoError(t, err)
+	require.Equal(t, 2, n,
+		"the day before January 1 is December 31 of the prior year, and the day after January 31 is February 1")
+}
+
+// A filter with no window at all must not emit partition predicates:
+// there is nothing to bound, and a bound built from a zero time would
+// exclude the entire archive.
+func TestPartitionBoundsAbsentWithoutAWindow(t *testing.T) {
+	q, _ := buildQuery("gcs://b/year=*/month=*/day=*/account=acct-1/*.parquet", store.Filter{})
+	require.NotContains(t, q, " AND (year", "an unbounded query must read every partition")
+	require.Contains(t, q, "year=*", "the glob still spans them; it is the predicate that must be absent")
+}

--- a/flow/store/archive/partition_pruning_test.go
+++ b/flow/store/archive/partition_pruning_test.go
@@ -316,8 +316,16 @@ func TestQueryNeverReturnsAnotherAccountsRows(t *testing.T) {
 	require.NoError(t, err, "the object is still read; it is the row that must be rejected")
 	require.Zero(t, n, "an object misfiled under acct-A leaked acct-B's event")
 
-	// The control: the same object answers acct-B, so the predicate is
-	// rejecting on identity rather than rejecting everything.
+	// The control: pointed at this object explicitly, the row does come
+	// back for acct-B. It proves the predicate rejects on identity
+	// rather than rejecting everything -- and no more than that.
+	//
+	// It is not a claim that acct-B can find this event. Query() builds
+	// the glob from the account, so acct-B would read account=acct-B and
+	// never open an object misfiled under account=acct-A. The glob here
+	// is passed by hand, which is the only reason the object is in
+	// scope. Closing the leak and recovering the data are different
+	// problems; only the first one is in this branch.
 	q, args = buildQuery(partitionGlob(root), store.Filter{
 		AccountID: "acct-B",
 		Since:     time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC),

--- a/flow/store/archive/partition_pruning_test.go
+++ b/flow/store/archive/partition_pruning_test.go
@@ -54,8 +54,9 @@ func TestPartitionPruningSkipsFilesOutsideTheWindow(t *testing.T) {
 	require.NoError(t, os.WriteFile(corrupt, []byte("not parquet"), 0o644))
 
 	f := store.Filter{
-		Since: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
-		Until: time.Date(2026, 7, 31, 23, 59, 59, 0, time.UTC),
+		AccountID: testAccount,
+		Since:     time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+		Until:     time.Date(2026, 7, 31, 23, 59, 59, 0, time.UTC),
 	}
 
 	q, args := buildQuery(partitionGlob(root), f, 1)
@@ -119,8 +120,9 @@ func TestPartitionBoundsAreWidenedByADay(t *testing.T) {
 	seedEventParquet(t, db, partitionPath(root, "2026", "06", "09", "x.parquet"), "2026-06-10 00:05:00")
 
 	q, args := buildQuery(partitionGlob(root), store.Filter{
-		Since: time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC),
-		Until: time.Date(2026, 6, 10, 23, 59, 59, 0, time.UTC),
+		AccountID: testAccount,
+		Since:     time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC),
+		Until:     time.Date(2026, 6, 10, 23, 59, 59, 0, time.UTC),
 	}, 1)
 	n, err := countRows(t, db, q, args)
 	require.NoError(t, err)
@@ -140,8 +142,9 @@ func TestPartitionBoundsSpanYearBoundary(t *testing.T) {
 	seedEventParquet(t, db, partitionPath(root, "2026", "01", "15", "x.parquet"), "2026-01-15 10:00:00")
 
 	q, args := buildQuery(partitionGlob(root), store.Filter{
-		Since: time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC),
-		Until: time.Date(2026, 1, 31, 0, 0, 0, 0, time.UTC),
+		AccountID: testAccount,
+		Since:     time.Date(2025, 12, 1, 0, 0, 0, 0, time.UTC),
+		Until:     time.Date(2026, 1, 31, 0, 0, 0, 0, time.UTC),
 	}, 1)
 	n, err := countRows(t, db, q, args)
 	require.NoError(t, err)
@@ -161,8 +164,9 @@ func TestPartitionBoundsWideningCrossesMonthAndYear(t *testing.T) {
 	seedEventParquet(t, db, partitionPath(root, "2026", "02", "01", "x.parquet"), "2026-01-31 23:55:00")
 
 	q, args := buildQuery(partitionGlob(root), store.Filter{
-		Since: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
-		Until: time.Date(2026, 1, 31, 23, 59, 59, 0, time.UTC),
+		AccountID: testAccount,
+		Since:     time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Until:     time.Date(2026, 1, 31, 23, 59, 59, 0, time.UTC),
 	}, 1)
 	n, err := countRows(t, db, q, args)
 	require.NoError(t, err)
@@ -174,7 +178,7 @@ func TestPartitionBoundsWideningCrossesMonthAndYear(t *testing.T) {
 // there is nothing to bound, and a bound built from a zero time would
 // exclude the entire archive.
 func TestPartitionBoundsAbsentWithoutAWindow(t *testing.T) {
-	q, _ := buildQuery("gcs://b/year=*/month=*/day=*/account=acct-1/*.parquet", store.Filter{}, 1)
+	q, _ := buildQuery("gcs://b/year=*/month=*/day=*/account=acct-1/*.parquet", store.Filter{AccountID: "acct-1"}, 1)
 	require.NotContains(t, q, " AND (year", "an unbounded query must read every partition")
 	require.Contains(t, q, "year=*", "the glob still spans them; it is the predicate that must be absent")
 }
@@ -221,8 +225,9 @@ func TestPruningFindsAnObjectOlderThanItsContents(t *testing.T) {
 	seedEventParquet(t, db, partitionPath(root, "2026", "06", "08", "x.parquet"), "2026-06-10 12:00:00")
 
 	f := store.Filter{
-		Since: time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC),
-		Until: time.Date(2026, 6, 10, 23, 59, 59, 0, time.UTC),
+		AccountID: testAccount,
+		Since:     time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC),
+		Until:     time.Date(2026, 6, 10, 23, 59, 59, 0, time.UTC),
 	}
 
 	q, args := buildQuery(partitionGlob(root), f, marginDaysFor(48*time.Hour))
@@ -281,4 +286,44 @@ func TestConfigFromEnvCarriesTheFlushInterval(t *testing.T) {
 		require.True(t, ok)
 		require.Zero(t, cfg.MaxBatchSpan)
 	})
+}
+
+// The archive path asserts an account; until #186 the writer did not
+// keep that promise, and those objects are on disk now. An object under
+// account=acct-A holding an acct-B row must return nothing for acct-A —
+// restricting on the path alone hands one account another's events.
+//
+// This is not a pruning predicate: account_id lives inside the file, so
+// the object is still opened. Opening it and returning nothing is the
+// point.
+func TestQueryNeverReturnsAnotherAccountsRows(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	root := t.TempDir()
+	// Filed under acct-A, carrying acct-B's event: exactly what a mixed
+	// batch produced.
+	seedEventParquetAs(t, db, partitionPath(root, "2026", "06", "10", "x.parquet"),
+		"2026-06-10 12:00:00", "acct-B")
+
+	q, args := buildQuery(partitionGlob(root), store.Filter{
+		AccountID: "acct-A",
+		Since:     time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC),
+		Until:     time.Date(2026, 6, 10, 23, 59, 59, 0, time.UTC),
+	}, 1)
+	n, err := countRows(t, db, q, args)
+	require.NoError(t, err, "the object is still read; it is the row that must be rejected")
+	require.Zero(t, n, "an object misfiled under acct-A leaked acct-B's event")
+
+	// The control: the same object answers acct-B, so the predicate is
+	// rejecting on identity rather than rejecting everything.
+	q, args = buildQuery(partitionGlob(root), store.Filter{
+		AccountID: "acct-B",
+		Since:     time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC),
+		Until:     time.Date(2026, 6, 10, 23, 59, 59, 0, time.UTC),
+	}, 1)
+	n, err = countRows(t, db, q, args)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
 }

--- a/flow/store/archive/query_bind_test.go
+++ b/flow/store/archive/query_bind_test.go
@@ -42,11 +42,12 @@ func TestBuildQueryPreparesWithFilters(t *testing.T) {
 
 	// The shape a dashboard request produces: a window plus predicates.
 	q, args := buildQuery(partitionGlob(root), store.Filter{
-		PeerID:   "peer-a",
-		DestPort: &port,
-		Protocol: &proto,
-		Since:    since,
-		Until:    until,
+		AccountID: testAccount,
+		PeerID:    "peer-a",
+		DestPort:  &port,
+		Protocol:  &proto,
+		Since:     since,
+		Until:     until,
 	}, 1)
 
 	rows, err := db.QueryContext(ctx, q, args...)
@@ -60,7 +61,7 @@ func TestBuildQueryPreparesWithFilters(t *testing.T) {
 // is now interpolated. Bucket and prefix come from operator configuration
 // rather than request input, so this is defence in depth, not a live hole.
 func TestBuildQueryQuotesTheGlob(t *testing.T) {
-	q, args := buildQuery("gcs://bucket/it's/**/*.parquet", store.Filter{}, 1)
+	q, args := buildQuery("gcs://bucket/it's/**/*.parquet", store.Filter{AccountID: "acct-1"}, 1)
 	require.Contains(t, q, "it''s", "a single quote has to be doubled for DuckDB")
 	require.NotContains(t, args, "gcs://bucket/it's/**/*.parquet", "the glob must not be an argument")
 }

--- a/flow/store/archive/query_bind_test.go
+++ b/flow/store/archive/query_bind_test.go
@@ -47,7 +47,7 @@ func TestBuildQueryPreparesWithFilters(t *testing.T) {
 		Protocol: &proto,
 		Since:    since,
 		Until:    until,
-	})
+	}, 1)
 
 	rows, err := db.QueryContext(ctx, q, args...)
 	require.NoError(t, err, "the query must prepare; binding the glob fails here as soon as a second parameter exists")
@@ -60,7 +60,7 @@ func TestBuildQueryPreparesWithFilters(t *testing.T) {
 // is now interpolated. Bucket and prefix come from operator configuration
 // rather than request input, so this is defence in depth, not a live hole.
 func TestBuildQueryQuotesTheGlob(t *testing.T) {
-	q, args := buildQuery("gcs://bucket/it's/**/*.parquet", store.Filter{})
+	q, args := buildQuery("gcs://bucket/it's/**/*.parquet", store.Filter{}, 1)
 	require.Contains(t, q, "it''s", "a single quote has to be doubled for DuckDB")
 	require.NotContains(t, args, "gcs://bucket/it's/**/*.parquet", "the glob must not be an argument")
 }

--- a/flow/store/archive/query_bind_test.go
+++ b/flow/store/archive/query_bind_test.go
@@ -5,7 +5,6 @@ package archive
 import (
 	"context"
 	"database/sql"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -31,25 +30,10 @@ func TestBuildQueryPreparesWithFilters(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = db.Close() })
 
-	// Every column the reader selects, so the failure under test is the
-	// bind and not a missing column.
-	path := filepath.Join(t.TempDir(), "events.parquet")
-	_, err = db.ExecContext(ctx, "COPY (SELECT "+
-		"TIMESTAMP '2026-05-12 10:00:00' AS received_at, "+
-		"TIMESTAMP '2026-05-12 10:00:00' AS occurred_at, "+
-		"'acct-1' AS account_id, 'peer-a' AS peer_id, "+
-		"'ev-1' AS event_id, 'fl-1' AS flow_id, "+
-		"1::UTINYINT AS type, 1::UTINYINT AS direction, "+
-		"6::USMALLINT AS protocol, "+
-		"'10.0.0.1' AS source_ip, '10.0.0.2' AS dest_ip, "+
-		"1024::UINTEGER AS source_port, 443::UINTEGER AS dest_port, "+
-		"0::UTINYINT AS icmp_type, 0::UTINYINT AS icmp_code, "+
-		"true AS is_initiator, "+
-		"1::UBIGINT AS rx_packets, 2::UBIGINT AS tx_packets, "+
-		"10::UBIGINT AS rx_bytes, 20::UBIGINT AS tx_bytes, "+
-		"'' AS rule_id, '' AS source_resource_id, '' AS dest_resource_id"+
-		") TO '"+path+"' (FORMAT PARQUET)")
-	require.NoError(t, err)
+	// A partitioned tree, because that is the only shape the reader ever
+	// builds: parquetURL always globs year/month/day above the account.
+	root := t.TempDir()
+	seedEventParquet(t, db, partitionPath(root, "2026", "05", "12", "events.parquet"), "2026-05-12 10:00:00")
 
 	since := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	until := time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -57,7 +41,7 @@ func TestBuildQueryPreparesWithFilters(t *testing.T) {
 	proto := uint16(6)
 
 	// The shape a dashboard request produces: a window plus predicates.
-	q, args := buildQuery(path, store.Filter{
+	q, args := buildQuery(partitionGlob(root), store.Filter{
 		PeerID:   "peer-a",
 		DestPort: &port,
 		Protocol: &proto,

--- a/flow/store/archive/seed_test.go
+++ b/flow/store/archive/seed_test.go
@@ -37,13 +37,25 @@ const testAccount = "acct-1"
 // ts is a DuckDB timestamp literal body, e.g. "2026-05-12 10:00:00".
 func seedEventParquetAs(t *testing.T, db *sql.DB, path, ts, accountID string) {
 	t.Helper()
+	seedTypedAs(t, db, path, ts, accountID, "start", "ingress")
+}
+
+// seedTyped writes a row with a chosen type and direction, for the
+// filters that compare them.
+func seedTyped(t *testing.T, db *sql.DB, path, ts, typ, dir string) {
+	t.Helper()
+	seedTypedAs(t, db, path, ts, testAccount, typ, dir)
+}
+
+func seedTypedAs(t *testing.T, db *sql.DB, path, ts, accountID, typ, dir string) {
+	t.Helper()
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 	_, err := db.ExecContext(context.Background(), "COPY (SELECT "+
 		"TIMESTAMP '"+ts+"' AS received_at, "+
 		"TIMESTAMP '"+ts+"' AS occurred_at, "+
 		"'"+accountID+"' AS account_id, 'peer-a' AS peer_id, "+
 		"'ev-1' AS event_id, 'fl-1' AS flow_id, "+
-		"'start' AS type, 'ingress' AS direction, "+
+		"'"+typ+"' AS type, '"+dir+"' AS direction, "+
 		"6::UINTEGER AS protocol, "+
 		"'10.0.0.1' AS source_ip, '10.0.0.2' AS dest_ip, "+
 		"1024::UINTEGER AS source_port, 443::UINTEGER AS dest_port, "+

--- a/flow/store/archive/seed_test.go
+++ b/flow/store/archive/seed_test.go
@@ -12,23 +12,42 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// seedEventParquet writes one row carrying every column the reader
-// selects, so a failure under test is the query and not a missing
-// column. ts is a DuckDB timestamp literal body, e.g. "2026-05-12
-// 10:00:00".
+// seedEventParquet writes one row for the default test account.
 func seedEventParquet(t *testing.T, db *sql.DB, path, ts string) {
+	t.Helper()
+	seedEventParquetAs(t, db, path, ts, testAccount)
+}
+
+// testAccount is the account the partition helpers file objects under.
+const testAccount = "acct-1"
+
+// seedEventParquetAs writes one row carrying every column the reader
+// selects, so a failure under test is the query and not a missing
+// column. accountID is a parameter because the account in the row and
+// the account in the path are separate facts -- objects written before
+// #186 disagree on them, and that disagreement is what the isolation
+// test needs to reproduce.
+//
+// The column types mirror flow/sinks/parquet.go's parquetEvent, which
+// matters for more than tidiness: type and direction are written as
+// strings there ("start", "ingress"), and a fixture that wrote them as
+// integers would let a broken string predicate pass. The fixture this
+// grew out of had exactly that defect.
+//
+// ts is a DuckDB timestamp literal body, e.g. "2026-05-12 10:00:00".
+func seedEventParquetAs(t *testing.T, db *sql.DB, path, ts, accountID string) {
 	t.Helper()
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 	_, err := db.ExecContext(context.Background(), "COPY (SELECT "+
 		"TIMESTAMP '"+ts+"' AS received_at, "+
 		"TIMESTAMP '"+ts+"' AS occurred_at, "+
-		"'acct-1' AS account_id, 'peer-a' AS peer_id, "+
+		"'"+accountID+"' AS account_id, 'peer-a' AS peer_id, "+
 		"'ev-1' AS event_id, 'fl-1' AS flow_id, "+
-		"1::UTINYINT AS type, 1::UTINYINT AS direction, "+
-		"6::USMALLINT AS protocol, "+
+		"'start' AS type, 'ingress' AS direction, "+
+		"6::UINTEGER AS protocol, "+
 		"'10.0.0.1' AS source_ip, '10.0.0.2' AS dest_ip, "+
 		"1024::UINTEGER AS source_port, 443::UINTEGER AS dest_port, "+
-		"0::UTINYINT AS icmp_type, 0::UTINYINT AS icmp_code, "+
+		"0::UINTEGER AS icmp_type, 0::UINTEGER AS icmp_code, "+
 		"true AS is_initiator, "+
 		"1::UBIGINT AS rx_packets, 2::UBIGINT AS tx_packets, "+
 		"10::UBIGINT AS rx_bytes, 20::UBIGINT AS tx_bytes, "+
@@ -40,10 +59,10 @@ func seedEventParquet(t *testing.T, db *sql.DB, path, ts string) {
 // partitionPath builds the layout flow/sinks writes: zero-padded
 // year/month/day above the account.
 func partitionPath(root, year, month, day, file string) string {
-	return filepath.Join(root, "year="+year, "month="+month, "day="+day, "account=acct-1", file)
+	return filepath.Join(root, "year="+year, "month="+month, "day="+day, "account="+testAccount, file)
 }
 
 // partitionGlob is what parquetURL produces for that layout.
 func partitionGlob(root string) string {
-	return filepath.Join(root, "year=*", "month=*", "day=*", "account=acct-1", "*.parquet")
+	return filepath.Join(root, "year=*", "month=*", "day=*", "account="+testAccount, "*.parquet")
 }

--- a/flow/store/archive/seed_test.go
+++ b/flow/store/archive/seed_test.go
@@ -1,0 +1,49 @@
+//go:build archive_duckdb
+
+package archive
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// seedEventParquet writes one row carrying every column the reader
+// selects, so a failure under test is the query and not a missing
+// column. ts is a DuckDB timestamp literal body, e.g. "2026-05-12
+// 10:00:00".
+func seedEventParquet(t *testing.T, db *sql.DB, path, ts string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	_, err := db.ExecContext(context.Background(), "COPY (SELECT "+
+		"TIMESTAMP '"+ts+"' AS received_at, "+
+		"TIMESTAMP '"+ts+"' AS occurred_at, "+
+		"'acct-1' AS account_id, 'peer-a' AS peer_id, "+
+		"'ev-1' AS event_id, 'fl-1' AS flow_id, "+
+		"1::UTINYINT AS type, 1::UTINYINT AS direction, "+
+		"6::USMALLINT AS protocol, "+
+		"'10.0.0.1' AS source_ip, '10.0.0.2' AS dest_ip, "+
+		"1024::UINTEGER AS source_port, 443::UINTEGER AS dest_port, "+
+		"0::UTINYINT AS icmp_type, 0::UTINYINT AS icmp_code, "+
+		"true AS is_initiator, "+
+		"1::UBIGINT AS rx_packets, 2::UBIGINT AS tx_packets, "+
+		"10::UBIGINT AS rx_bytes, 20::UBIGINT AS tx_bytes, "+
+		"'' AS rule_id, '' AS source_resource_id, '' AS dest_resource_id"+
+		") TO '"+path+"' (FORMAT PARQUET)")
+	require.NoError(t, err)
+}
+
+// partitionPath builds the layout flow/sinks writes: zero-padded
+// year/month/day above the account.
+func partitionPath(root, year, month, day, file string) string {
+	return filepath.Join(root, "year="+year, "month="+month, "day="+day, "account=acct-1", file)
+}
+
+// partitionGlob is what parquetURL produces for that layout.
+func partitionGlob(root string) string {
+	return filepath.Join(root, "year=*", "month=*", "day=*", "account=acct-1", "*.parquet")
+}

--- a/flow/store/archive/type_direction_test.go
+++ b/flow/store/archive/type_direction_test.go
@@ -1,0 +1,95 @@
+//go:build archive_duckdb
+
+package archive
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openzro/openzro/flow/store"
+)
+
+// The handler accepts type and direction and the hot store applies them,
+// but the archive reader dropped both. The filter therefore worked for
+// the retention window and quietly stopped working past it: same UI,
+// same request, and the cold half of the answer ignored the filter.
+//
+// Silently returning too much is the bad half. A "drop" filter that also
+// returns "start" events past the retention boundary is a wrong answer
+// presented as a filtered one.
+func TestQueryFiltersTypeAndDirection(t *testing.T) {
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	root := t.TempDir()
+	seedTyped(t, db, partitionPath(root, "2026", "06", "10", "a.parquet"),
+		"2026-06-10 10:00:00", "start", "ingress")
+	seedTyped(t, db, partitionPath(root, "2026", "06", "10", "b.parquet"),
+		"2026-06-10 11:00:00", "drop", "egress")
+
+	window := store.Filter{
+		AccountID: testAccount,
+		Since:     time.Date(2026, 6, 10, 0, 0, 0, 0, time.UTC),
+		Until:     time.Date(2026, 6, 10, 23, 59, 59, 0, time.UTC),
+	}
+
+	drop := store.EventTypeDrop
+	egress := store.DirectionEgress
+	start := store.EventTypeStart
+	ingress := store.DirectionIngress
+
+	for _, tc := range []struct {
+		name string
+		typ  *store.EventType
+		dir  *store.Direction
+		want int
+	}{
+		{"no type or direction returns both", nil, nil, 2},
+		{"type alone", &drop, nil, 1},
+		{"direction alone", nil, &egress, 1},
+		{"both, agreeing", &drop, &egress, 1},
+		{"both, disagreeing, returns nothing", &drop, &ingress, 0},
+		{"the other row", &start, &ingress, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := window
+			f.Type = tc.typ
+			f.Direction = tc.dir
+			q, args := buildQuery(partitionGlob(root), f, 1)
+			n, err := countRows(t, db, q, args)
+			require.NoError(t, err)
+			require.Equal(t, tc.want, n)
+		})
+	}
+}
+
+// The archive stores these as strings, so the filter has to be encoded
+// with the same spelling the writer used. A disagreement does not fail:
+// it matches nothing, and an empty result page looks exactly like an
+// account with no traffic. Pinned against the reader's own decoder, so
+// the pair cannot drift apart on one side only.
+func TestTypeAndDirectionStringsRoundTrip(t *testing.T) {
+	for _, v := range []store.EventType{
+		store.EventTypeStart, store.EventTypeEnd, store.EventTypeDrop,
+	} {
+		require.Equal(t, v, parseEventType(typeString(v)))
+	}
+	for _, v := range []store.Direction{
+		store.DirectionIngress, store.DirectionEgress,
+	} {
+		require.Equal(t, v, parseDirection(dirString(v)))
+	}
+
+	// The literals themselves, because a round trip through two
+	// functions that agree with each other and disagree with
+	// flow/sinks/parquet.go would still pass.
+	require.Equal(t, "start", typeString(store.EventTypeStart))
+	require.Equal(t, "end", typeString(store.EventTypeEnd))
+	require.Equal(t, "drop", typeString(store.EventTypeDrop))
+	require.Equal(t, "ingress", dirString(store.DirectionIngress))
+	require.Equal(t, "egress", dirString(store.DirectionEgress))
+}

--- a/management/server/flow_exports/archive_config.go
+++ b/management/server/flow_exports/archive_config.go
@@ -61,6 +61,9 @@ func ArchiveConfigFromRows(ctx context.Context, cfgStore *Store) (flowArchive.Co
 				Region:          c.Region,
 				AccessKeyID:     c.AccessKey,
 				SecretAccessKey: c.SecretKey,
+				// Sizes the partition-pruning margin; see
+				// flowArchive.Config.MaxBatchSpan.
+				MaxBatchSpan: c.FlushInterval,
 			}, archiveReaderSource(row), true, nil
 		case TypeGCS:
 			c, ok := plain.(*GCSDestConfig)
@@ -81,6 +84,9 @@ func ArchiveConfigFromRows(ctx context.Context, cfgStore *Store) (flowArchive.Co
 				ProjectID:       c.ProjectID,
 				CredentialsFile: c.CredentialsFile,
 				CredentialsJSON: []byte(c.CredentialsJSON),
+				// Sizes the partition-pruning margin; see
+				// flowArchive.Config.MaxBatchSpan.
+				MaxBatchSpan: c.FlushInterval,
 			}, archiveReaderSource(row), true, nil
 		}
 	}


### PR DESCRIPTION
Three commits. The first was the intended change; review found that it was unsafe on its own, and the second is the reason why.

## 1 · Prune hive partitions before opening any file

The archive reader filtered only on `received_at`, a column that lives *inside* the parquet files. DuckDB therefore opened every object under the account to answer any question, and the `year=/month=/day=` layout was decorative. A two-month window over a four-month archive read all four months, exceeded the ingress timeout, and returned 504.

The literals are quoted because the partition columns do not share a type: DuckDB infers `year=2026` as `BIGINT` but leaves `month=05` as `VARCHAR`, the leading zero defeating the cast, and comparing that `VARCHAR` against an integer is a binder error. `hive_types=` would pin them but is rejected outright on any glob whose path lacks those partitions — one brittleness traded for a worse one.

## 2 · Write one object per account and UTC date

Pruning is only sound if the path describes the file. It did not.

Both sinks buffer into a single queue shared by every account and drain it on a timer, then took the whole object path from `batch[0]`. The path asserts an account and a date; `batch[0]` only ever spoke for itself.

The worst consequence is not the one this branch went looking for. **A batch routinely mixes accounts, and every event in it was filed under `batch[0]`'s account.** The archive query restricted by the path alone, so those events were returned to the wrong account and were missing from their own. Reproduced against the real `objectKey`:

```
one object key for the whole batch: year=2026/month=06/day=10/account=acct-A/...parquet
  contains account=acct-A received_at=2026-06-10T23:59:00Z
  contains account=acct-B received_at=2026-06-11T00:01:00Z
```

The date has the same shape, and neither followed from ordering — nothing orders the queue, so `batch[0]` is the first event *dequeued*, not the earliest, and the skew runs both ways.

Grouping by `(account, UTC date)` makes the path describe the contents. A batch that already belongs to one partition still goes out as one object, so this does not fragment the archive into small files — there is a test for that, because it is the obvious way to get this wrong.

Details in #186.

## 3 · Size the pruning margin from the flush interval

Commit 2 fixes new objects; the skew already on disk does not go away. An object written earlier can carry events as far from the date in its own name as the sink's flush interval, which is operator-configurable through env and the dashboard with no upper bound.

A fixed one-day margin is safe for the 15m default and wrong for anything longer: under a 48h flush an object named `day=08` can hold an event from `day=10`, and a predicate stopping at `day=09` skips it and reports nothing. **That is worse than the slow scan it replaced, because the slow scan found the event.** This was P1 in review and is the reason the first commit could not merge alone.

`Config.MaxBatchSpan` carries the writer's flush interval to the reader — from the same env var for env-configured archives, from the row for dashboard-configured ones — and the margin rounds up to whole days with a floor of one.


## 4 · Reject another account's rows inside the file

Fixing the writer does not unwrite what is on disk, and the reader was still trusting the path for isolation — the assumption commit 2 had just disproved. The query now also compares `account_id`.

It is unconditional rather than guarded on a non-empty `AccountID`: `Query()` already rejects an empty one, and a filter that somehow arrived without it should return no rows, not every row.

This predicate does not prune. `account_id` lives inside the file, so every object the path selects is still opened; opening it and rejecting the row is the point. The path keeps doing the pruning it is good at and stops answering for the isolation it could never guarantee.

**What this does not do:** recover the data. The path decides which objects are opened, the column decides which rows are returned, and only the second was repaired. A legacy object misfiled under `account=acct-A` is no longer served to `acct-A`, but `acct-B` reads `account=acct-B` and never opens it.

| | before | after |
|---|---|---|
| wrong account sees the rows | yes | **no** |
| right account sees the rows | no | no |

Repartitioning existing objects is a separate decision, not in this branch.

## 5 · Apply the type and direction filters

The handler accepts `type` and `direction` and the hot store applies both; the archive reader dropped them. The filter worked inside the retention window and quietly stopped working past it — same screen, same request.

It errs toward returning **too much**: a `drop` filter that also returns `start` events past the retention boundary is a wrong answer presented as a filtered one, and nothing on the page says which half it came from.

The comparison has to be encoded rather than passed through — the hot store keeps these as integers, the parquet writer as strings. `typeString`/`dirString` must spell them exactly as `flow/sinks/parquet.go` did, and a disagreement there does not fail: it matches nothing, and an empty page is indistinguishable from an account with no traffic. So the test pins the literals as well as the round trip, because two functions that agree with each other and disagree with the writer would pass a round-trip check.

## 6 · Comments

`objectKey`'s comment did not merely go stale — it recorded the false premise that produced the bug ("within a single batch they are nanoseconds apart"). Rewritten rather than deleted, because the fear behind the shortcut was real; the answer is that it is narrower than it looked.

The shared test fixture had been writing `type`/`direction` as integers while the writer writes strings. That predates this branch, and on its own it was not a runtime defect — but it would have let the string predicate in §5 pass while broken.

## Tests

`TestPartitionPruningSkipsFilesOutsideTheWindow` asserts the *skip*, not the speed: the excluded partition holds a file that is not parquet, so any query reaching it fails. Its negative control runs the same data and window with the predicates stripped and requires the error.

Every property was verified by mutation, including two that were added because a mutation escaped:

| Mutation | Caught by |
|---|---|
| drop the one-day widening | `BoundsAreWidenedByADay`, `WideningCrossesMonthAndYear` |
| emit no partition predicates | `PruningSkipsFilesOutsideTheWindow` |
| compare `month` without nesting under `year` | four tests |
| one object per batch (the old sink) | `GroupsAgreeWithTheirObjectKey`, `NeverMixesAccounts`, `DoesNotDependOnArrivalOrder` |
| margin ignores the configured span | `MarginDaysForCovers…`, `PruningFindsAnObjectOlderThanItsContents` |
| store computes the margin, then queries with the default | `StoreReadsWithTheConfiguredMargin` — *added after this mutation escaped* |
| factory drops the flush interval | `ConfigFromEnvCarriesTheFlushInterval` — *same* |

Green with `-race` across `./flow/...` and `./management/server/flow_exports/`.

Refs #186
