### PR TITLE
fix(flow): stop presenting a truncated result as the whole answer

### DIFF
--- a/dashboard/src/interfaces/NetworkTrafficEvent.ts
+++ b/dashboard/src/interfaces/NetworkTrafficEvent.ts
@@ -36,4 +36,11 @@ export interface NetworkTrafficEventsResponse {
   events: NetworkTrafficEvent[];
   limit: number;
   offset: number;
+  // Set when part of the requested window could not be read, so the
+  // events above are real but not all of them. Absent on a whole
+  // answer. Worth surfacing rather than ignoring: a gap in flow events
+  // is indistinguishable from a quiet period, and this screen is used
+  // to decide that nothing happened.
+  incomplete?: boolean;
+  incomplete_reason?: string;
 }

--- a/dashboard/src/modules/network-traffic/v2/NetworkTrafficV2.tsx
+++ b/dashboard/src/modules/network-traffic/v2/NetworkTrafficV2.tsx
@@ -350,6 +350,19 @@ export default function NetworkTrafficV2() {
         </p>
       </header>
 
+      {data?.incomplete ? (
+        <OzCard className="flex items-start gap-3 border-oz2-warn bg-oz2-warn-bg px-4 py-3">
+          <span className="mt-0.5 shrink-0 text-oz2-warn">{ICONS.warn}</span>
+          <div className="text-[13.5px] leading-relaxed text-oz2-text">
+            <span className="font-medium">This list is incomplete.</span>{" "}
+            {data.incomplete_reason ??
+              "Part of the selected range could not be read."}{" "}
+            Absent events here do not mean absent traffic — narrow the range or
+            retry before drawing conclusions.
+          </div>
+        </OzCard>
+      ) : null}
+
       {isColdStart ? (
         <OzEmptyState
           title="No network traffic events yet"
@@ -1163,6 +1176,13 @@ const ICONS = {
     </>,
   ),
   chevDown: baseIcon(<path d="m6 9 6 6 6-6" />),
+  warn: baseIcon(
+    <>
+      <path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0Z" />
+      <path d="M12 9v4" />
+      <path d="M12 17h.01" />
+    </>,
+  ),
   refresh: baseIcon(
     <>
       <path d="M21 12a9 9 0 1 1-3.5-7.1" />

--- a/dashboard/src/modules/network-traffic/v2/NetworkTrafficV2.tsx
+++ b/dashboard/src/modules/network-traffic/v2/NetworkTrafficV2.tsx
@@ -242,6 +242,18 @@ export default function NetworkTrafficV2() {
     return `/network-traffic-events?${qs}`;
   }, [range]);
 
+  // A range with a start and no end is the calendar mid-selection: the
+  // first click of a two-click pick. DateRangePickerV2 emits it, so
+  // without this the picker fires a query for "from that date onward",
+  // which on the archive side means from that date to the retention
+  // boundary. Picking a start date in June asked for two months of cold
+  // storage nobody wanted, took 280s, exceeded the query deadline, and
+  // occupied one of four archive slots the whole time.
+  //
+  // A half-picked range is a UI state, not a question. Presets are
+  // unaffected — every one of them carries both bounds.
+  const rangeSettled = !range?.from || !!range?.to;
+
   // Held until the default range has been decided, so the page issues
   // one request with the operator's window rather than an unbounded one
   // followed by the real one. An operator who chose "all" still gets an
@@ -254,7 +266,7 @@ export default function NetworkTrafficV2() {
     queryUrl,
     false,
     true,
-    defaultApplied,
+    defaultApplied && rangeSettled,
   );
 
   // Holding the request makes SWR's key null, and a null key reports
@@ -263,7 +275,7 @@ export default function NetworkTrafficV2() {
   // show", so without folding the hold into it the mount renders the
   // cold-start panel over an empty groups array and then replaces it
   // with the table a moment later.
-  const isLoading = eventsLoading || !defaultApplied;
+  const isLoading = eventsLoading || !defaultApplied || !rangeSettled;
 
   const groups = useMemo(
     () =>

--- a/flow/store/federated/federated.go
+++ b/flow/store/federated/federated.go
@@ -128,9 +128,21 @@ func (f *Federated) Query(ctx context.Context, filter store.Filter) ([]*store.Ev
 
 // queryBoth fans out to hot + archive in parallel, merges by
 // ReceivedAt desc, and applies the caller's Limit / Offset on the
-// merged stream. A failure on either side is logged but does not
-// fail the whole call — operators get partial data with a warning,
-// which is better than an empty result during a bucket outage.
+// merged stream.
+//
+// A failure on one side returns the other side's events together with a
+// store.IncompleteError. Dropping the failed half and returning nil
+// error, which is what this used to do, is the worst available
+// behaviour: the caller renders a short list as if it were the whole
+// answer, and a gap in flow events reads as "nothing happened" rather
+// than "we could not look". The only record was a warning in a log
+// nobody reads while looking at a dashboard.
+//
+// Failing outright is not better either. It would take the hot path down
+// whenever the object store is slow, which is exactly when an operator
+// most wants to see recent traffic. So: both halves when both work, one
+// half plus a labelled error when one does not, and a real error only
+// when there is nothing to show.
 func (f *Federated) queryBoth(
 	ctx context.Context,
 	original, hotFilter, archFilter store.Filter,
@@ -166,7 +178,18 @@ func (f *Federated) queryBoth(
 	}
 
 	merged := mergeByReceivedAtDesc(hotEv, archEv)
-	return applyPaging(merged, original.Limit, original.Offset), nil
+	paged := applyPaging(merged, original.Limit, original.Offset)
+
+	// The window is named from the caller's point of view. "archive" and
+	// "hot" are storage details; what the caller lost is older events or
+	// recent ones.
+	if archErr != nil {
+		return paged, &store.IncompleteError{Missing: "older", Err: archErr}
+	}
+	if hotErr != nil {
+		return paged, &store.IncompleteError{Missing: "recent", Err: hotErr}
+	}
+	return paged, nil
 }
 
 // splitByBoundary chops the filter's time window so the hot side

--- a/flow/store/federated/federated.go
+++ b/flow/store/federated/federated.go
@@ -133,7 +133,7 @@ func (f *Federated) Query(ctx context.Context, filter store.Filter) ([]*store.Ev
 // A failure on one side returns the other side's events together with a
 // store.IncompleteError. Dropping the failed half and returning nil
 // error, which is what this used to do, is the worst available
-// behaviour: the caller renders a short list as if it were the whole
+// behavior: the caller renders a short list as if it were the whole
 // answer, and a gap in flow events reads as "nothing happened" rather
 // than "we could not look". The only record was a warning in a log
 // nobody reads while looking at a dashboard.
@@ -141,7 +141,7 @@ func (f *Federated) Query(ctx context.Context, filter store.Filter) ([]*store.Ev
 // Failing outright is not better either. It would take the hot path down
 // whenever the object store is slow, which is exactly when an operator
 // most wants to see recent traffic. So: both halves when both work, one
-// half plus a labelled error when one does not, and a real error only
+// half plus a labeled error when one does not, and a real error only
 // when there is nothing to show.
 func (f *Federated) queryBoth(
 	ctx context.Context,

--- a/flow/store/federated/federated_test.go
+++ b/flow/store/federated/federated_test.go
@@ -230,11 +230,21 @@ func TestQuery_AppliesPagingAfterMerge(t *testing.T) {
 	assert.Len(t, got, 2, "paging should apply across merged result")
 }
 
-// TestQuery_PartialFailure_HotOnly captures the resilience contract:
-// when the archive bucket is briefly unreachable, federated still
-// returns the hot half rather than failing the whole call. The
-// dashboard surfaces "incomplete" via the ProbeAvailability hook;
-// this test pins the behavior.
+// TestQuery_PartialFailure_HotOnly keeps the resilience half of the
+// contract and fixes the half that was never built. When the archive is
+// unreachable, federated still returns the hot events rather than
+// failing the whole call -- an operator should not lose sight of recent
+// traffic because an object store is slow.
+//
+// It used to also require a nil error, on the stated grounds that "the
+// dashboard surfaces incomplete via the ProbeAvailability hook". No such
+// hook exists in this path; the only ProbeAvailability in the tree is
+// the client's DNS resolver pool, which has nothing to do with flow
+// storage. So the resilience decision was made against a signal nobody
+// wrote, and the result shipped: a truncated list rendered as the whole
+// answer, with a gap in the data indistinguishable from a quiet period.
+//
+// The events still come back. They now come back labelled.
 func TestQuery_PartialFailure_HotOnly(t *testing.T) {
 	arch := &fakeStore{name: "arch", queryErr: errors.New("bucket unreachable")}
 	hot := &fakeStore{
@@ -249,8 +259,12 @@ func TestQuery_PartialFailure_HotOnly(t *testing.T) {
 		AccountID: "a",
 		Since:     fixedNow().Add(-50 * 24 * time.Hour),
 	})
-	require.NoError(t, err, "hot success should mask archive failure")
-	assert.Len(t, got, 1)
+	assert.Len(t, got, 1, "the readable half is still served")
+
+	var incomplete *store.IncompleteError
+	require.ErrorAs(t, err, &incomplete,
+		"the caller has to be able to tell a short answer from a complete one")
+	assert.Equal(t, "older", incomplete.Missing)
 }
 
 // TestQuery_BothFailed_PropagatesError ensures we never silently

--- a/flow/store/federated/federated_test.go
+++ b/flow/store/federated/federated_test.go
@@ -244,7 +244,7 @@ func TestQuery_AppliesPagingAfterMerge(t *testing.T) {
 // wrote, and the result shipped: a truncated list rendered as the whole
 // answer, with a gap in the data indistinguishable from a quiet period.
 //
-// The events still come back. They now come back labelled.
+// The events still come back. They now come back labeled.
 func TestQuery_PartialFailure_HotOnly(t *testing.T) {
 	arch := &fakeStore{name: "arch", queryErr: errors.New("bucket unreachable")}
 	hot := &fakeStore{

--- a/flow/store/federated/incomplete_test.go
+++ b/flow/store/federated/incomplete_test.go
@@ -104,7 +104,7 @@ func TestQueryStaysCleanWhenBothSidesWork(t *testing.T) {
 		Until:     now,
 		Limit:     100,
 	})
-	require.NoError(t, err, "a complete answer must not be labelled incomplete")
+	require.NoError(t, err, "a complete answer must not be labeled incomplete")
 	require.Len(t, events, 2)
 }
 

--- a/flow/store/federated/incomplete_test.go
+++ b/flow/store/federated/incomplete_test.go
@@ -1,0 +1,134 @@
+package federated
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openzro/openzro/flow/store"
+)
+
+// Reuses fakeStore from federated_test.go; these tests only need to
+// steer what each side returns.
+func hotAnd(hot, arch *fakeStore) *Federated {
+	f, err := New(hot, arch, 720*time.Hour)
+	if err != nil {
+		panic(err)
+	}
+	return f
+}
+
+func at(t time.Time) *store.Event { return &store.Event{ReceivedAt: t, AccountID: "acct-1"} }
+
+// A window that spans both sources, with the archive failing, used to
+// return the hot events and a nil error. The caller then rendered a
+// short list as the whole answer -- and a gap in flow events reads as
+// "nothing happened", which is the most damaging wrong conclusion this
+// screen can produce.
+//
+// Observed in production: a 280s archive timeout returned HTTP 200
+// carrying only events newer than the retention boundary, for a window
+// that started a week earlier. The only trace was a warning in a log
+// nobody reads while looking at a dashboard.
+func TestQueryReportsWhenOneSideFailed(t *testing.T) {
+	now := time.Now().UTC()
+	boundary := now.Add(-720 * time.Hour)
+
+	hotEvent := at(boundary.Add(24 * time.Hour))
+	f := hotAnd(
+		&fakeStore{name: "hot", queryResult: []*store.Event{hotEvent}},
+		&fakeStore{name: "archive", queryErr: context.DeadlineExceeded},
+	)
+
+	events, err := f.Query(context.Background(), store.Filter{
+		AccountID: "acct-1",
+		Since:     boundary.Add(-48 * time.Hour),
+		Until:     now,
+		Limit:     100,
+	})
+
+	require.Len(t, events, 1, "the readable half must still be served")
+	require.Equal(t, hotEvent, events[0])
+
+	var incomplete *store.IncompleteError
+	require.ErrorAs(t, err, &incomplete,
+		"a short answer must say so; nil error here is what made the dashboard lie")
+	require.Equal(t, "older", incomplete.Missing,
+		"named from the caller's side: what they lost is older events, not 'the archive'")
+	require.ErrorIs(t, err, context.DeadlineExceeded, "the cause has to survive for logs")
+}
+
+// The mirror case. The hot store failing is rarer but reads the same
+// way, and gets the same treatment with the other label.
+func TestQueryReportsWhenTheHotSideFailed(t *testing.T) {
+	now := time.Now().UTC()
+	boundary := now.Add(-720 * time.Hour)
+	archEvent := at(boundary.Add(-24 * time.Hour))
+
+	f := hotAnd(
+		&fakeStore{name: "hot", queryErr: errors.New("postgres is down")},
+		&fakeStore{name: "archive", queryResult: []*store.Event{archEvent}},
+	)
+
+	events, err := f.Query(context.Background(), store.Filter{
+		AccountID: "acct-1",
+		Since:     boundary.Add(-48 * time.Hour),
+		Until:     now,
+		Limit:     100,
+	})
+
+	require.Len(t, events, 1)
+	var incomplete *store.IncompleteError
+	require.ErrorAs(t, err, &incomplete)
+	require.Equal(t, "recent", incomplete.Missing)
+}
+
+// Both working must stay exactly as it was: no error, both halves
+// merged. If this drifted, every complete answer would start carrying a
+// warning and the signal would be worth nothing.
+func TestQueryStaysCleanWhenBothSidesWork(t *testing.T) {
+	now := time.Now().UTC()
+	boundary := now.Add(-720 * time.Hour)
+
+	f := hotAnd(
+		&fakeStore{name: "hot", queryResult: []*store.Event{at(boundary.Add(time.Hour))}},
+		&fakeStore{name: "archive", queryResult: []*store.Event{at(boundary.Add(-time.Hour))}},
+	)
+
+	events, err := f.Query(context.Background(), store.Filter{
+		AccountID: "acct-1",
+		Since:     boundary.Add(-48 * time.Hour),
+		Until:     now,
+		Limit:     100,
+	})
+	require.NoError(t, err, "a complete answer must not be labelled incomplete")
+	require.Len(t, events, 2)
+}
+
+// Both failing still fails outright. There is nothing to show, so
+// pretending otherwise would be the same lie in a different shape.
+func TestQueryFailsWhenBothSidesFail(t *testing.T) {
+	now := time.Now().UTC()
+	boundary := now.Add(-720 * time.Hour)
+
+	f := hotAnd(
+		&fakeStore{name: "hot", queryErr: errors.New("postgres is down")},
+		&fakeStore{name: "archive", queryErr: context.DeadlineExceeded},
+	)
+
+	events, err := f.Query(context.Background(), store.Filter{
+		AccountID: "acct-1",
+		Since:     boundary.Add(-48 * time.Hour),
+		Until:     now,
+		Limit:     100,
+	})
+	require.Error(t, err)
+	require.Empty(t, events)
+
+	var incomplete *store.IncompleteError
+	require.False(t, errors.As(err, &incomplete),
+		"nothing readable is a failure, not an incomplete result")
+}

--- a/flow/store/store.go
+++ b/flow/store/store.go
@@ -19,6 +19,7 @@ package store
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 )
 
@@ -148,3 +149,34 @@ type Store interface {
 	// this as DROP PARTITION rather than DELETE for O(1) cost.
 	Purge(ctx context.Context, olderThan time.Time) (int64, error)
 }
+
+// IncompleteError reports that a query was answered from more than one
+// source and at least one source failed. The events returned alongside
+// it are real and correctly ordered; they are simply not all of them.
+//
+// It exists because the alternative shapes are both wrong. Returning
+// nil error throws away the only evidence that the answer is short, and
+// an absence of events reads as "nothing happened" — the most damaging
+// wrong conclusion this data can produce, since the screen is used to
+// investigate incidents. Returning a plain error throws away events that
+// were fetched successfully, and makes a slow object store take the hot
+// path down with it.
+//
+// Callers that do not know about this type treat it as a failure, which
+// is the safe default: they report a problem instead of a truncated
+// answer. Callers that do know can serve the events and say what is
+// missing.
+type IncompleteError struct {
+	// Missing names the half of the window that could not be read, in
+	// the caller's terms rather than the storage layer's: "older" or
+	// "recent", not "archive" or "hot".
+	Missing string
+	// Err is the underlying failure, kept for logs and errors.Is.
+	Err error
+}
+
+func (e *IncompleteError) Error() string {
+	return fmt.Sprintf("incomplete result: %s events could not be read: %v", e.Missing, e.Err)
+}
+
+func (e *IncompleteError) Unwrap() error { return e.Err }

--- a/management/server/http/handlers/network_events/network_events_handler.go
+++ b/management/server/http/handlers/network_events/network_events_handler.go
@@ -80,7 +80,7 @@ func (h *Handler) list(w http.ResponseWriter, r *http.Request) {
 
 	events, err := h.store.Query(r.Context(), filter)
 	// A partly-readable window answers with the events it has plus a
-	// labelled error. Serving them is right -- recent traffic should not
+	// labeled error. Serving them is right -- recent traffic should not
 	// go dark because an object store is slow -- but only if the caller
 	// is told the answer is short. Anything else reports a gap in the
 	// data as a gap in the traffic.

--- a/management/server/http/handlers/network_events/network_events_handler.go
+++ b/management/server/http/handlers/network_events/network_events_handler.go
@@ -13,6 +13,7 @@ package network_events
 import (
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -78,6 +79,16 @@ func (h *Handler) list(w http.ResponseWriter, r *http.Request) {
 	}
 
 	events, err := h.store.Query(r.Context(), filter)
+	// A partly-readable window answers with the events it has plus a
+	// labelled error. Serving them is right -- recent traffic should not
+	// go dark because an object store is slow -- but only if the caller
+	// is told the answer is short. Anything else reports a gap in the
+	// data as a gap in the traffic.
+	var incomplete *store.IncompleteError
+	if errors.As(err, &incomplete) {
+		writeIncompleteResponse(w, events, filter.Offset, filter.Limit, incomplete)
+		return
+	}
 	if err != nil {
 		util.WriteError(r.Context(), err, w)
 		return
@@ -230,6 +241,17 @@ type response struct {
 	Events []eventDTO `json:"events"`
 	Limit  int        `json:"limit"`
 	Offset int        `json:"offset"`
+	// Incomplete marks a result that is real but short: part of the
+	// requested window could not be read. Omitted when the answer is
+	// whole, so a complete response is byte-identical to what clients
+	// received before this field existed.
+	//
+	// It matters more than it looks. Flow events are read to find out
+	// what happened, and a missing half looks exactly like a quiet
+	// period. Without this the only trace was a warning in a server log,
+	// which is not where anyone is looking while staring at a dashboard.
+	Incomplete       bool   `json:"incomplete,omitempty"`
+	IncompleteReason string `json:"incomplete_reason,omitempty"`
 }
 
 // eventDTO is the wire shape per event. Bytes-typed fields go on the
@@ -334,18 +356,47 @@ func formatDirection(d store.Direction) string {
 	return "unknown"
 }
 
-func writeListResponse(w http.ResponseWriter, events []*store.Event, offset, limit int) {
+// writeIncompleteResponse serves what was readable and says what was
+// not. Still 200: the events are real, the ordering is real, and the
+// caller asked for a page of them. The status code cannot express "here,
+// but short", so the body does.
+func writeIncompleteResponse(
+	w http.ResponseWriter,
+	events []*store.Event,
+	offset, limit int,
+	incomplete *store.IncompleteError,
+) {
+	writeResponse(w, response{
+		Events:     toDTOs(events),
+		Limit:      limit,
+		Offset:     offset,
+		Incomplete: true,
+		IncompleteReason: fmt.Sprintf(
+			"%s events could not be read, so this list may be missing entries",
+			incomplete.Missing),
+	})
+}
+
+func toDTOs(events []*store.Event) []eventDTO {
 	dtos := make([]eventDTO, len(events))
 	for i, e := range events {
 		dtos[i] = toDTO(e)
 	}
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusOK)
-	if err := json.NewEncoder(w).Encode(response{
-		Events: dtos,
+	return dtos
+}
+
+func writeListResponse(w http.ResponseWriter, events []*store.Event, offset, limit int) {
+	writeResponse(w, response{
+		Events: toDTOs(events),
 		Limit:  limit,
 		Offset: offset,
-	}); err != nil {
+	})
+}
+
+func writeResponse(w http.ResponseWriter, body response) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	if err := json.NewEncoder(w).Encode(body); err != nil {
 		// Encoding failure is a programming bug, not an operator
 		// problem — log loud rather than try to recover.
 		_, _ = fmt.Fprintf(w, "encode response: %v", err)

--- a/management/server/http/handlers/network_events/network_events_handler_test.go
+++ b/management/server/http/handlers/network_events/network_events_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -245,4 +246,59 @@ func TestList_RendersEventDTO(t *testing.T) {
 	// (older agents) round-trip via hex; that path is exercised by other
 	// cases.
 	assert.Equal(t, "rule-allow", e.RuleID)
+}
+
+// The store answering with events *and* an error is the shape a
+// partly-readable window produces. It has to reach the client as a 200
+// carrying the events, plus a marker saying the list is short.
+//
+// Serving the events is deliberate: recent traffic should not go dark
+// because an object store is slow. Marking them is the half that was
+// missing, and its absence is what let a 280s archive timeout return
+// HTTP 200 with only post-retention events for a window that began a
+// week earlier.
+func TestList_IncompleteResultIsServedAndMarked(t *testing.T) {
+	fs := &fakeStore{
+		out: []*store.Event{{EventID: []byte{0x01}, ReceivedAt: time.Now().UTC()}},
+		err: &store.IncompleteError{Missing: "older", Err: context.DeadlineExceeded},
+	}
+	rec := httptest.NewRecorder()
+	newServer(true, fs).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/network-traffic-events", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code,
+		"the events are real; the status code cannot say 'here, but short'")
+
+	var body struct {
+		Events           []map[string]any `json:"events"`
+		Incomplete       bool             `json:"incomplete"`
+		IncompleteReason string           `json:"incomplete_reason"`
+	}
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	require.Len(t, body.Events, 1, "the readable half must still be served")
+	require.True(t, body.Incomplete, "a short list rendered as complete is the bug")
+	require.Contains(t, body.IncompleteReason, "older",
+		"the reason must say which end is missing, so the reader knows where not to trust it")
+}
+
+// A complete answer must be byte-identical to what clients received
+// before the field existed. If every response carried the marker, it
+// would stop meaning anything.
+func TestList_CompleteResultCarriesNoMarker(t *testing.T) {
+	fs := &fakeStore{out: []*store.Event{{EventID: []byte{0x01}, ReceivedAt: time.Now().UTC()}}}
+	rec := httptest.NewRecorder()
+	newServer(true, fs).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/network-traffic-events", nil))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.NotContains(t, rec.Body.String(), "incomplete",
+		"omitempty keeps a whole answer indistinguishable from before this field")
+}
+
+// An error that is not an IncompleteError still fails the request. The
+// new path must not turn real outages into quiet 200s.
+func TestList_RealErrorStillFails(t *testing.T) {
+	fs := &fakeStore{err: errors.New("everything is down")}
+	rec := httptest.NewRecorder()
+	newServer(true, fs).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/network-traffic-events", nil))
+
+	require.GreaterOrEqual(t, rec.Code, 500, "nothing readable is a failure, not a short answer")
 }


### PR DESCRIPTION
Not too big — one commit, ~350 lines including tests.

## The bug

When a query spanned both stores and one side failed, the federated store returned the other side's events **and a nil error**. The caller rendered a short list as the complete answer.

Seen in production today, in the gateway access log:

```
15:37:00   280.8s   code=200   since=2026-07-30  until=-
```

The archive side hit its deadline; the hot side answered. The user asked for events from July 30 onward and got only events newer than the retention boundary (August 6), as a clean `200`. The only trace was a `WARN` in a server log.

This is the most damaging shape this data can take. Flow events are read to find out what happened, so a missing half does not look like a failure — **it looks like a quiet period**. A 500 tells you something broke; this tells you nothing happened.

## Why it shipped

The masking was deliberate, and the test pinned it:

```go
// The dashboard surfaces "incomplete" via the ProbeAvailability hook;
// this test pins the behavior.
require.NoError(t, err, "hot success should mask archive failure")
```

**No such hook exists in this path.** The only `ProbeAvailability` in the tree belongs to the client's DNS resolver pool (`client/internal/dns/`) and has nothing to do with flow storage. The resilience decision was made against a signal nobody had written.

## The fix

Serving the readable half **stays** — recent traffic should not go dark because an object store is slow, and failing outright would do exactly that. What changes is that the answer says it is short.

- `store.IncompleteError` carries which half was lost, named from the caller's side: `"older"` / `"recent"`, not `"archive"` / `"hot"`.
- The handler turns it into a `200` with `incomplete` + `incomplete_reason`. The status code cannot express "here, but short", so the body does.
- The page shows a banner: *absent events here do not mean absent traffic*.

Callers that do not know the type treat it as a failure, which is the safe default — they report a problem instead of a truncated answer.

## Tests

Two properties are load-bearing:

- **A complete answer stays byte-identical.** `omitempty` on both fields; if every response carried the marker it would mean nothing.
- **A non-`IncompleteError` error still fails.** Real outages must not become quiet 200s.

Mutations, both caught:

| Mutation | Caught by |
|---|---|
| handler ignores `IncompleteError` (old behaviour) | `List_IncompleteResultIsServedAndMarked` |
| federated returns nil error again (old behaviour) | `PartialFailure_HotOnly`, `ReportsWhenOneSideFailed`, `ReportsWhenTheHotSideFailed` |

`TestQuery_PartialFailure_HotOnly` was updated rather than deleted: its resilience half was right and is kept, its nil-error half rested on the hook that does not exist. The comment now records that, because the next person to read it deserves to know why the original reasoning failed.

## Note

`NetworkTrafficEventsResponse` in `openapi.yml` is **not** this endpoint's schema — the path is not in the spec and the handler serialises a local struct. I edited the spec first and reverted it. Worth knowing before someone changes the wrong type.