### PR TITLE
feat(flow/archive): compact the archive into one object per account-day

### DIFF
--- a/docs/operator/upgrade-notes.md
+++ b/docs/operator/upgrade-notes.md
@@ -39,7 +39,7 @@ serialization changes.
 
 If you archive flow events to S3 or GCS in Parquet, see **Flow archive**
 below before upgrading. Nothing breaks if you skip this, but the check is
-easier to interpret before the reader's behaviour changes.
+easier to interpret before the reader's behavior changes.
 
 ### After upgrading
 
@@ -141,7 +141,7 @@ object is still under the wrong prefix.
 
 **To find out whether you are affected**, run these against your archive
 with the DuckDB CLI. Substitute your bucket, prefix and scheme (`s3://`
-or `gs://`), and configure credentials as your DuckDB install expects.
+or `gcs://`), and configure credentials as your DuckDB install expects.
 
 ```sql
 -- Events filed under the wrong account.
@@ -179,6 +179,55 @@ it set. The reader now reads that value to size how far its partition
 filter reaches back, because a long flush is exactly what produced
 objects whose contents predate their own name. Lowering or unsetting it
 after the fact can hide older events written under the previous setting.
+
+**Archive compaction is available as an explicit operator action.** Use
+it only if the detection queries above return rows and the archive is
+used for audit or compliance, not just dashboard history. It is not a
+background task and management never runs it automatically.
+
+Build management with DuckDB support and run:
+
+```sh
+openzro-mgmt flow-archive compact \
+  --from 2026-06-01 \
+  --to 2026-06-30 \
+  --manifest /path/to/flow-archive-compact-2026-06.jsonl
+```
+
+The command is a dry run unless `--delete-originals` is present. It
+requires `--from`, `--to` and `--manifest`, writes a JSONL manifest to a
+new file, and refuses to overwrite an existing manifest. Dates are UTC
+and inclusive. Today and yesterday are skipped because a sink may still
+be writing those partitions. In dry-run entries, the manifest reports
+planned replacement size as `bytes_planned`; `bytes_written` remains
+zero because nothing was written to the bucket.
+
+The command reads archive bucket settings from the same
+`OPENZRO_FLOW_ARCHIVE_*` environment variables as management; non-secret
+values can be overridden with flags. Secrets stay in environment
+variables or credential files rather than command-line arguments, so they
+do not land in shell history. For GCS, the DuckDB read side still needs
+`OPENZRO_FLOW_ARCHIVE_GCS_HMAC_KEY_ID` and
+`OPENZRO_FLOW_ARCHIVE_GCS_HMAC_SECRET`, while writes/deletes use the
+service-account credential path already used by the GCS sink.
+
+Keep `--concurrency` low unless the compaction pod has memory reserved
+for it. Each worker opens its own DuckDB handle, and
+`OPENZRO_FLOW_ARCHIVE_MEMORY_LIMIT` is per handle, not a global cap; the
+default `--concurrency 1` is deliberately conservative. Verification
+also has to re-read the replacement objects from the bucket. Today that
+read is scoped by the compaction run ID rather than a narrow day range,
+so very large archives pay extra object listing cost during backfills.
+That cost is accepted to keep the delete gate simple and auditable.
+
+To actually replace objects after reviewing the dry-run manifest, repeat
+the same command with `--delete-originals`. The compactor writes
+replacement objects, re-reads what landed in the bucket, compares a row
+fingerprint, and only then deletes the original keys it listed at the
+start of that day. If deletion fails before any original was removed, the
+replacement is cleaned up. If deletion fails after at least one original
+was removed, the replacement is kept; this can temporarily duplicate cold
+results for that day, but it avoids losing the only good copy.
 
 
 ## v0.53.1-alpha.89

--- a/flow/store/archive/compact/compact.go
+++ b/flow/store/archive/compact/compact.go
@@ -51,12 +51,16 @@ func (f Fingerprint) String() string {
 // rather than assumed, because the operation ends in a delete and an
 // operator asked to trust it deserves the arithmetic.
 type Result struct {
-	Day            time.Time
-	ObjectsBefore  int
-	ObjectsAfter   int
-	Rows           int64
-	BytesWritten   int64
-	Accounts       []string
+	Day           time.Time
+	ObjectsBefore int
+	ObjectsAfter  int
+	Rows          int64
+	BytesWritten  int64
+	Accounts      []string
+	// Orphans names replacements this run wrote and then could not
+	// remove after refusing to finish. They are the operator's to delete;
+	// nothing else will, and the reader will trip over them.
+	Orphans        []string
 	Fingerprint    Fingerprint
 	Skipped        bool   // already compact; nothing was written or deleted
 	SkippedBecause string //nolint:revive // reported to the operator, not branched on
@@ -99,11 +103,12 @@ type Compactor struct {
 // is deleted until the replacement is written AND its row count matches
 // what was read. A compaction that loses rows leaves the originals in
 // place and says so.
-func (c *Compactor) CompactDay(ctx context.Context, day time.Time) (Result, error) {
+func (c *Compactor) CompactDay(ctx context.Context, day time.Time) (res Result, err error) {
 	day = day.UTC()
-	res := Result{Day: day}
+	res = Result{Day: day}
 
-	dayPrefix := c.dayPrefix(day)
+	rel := dayPath(day)
+	dayPrefix := c.keyPrefix(rel)
 	sources, err := c.Store.List(ctx, dayPrefix)
 	if err != nil {
 		return res, fmt.Errorf("list %s: %w", dayPrefix, err)
@@ -128,7 +133,7 @@ func (c *Compactor) CompactDay(ctx context.Context, day time.Time) (Result, erro
 	}
 	defer func() { _ = os.RemoveAll(tmp) }()
 
-	glob := c.dayGlob(day)
+	glob := c.url(rel + "/account=*/*.parquet")
 	before, err := c.fingerprint(ctx, glob)
 	if err != nil {
 		return res, fmt.Errorf("fingerprint sources: %w", err)
@@ -150,11 +155,11 @@ func (c *Compactor) CompactDay(ctx context.Context, day time.Time) (Result, erro
 		return res, fmt.Errorf("rewrite: %w", err)
 	}
 
-	written, err := collectOutputs(out)
+	outputs, err := collectOutputs(out)
 	if err != nil {
 		return res, fmt.Errorf("collect outputs: %w", err)
 	}
-	if len(written) == 0 {
+	if len(outputs) == 0 {
 		return res, fmt.Errorf("rewrite produced no files for %d rows", rowsBefore)
 	}
 
@@ -176,8 +181,28 @@ func (c *Compactor) CompactDay(ctx context.Context, day time.Time) (Result, erro
 	res.Fingerprint = after
 
 	stamp := c.now().UTC().UnixNano()
-	for _, w := range written {
-		body, err := os.ReadFile(w.path)
+	// Every key written this run, so a failure before the delete can
+	// take them back out. A half-written replacement left in the bucket
+	// is not inert: the reader globs the partition and opens whatever it
+	// finds, so a truncated parquet fails every query that touches the
+	// day -- turning a compaction that safely refused into an outage.
+	var writtenKeys []string
+	defer func() {
+		if err == nil {
+			return
+		}
+		for _, k := range writtenKeys {
+			if delErr := c.Store.Delete(ctx, k); delErr != nil {
+				// Best effort: the originals are intact either way, and
+				// the operator needs the name to finish the cleanup.
+				res.Orphans = append(res.Orphans, k)
+			}
+		}
+	}()
+
+	for _, w := range outputs {
+		var body []byte
+		body, err = os.ReadFile(w.path)
 		if err != nil {
 			return res, fmt.Errorf("read %s: %w", w.path, err)
 		}
@@ -185,22 +210,46 @@ func (c *Compactor) CompactDay(ctx context.Context, day time.Time) (Result, erro
 		// is where the zero padding in rewrite becomes load-bearing:
 		// these strings go straight into the object key the reader
 		// prunes on, and "month=7" is a directory no query will match.
-		key := fmt.Sprintf("%s/%s/compact-%d.parquet", c.rootPrefix(), w.partition(), stamp)
-		if err := c.Store.Put(ctx, key, body); err != nil {
+		key := c.keyPrefix(w.partition() + fmt.Sprintf("/compact-%d.parquet", stamp))
+		if err = c.Store.Write(ctx, key, body); err != nil {
 			// Nothing has been deleted yet, so a failure here costs a
 			// stray object and no data. The next run overwrites it.
-			return res, fmt.Errorf("put %s: %w", key, err)
+			return res, fmt.Errorf("write %s: %w", key, err)
 		}
+		writtenKeys = append(writtenKeys, key)
 		res.BytesWritten += int64(len(body))
 		res.Accounts = append(res.Accounts, w.account)
 		res.ObjectsAfter++
 	}
 
+	// Read the replacements back out of the store and fingerprint what
+	// actually landed there. Everything up to here proves the rewrite
+	// was right; this proves the write was. A Write that reported
+	// success while truncating, or a store that accepted bytes and
+	// returned different ones, is indistinguishable from success at
+	// every earlier step -- and the next step deletes the only other
+	// copy.
+	var written Fingerprint
+	written, err = c.fingerprint(ctx, c.url(fmt.Sprintf("year=*/month=*/day=*/account=*/compact-%d.parquet", stamp)))
+	if err != nil {
+		// Unreadable is as disqualifying as different, and says the same
+		// thing to the operator: the originals are still the only good
+		// copy, and they are still there.
+		return res, fmt.Errorf(
+			"refusing to delete: stored objects could not be read back; originals left untouched: %w", err)
+	}
+	if !before.Equal(written) {
+		return res, fmt.Errorf(
+			"refusing to delete: read [%s], stored [%s]; originals left untouched",
+			before, written)
+	}
+
 	// Only the keys listed at the start. Anything the sink wrote while
 	// this ran is not in that list and survives, which is why the list
-	// is taken once and not refreshed.
+	// is taken once and not refreshed -- and why a re-listed prefix at
+	// the end would be a way to delete data nobody inspected.
 	for _, key := range sources {
-		if err := c.Store.Delete(ctx, key); err != nil {
+		if err = c.Store.Delete(ctx, key); err != nil {
 			return res, fmt.Errorf("delete %s: %w", key, err)
 		}
 	}
@@ -252,21 +301,25 @@ func (c *Compactor) fingerprint(ctx context.Context, glob string) (Fingerprint, 
 	return f, nil
 }
 
-func (c *Compactor) dayPrefix(day time.Time) string {
-	p := fmt.Sprintf("year=%04d/month=%02d/day=%02d", day.Year(), int(day.Month()), day.Day())
+// dayPath is the day's location relative to the archive root, and the
+// only place the layout is spelled out. Both the object key and the
+// DuckDB URL are built by prefixing it, so neither is ever recovered by
+// trimming the other apart.
+func dayPath(day time.Time) string {
+	return fmt.Sprintf("year=%04d/month=%02d/day=%02d", day.Year(), int(day.Month()), day.Day())
+}
+
+// keyPrefix turns a root-relative path into an object key.
+func (c *Compactor) keyPrefix(rel string) string {
 	if c.KeyPrefix == "" {
-		return p
+		return rel
 	}
-	return c.rootPrefix() + "/" + p
+	return strings.TrimSuffix(c.KeyPrefix, "/") + "/" + rel
 }
 
-func (c *Compactor) rootPrefix() string {
-	return strings.TrimSuffix(c.KeyPrefix, "/")
-}
-
-func (c *Compactor) dayGlob(day time.Time) string {
-	return fmt.Sprintf("%s/%s/account=*/*.parquet",
-		strings.TrimSuffix(c.ReadRoot, "/"), trimPrefixPath(c.dayPrefix(day), c.KeyPrefix))
+// url turns a root-relative path into something DuckDB can read.
+func (c *Compactor) url(rel string) string {
+	return strings.TrimSuffix(c.ReadRoot, "/") + "/" + rel
 }
 
 func (c *Compactor) now() time.Time {
@@ -340,13 +393,6 @@ func onlyParquet(keys []string) []string {
 		}
 	}
 	return out
-}
-
-func trimPrefixPath(full, prefix string) string {
-	if prefix == "" {
-		return full
-	}
-	return strings.TrimPrefix(full, strings.TrimSuffix(prefix, "/")+"/")
 }
 
 // quote single-quotes a path for DuckDB, doubling any quote inside it.

--- a/flow/store/archive/compact/compact.go
+++ b/flow/store/archive/compact/compact.go
@@ -10,6 +10,43 @@ import (
 	"time"
 )
 
+// Fingerprint identifies a set of rows independently of how they are
+// grouped into files or ordered within them, which is what makes it
+// comparable across a rewrite that changes both.
+//
+// Three numbers, because none of them is sufficient alone:
+//
+//   - Rows catches loss, and nothing else. A rewrite that replaced one
+//     row with a different one keeps the count exactly.
+//   - XOR catches substitution, and is order-independent as required --
+//     but identical rows cancel each other out, so losing a matched pair
+//     leaves it unchanged. Measured, not assumed: two copies of the same
+//     row hash to 0.
+//   - Sum catches what XOR cancels, since duplicates accumulate rather
+//     than annihilate.
+//
+// The partition columns are excluded on both sides. They are derived
+// from the path on the way in and rebuilt from received_at on the way
+// out, and repartitioning changes them on purpose -- including them
+// would report every corrected row as a corrupted one.
+type Fingerprint struct {
+	Rows int64
+	// XOR and Sum are text because neither fits a Go integer: bit_xor
+	// returns UBIGINT and sum returns HUGEINT. They are compared, never
+	// arithmetic, so the width does not need to travel.
+	XOR string
+	Sum string
+}
+
+// Equal reports whether two fingerprints describe the same rows.
+func (f Fingerprint) Equal(o Fingerprint) bool {
+	return f.Rows == o.Rows && f.XOR == o.XOR && f.Sum == o.Sum
+}
+
+func (f Fingerprint) String() string {
+	return fmt.Sprintf("rows=%d xor=%s sum=%s", f.Rows, f.XOR, f.Sum)
+}
+
 // Result reports what one day's compaction did. Every field is measured
 // rather than assumed, because the operation ends in a delete and an
 // operator asked to trust it deserves the arithmetic.
@@ -20,6 +57,7 @@ type Result struct {
 	Rows           int64
 	BytesWritten   int64
 	Accounts       []string
+	Fingerprint    Fingerprint
 	Skipped        bool   // already compact; nothing was written or deleted
 	SkippedBecause string //nolint:revive // reported to the operator, not branched on
 }
@@ -91,10 +129,11 @@ func (c *Compactor) CompactDay(ctx context.Context, day time.Time) (Result, erro
 	defer func() { _ = os.RemoveAll(tmp) }()
 
 	glob := c.dayGlob(day)
-	rowsBefore, err := c.countRows(ctx, glob)
+	before, err := c.fingerprint(ctx, glob)
 	if err != nil {
-		return res, fmt.Errorf("count rows: %w", err)
+		return res, fmt.Errorf("fingerprint sources: %w", err)
 	}
+	rowsBefore := before.Rows
 	if rowsBefore == 0 {
 		res.Skipped = true
 		res.SkippedBecause = "no rows"
@@ -119,20 +158,22 @@ func (c *Compactor) CompactDay(ctx context.Context, day time.Time) (Result, erro
 		return res, fmt.Errorf("rewrite produced no files for %d rows", rowsBefore)
 	}
 
-	// Count what is about to replace the originals, from the files
+	// Fingerprint what is about to replace the originals, from the files
 	// themselves rather than from the statement that produced them. A
-	// COPY that silently dropped a row would otherwise be discovered by
-	// the operator, months later, as missing history.
-	rowsAfter, err := c.countRows(ctx, filepath.Join(out, "**", "*.parquet"))
+	// COPY that dropped or altered a row would otherwise be discovered
+	// by the operator months later, as missing or wrong history, with
+	// the originals long gone.
+	after, err := c.fingerprint(ctx, filepath.Join(out, "**", "*.parquet"))
 	if err != nil {
-		return res, fmt.Errorf("verify rows: %w", err)
+		return res, fmt.Errorf("fingerprint rewrite: %w", err)
 	}
-	if rowsAfter != rowsBefore {
+	if !before.Equal(after) {
 		return res, fmt.Errorf(
-			"refusing to delete: read %d rows, rewrote %d; originals left untouched",
-			rowsBefore, rowsAfter)
+			"refusing to delete: read [%s], rewrote [%s]; originals left untouched",
+			before, after)
 	}
-	res.Rows = rowsAfter
+	res.Rows = after.Rows
+	res.Fingerprint = after
 
 	stamp := c.now().UTC().UnixNano()
 	for _, w := range written {
@@ -188,11 +229,27 @@ func (c *Compactor) rewrite(ctx context.Context, glob, outDir string) error {
 	return err
 }
 
-func (c *Compactor) countRows(ctx context.Context, glob string) (int64, error) {
-	var n int64
-	err := c.DB.QueryRowContext(ctx,
-		"SELECT count(*) FROM read_parquet("+quote(glob)+", hive_partitioning=true)").Scan(&n)
-	return n, err
+// fingerprint reads a glob and summarises its rows. See Fingerprint for
+// why it is three numbers and why the partition columns are excluded.
+func (c *Compactor) fingerprint(ctx context.Context, glob string) (Fingerprint, error) {
+	var f Fingerprint
+	// Both as text: bit_xor returns UBIGINT and sum returns HUGEINT,
+	// and neither fits an int64 the driver would hand back.
+	var xor sql.NullString
+	var sum sql.NullString
+	err := c.DB.QueryRowContext(ctx, `SELECT count(*),
+		    CAST(bit_xor(hash(r)) AS VARCHAR),
+		    CAST(sum(hash(r)::HUGEINT) AS VARCHAR)
+		FROM (
+		    SELECT * EXCLUDE (year, month, day, account)
+		    FROM read_parquet(`+quote(glob)+`, hive_partitioning=true)
+		) r`).Scan(&f.Rows, &xor, &sum)
+	if err != nil {
+		return Fingerprint{}, err
+	}
+	f.XOR = xor.String
+	f.Sum = sum.String
+	return f, nil
 }
 
 func (c *Compactor) dayPrefix(day time.Time) string {

--- a/flow/store/archive/compact/compact.go
+++ b/flow/store/archive/compact/compact.go
@@ -113,25 +113,14 @@ func (c *Compactor) CompactDay(ctx context.Context, day time.Time) (res Result, 
 	if err != nil {
 		return res, fmt.Errorf("list %s: %w", dayPrefix, err)
 	}
-	sources = onlyParquet(sources)
+	sources = compactableParquet(sources, dayPrefix)
 	res.ObjectsBefore = len(sources)
 
-	// One object per account is the goal, so a day already at or below
-	// the number of accounts in it has nothing to gain and would only
-	// churn the bucket. Checking the count first also means a rerun over
-	// an already-compacted day is free rather than merely harmless.
-	if len(sources) <= 1 {
+	if len(sources) == 0 {
 		res.Skipped = true
-		res.SkippedBecause = "nothing to merge"
-		res.ObjectsAfter = len(sources)
+		res.SkippedBecause = "no source objects"
 		return res, nil
 	}
-
-	tmp, err := os.MkdirTemp("", "openzro-compact-")
-	if err != nil {
-		return res, fmt.Errorf("temp dir: %w", err)
-	}
-	defer func() { _ = os.RemoveAll(tmp) }()
 
 	glob := c.url(rel + "/account=*/*.parquet")
 	before, err := c.fingerprint(ctx, glob)
@@ -145,6 +134,25 @@ func (c *Compactor) CompactDay(ctx context.Context, day time.Time) (res Result, 
 		res.ObjectsAfter = len(sources)
 		return res, nil
 	}
+	res.Rows = before.Rows
+	res.Fingerprint = before
+
+	compact, err := c.isAlreadyCompact(ctx, glob, sources, dayPrefix)
+	if err != nil {
+		return res, fmt.Errorf("check compactness: %w", err)
+	}
+	if compact {
+		res.Skipped = true
+		res.SkippedBecause = "already compact"
+		res.ObjectsAfter = len(sources)
+		return res, nil
+	}
+
+	tmp, err := os.MkdirTemp("", "openzro-compact-")
+	if err != nil {
+		return res, fmt.Errorf("temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmp) }()
 
 	out := filepath.Join(tmp, "out")
 	rewrite := c.rewrite
@@ -254,6 +262,38 @@ func (c *Compactor) CompactDay(ctx context.Context, day time.Time) (res Result, 
 		}
 	}
 	return res, nil
+}
+
+// isAlreadyCompact reports whether the listed day is already in the
+// shape the reader expects: one object per path account, and every row
+// inside matching both that path account and that path date. A single
+// object is not enough evidence. Legacy batches can put another
+// account's rows, or another day's rows, into one otherwise-normal
+// object, and those are exactly the rows this tool exists to recover.
+func (c *Compactor) isAlreadyCompact(ctx context.Context, glob string, sources []string, dayPrefix string) (bool, error) {
+	accounts := make(map[string]struct{}, len(sources))
+	for _, k := range sources {
+		account, ok := sourceAccount(k, dayPrefix)
+		if !ok {
+			return false, fmt.Errorf("source %s is outside the compactable day layout", k)
+		}
+		accounts[account] = struct{}{}
+	}
+	if len(sources) != len(accounts) {
+		return false, nil
+	}
+
+	var mismatched int64
+	err := c.DB.QueryRowContext(ctx, `SELECT count(*)
+		FROM read_parquet(`+quote(glob)+`, hive_partitioning=true)
+		WHERE account_id <> CAST(account AS VARCHAR)
+		   OR printf('%04d', year(received_at)) <> CAST(year AS VARCHAR)
+		   OR printf('%02d', month(received_at)) <> CAST(month AS VARCHAR)
+		   OR printf('%02d', day(received_at)) <> CAST(day AS VARCHAR)`).Scan(&mismatched)
+	if err != nil {
+		return false, err
+	}
+	return mismatched == 0, nil
 }
 
 // rewrite is the whole merge. DuckDB reads the day, regroups by the
@@ -385,14 +425,36 @@ func collectOutputs(root string) ([]output, error) {
 	return out, err
 }
 
-func onlyParquet(keys []string) []string {
+func compactableParquet(keys []string, dayPrefix string) []string {
 	out := keys[:0:0]
 	for _, k := range keys {
-		if strings.HasSuffix(k, ".parquet") {
+		if strings.HasSuffix(k, ".parquet") && isCompactableDayObject(k, dayPrefix) {
 			out = append(out, k)
 		}
 	}
 	return out
+}
+
+func isCompactableDayObject(key, dayPrefix string) bool {
+	_, ok := sourceAccount(key, dayPrefix)
+	return ok
+}
+
+func sourceAccount(key, dayPrefix string) (string, bool) {
+	prefix := strings.TrimSuffix(dayPrefix, "/") + "/"
+	rel, ok := strings.CutPrefix(key, prefix)
+	if !ok {
+		return "", false
+	}
+	parts := strings.Split(rel, "/")
+	if len(parts) != 2 || !strings.HasSuffix(parts[1], ".parquet") {
+		return "", false
+	}
+	account, ok := strings.CutPrefix(parts[0], "account=")
+	if !ok || account == "" {
+		return "", false
+	}
+	return account, true
 }
 
 // quote single-quotes a path for DuckDB, doubling any quote inside it.

--- a/flow/store/archive/compact/compact.go
+++ b/flow/store/archive/compact/compact.go
@@ -1,0 +1,301 @@
+package compact
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Result reports what one day's compaction did. Every field is measured
+// rather than assumed, because the operation ends in a delete and an
+// operator asked to trust it deserves the arithmetic.
+type Result struct {
+	Day            time.Time
+	ObjectsBefore  int
+	ObjectsAfter   int
+	Rows           int64
+	BytesWritten   int64
+	Accounts       []string
+	Skipped        bool   // already compact; nothing was written or deleted
+	SkippedBecause string //nolint:revive // reported to the operator, not branched on
+}
+
+// Compactor rewrites one archive day at a time.
+//
+// It is deliberately not a service. Compaction reads a day, writes it
+// back, and deletes the originals; doing that on a schedule from outside
+// the request path keeps it away from the memory and CPU the API needs,
+// and makes a bad run something an operator can stop.
+type Compactor struct {
+	// DB is a DuckDB handle with the archive's credentials already
+	// applied, so read_parquet can reach the same objects the reader
+	// reads.
+	DB *sql.DB
+	// Store writes and deletes. See ObjectStore for why this is not
+	// DuckDB.
+	Store ObjectStore
+	// ReadRoot is the URL prefix DuckDB globs under, e.g.
+	// "gs://bucket/flows" or a local directory in tests.
+	ReadRoot string
+	// KeyPrefix is the same location expressed as an object key prefix,
+	// e.g. "flows". Empty for a bucket root.
+	KeyPrefix string
+	// Now supplies the clock for output names. Tests pin it.
+	Now func() time.Time
+
+	// rewriteFn is a seam. The row-count check below is the only thing
+	// standing between a bad rewrite and deleted history, and a
+	// guard that cannot be made to fire is a guard nobody has tested.
+	// Production leaves this nil and gets the real rewrite.
+	rewriteFn func(ctx context.Context, glob, outDir string) error
+}
+
+// CompactDay rewrites every object for one UTC day into one object per
+// account, then deletes what it replaced.
+//
+// The order is the safety property, and it only reads one way: nothing
+// is deleted until the replacement is written AND its row count matches
+// what was read. A compaction that loses rows leaves the originals in
+// place and says so.
+func (c *Compactor) CompactDay(ctx context.Context, day time.Time) (Result, error) {
+	day = day.UTC()
+	res := Result{Day: day}
+
+	dayPrefix := c.dayPrefix(day)
+	sources, err := c.Store.List(ctx, dayPrefix)
+	if err != nil {
+		return res, fmt.Errorf("list %s: %w", dayPrefix, err)
+	}
+	sources = onlyParquet(sources)
+	res.ObjectsBefore = len(sources)
+
+	// One object per account is the goal, so a day already at or below
+	// the number of accounts in it has nothing to gain and would only
+	// churn the bucket. Checking the count first also means a rerun over
+	// an already-compacted day is free rather than merely harmless.
+	if len(sources) <= 1 {
+		res.Skipped = true
+		res.SkippedBecause = "nothing to merge"
+		res.ObjectsAfter = len(sources)
+		return res, nil
+	}
+
+	tmp, err := os.MkdirTemp("", "openzro-compact-")
+	if err != nil {
+		return res, fmt.Errorf("temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmp) }()
+
+	glob := c.dayGlob(day)
+	rowsBefore, err := c.countRows(ctx, glob)
+	if err != nil {
+		return res, fmt.Errorf("count rows: %w", err)
+	}
+	if rowsBefore == 0 {
+		res.Skipped = true
+		res.SkippedBecause = "no rows"
+		res.ObjectsAfter = len(sources)
+		return res, nil
+	}
+
+	out := filepath.Join(tmp, "out")
+	rewrite := c.rewrite
+	if c.rewriteFn != nil {
+		rewrite = c.rewriteFn
+	}
+	if err := rewrite(ctx, glob, out); err != nil {
+		return res, fmt.Errorf("rewrite: %w", err)
+	}
+
+	written, err := collectOutputs(out)
+	if err != nil {
+		return res, fmt.Errorf("collect outputs: %w", err)
+	}
+	if len(written) == 0 {
+		return res, fmt.Errorf("rewrite produced no files for %d rows", rowsBefore)
+	}
+
+	// Count what is about to replace the originals, from the files
+	// themselves rather than from the statement that produced them. A
+	// COPY that silently dropped a row would otherwise be discovered by
+	// the operator, months later, as missing history.
+	rowsAfter, err := c.countRows(ctx, filepath.Join(out, "**", "*.parquet"))
+	if err != nil {
+		return res, fmt.Errorf("verify rows: %w", err)
+	}
+	if rowsAfter != rowsBefore {
+		return res, fmt.Errorf(
+			"refusing to delete: read %d rows, rewrote %d; originals left untouched",
+			rowsBefore, rowsAfter)
+	}
+	res.Rows = rowsAfter
+
+	stamp := c.now().UTC().UnixNano()
+	for _, w := range written {
+		body, err := os.ReadFile(w.path)
+		if err != nil {
+			return res, fmt.Errorf("read %s: %w", w.path, err)
+		}
+		// Keyed by the partition DuckDB derived from received_at. This
+		// is where the zero padding in rewrite becomes load-bearing:
+		// these strings go straight into the object key the reader
+		// prunes on, and "month=7" is a directory no query will match.
+		key := fmt.Sprintf("%s/%s/compact-%d.parquet", c.rootPrefix(), w.partition(), stamp)
+		if err := c.Store.Put(ctx, key, body); err != nil {
+			// Nothing has been deleted yet, so a failure here costs a
+			// stray object and no data. The next run overwrites it.
+			return res, fmt.Errorf("put %s: %w", key, err)
+		}
+		res.BytesWritten += int64(len(body))
+		res.Accounts = append(res.Accounts, w.account)
+		res.ObjectsAfter++
+	}
+
+	// Only the keys listed at the start. Anything the sink wrote while
+	// this ran is not in that list and survives, which is why the list
+	// is taken once and not refreshed.
+	for _, key := range sources {
+		if err := c.Store.Delete(ctx, key); err != nil {
+			return res, fmt.Errorf("delete %s: %w", key, err)
+		}
+	}
+	return res, nil
+}
+
+// rewrite is the whole merge. DuckDB reads the day, regroups by the
+// account each row actually carries, and writes one file per partition.
+//
+// The partition columns are rebuilt from received_at rather than carried
+// over, because carrying them over would preserve the misfiling this is
+// meant to undo. They are formatted, not cast: DuckDB's PARTITION_BY
+// writes an integer as "month=7", and the sinks write "month=07". The
+// reader compares those as strings, where '7' sorts after '07', so an
+// unpadded directory would be silently excluded from every query whose
+// window it should match.
+func (c *Compactor) rewrite(ctx context.Context, glob, outDir string) error {
+	_, err := c.DB.ExecContext(ctx, `COPY (
+		SELECT * EXCLUDE (year, month, day, account),
+		       printf('%04d', year(received_at))  AS year,
+		       printf('%02d', month(received_at)) AS month,
+		       printf('%02d', day(received_at))   AS day,
+		       account_id                         AS account
+		FROM read_parquet(`+quote(glob)+`, hive_partitioning=true)
+	) TO `+quote(outDir)+` (FORMAT PARQUET, PARTITION_BY (year, month, day, account), OVERWRITE_OR_IGNORE)`)
+	return err
+}
+
+func (c *Compactor) countRows(ctx context.Context, glob string) (int64, error) {
+	var n int64
+	err := c.DB.QueryRowContext(ctx,
+		"SELECT count(*) FROM read_parquet("+quote(glob)+", hive_partitioning=true)").Scan(&n)
+	return n, err
+}
+
+func (c *Compactor) dayPrefix(day time.Time) string {
+	p := fmt.Sprintf("year=%04d/month=%02d/day=%02d", day.Year(), int(day.Month()), day.Day())
+	if c.KeyPrefix == "" {
+		return p
+	}
+	return c.rootPrefix() + "/" + p
+}
+
+func (c *Compactor) rootPrefix() string {
+	return strings.TrimSuffix(c.KeyPrefix, "/")
+}
+
+func (c *Compactor) dayGlob(day time.Time) string {
+	return fmt.Sprintf("%s/%s/account=*/*.parquet",
+		strings.TrimSuffix(c.ReadRoot, "/"), trimPrefixPath(c.dayPrefix(day), c.KeyPrefix))
+}
+
+func (c *Compactor) now() time.Time {
+	if c.Now != nil {
+		return c.Now()
+	}
+	return time.Now()
+}
+
+// output is one file DuckDB's PARTITION_BY produced, with its partition
+// read back out of the directory it landed in.
+//
+// The partition is taken from the output and not from the day that was
+// asked for, and the difference is not academic. A day's objects can
+// hold rows belonging to another day: batches that crossed midnight were
+// filed under the earlier day before the sinks split by date. Writing
+// those rows back under the requested day would move the misfiling
+// rather than undo it -- and undoing it is the point.
+type output struct {
+	path             string
+	year, month, day string
+	account          string
+}
+
+// partition returns the object-key fragment this output belongs under,
+// which is DuckDB's own answer rather than the caller's assumption.
+func (o output) partition() string {
+	return fmt.Sprintf("year=%s/month=%s/day=%s/account=%s", o.year, o.month, o.day, o.account)
+}
+
+func collectOutputs(root string) ([]output, error) {
+	var out []output
+	err := filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !strings.HasSuffix(p, ".parquet") {
+			return nil
+		}
+		o := output{path: p}
+		for _, part := range strings.Split(filepath.ToSlash(p), "/") {
+			k, v, ok := strings.Cut(part, "=")
+			if !ok {
+				continue
+			}
+			switch k {
+			case "year":
+				o.year = v
+			case "month":
+				o.month = v
+			case "day":
+				o.day = v
+			case "account":
+				o.account = v
+			}
+		}
+		if o.year == "" || o.month == "" || o.day == "" || o.account == "" {
+			return fmt.Errorf("output %s is missing a partition component", p)
+		}
+		out = append(out, o)
+		return nil
+	})
+	return out, err
+}
+
+func onlyParquet(keys []string) []string {
+	out := keys[:0:0]
+	for _, k := range keys {
+		if strings.HasSuffix(k, ".parquet") {
+			out = append(out, k)
+		}
+	}
+	return out
+}
+
+func trimPrefixPath(full, prefix string) string {
+	if prefix == "" {
+		return full
+	}
+	return strings.TrimPrefix(full, strings.TrimSuffix(prefix, "/")+"/")
+}
+
+// quote single-quotes a path for DuckDB, doubling any quote inside it.
+// Paths come from operator configuration, never from request input, so
+// this is defence in depth rather than a live hole -- the same posture
+// the reader takes.
+func quote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}

--- a/flow/store/archive/compact/compact.go
+++ b/flow/store/archive/compact/compact.go
@@ -2,7 +2,9 @@ package compact
 
 import (
 	"context"
+	"crypto/rand"
 	"database/sql"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -61,6 +63,7 @@ type Result struct {
 	// remove after refusing to finish. They are the operator's to delete;
 	// nothing else will, and the reader will trip over them.
 	Orphans        []string
+	DryRun         bool
 	Fingerprint    Fingerprint
 	Skipped        bool   // already compact; nothing was written or deleted
 	SkippedBecause string //nolint:revive // reported to the operator, not branched on
@@ -81,17 +84,20 @@ type Compactor struct {
 	// DuckDB.
 	Store ObjectStore
 	// ReadRoot is the URL prefix DuckDB globs under, e.g.
-	// "gs://bucket/flows" or a local directory in tests.
+	// "gcs://bucket/flows" or a local directory in tests.
 	ReadRoot string
 	// KeyPrefix is the same location expressed as an object key prefix,
 	// e.g. "flows". Empty for a bucket root.
 	KeyPrefix string
 	// Now supplies the clock for output names. Tests pin it.
 	Now func() time.Time
+	// DryRun performs every read-side validation and local rewrite, but
+	// stops before writing replacements or deleting originals.
+	DryRun bool
 
-	// rewriteFn is a seam. The row-count check below is the only thing
-	// standing between a bad rewrite and deleted history, and a
-	// guard that cannot be made to fire is a guard nobody has tested.
+	// rewriteFn is a seam. The fingerprint check below is the only thing
+	// standing between a bad rewrite and deleted history, and a guard
+	// that cannot be made to fire is a guard nobody has tested.
 	// Production leaves this nil and gets the real rewrite.
 	rewriteFn func(ctx context.Context, glob, outDir string) error
 }
@@ -100,12 +106,12 @@ type Compactor struct {
 // account, then deletes what it replaced.
 //
 // The order is the safety property, and it only reads one way: nothing
-// is deleted until the replacement is written AND its row count matches
-// what was read. A compaction that loses rows leaves the originals in
-// place and says so.
+// is deleted until the replacement is written AND its fingerprint matches
+// what was read. A compaction that loses or changes rows leaves the
+// originals in place and says so.
 func (c *Compactor) CompactDay(ctx context.Context, day time.Time) (res Result, err error) {
 	day = day.UTC()
-	res = Result{Day: day}
+	res = Result{Day: day, DryRun: c.DryRun}
 
 	rel := dayPath(day)
 	dayPrefix := c.keyPrefix(rel)
@@ -188,15 +194,32 @@ func (c *Compactor) CompactDay(ctx context.Context, day time.Time) (res Result, 
 	res.Rows = after.Rows
 	res.Fingerprint = after
 
-	stamp := c.now().UTC().UnixNano()
+	if c.DryRun {
+		for _, w := range outputs {
+			info, statErr := os.Stat(w.path)
+			if statErr != nil {
+				return res, fmt.Errorf("stat %s: %w", w.path, statErr)
+			}
+			res.BytesWritten += info.Size()
+			res.Accounts = append(res.Accounts, w.account)
+			res.ObjectsAfter++
+		}
+		return res, nil
+	}
+
+	runID, err := c.runID()
+	if err != nil {
+		return res, err
+	}
 	// Every key written this run, so a failure before the delete can
 	// take them back out. A half-written replacement left in the bucket
 	// is not inert: the reader globs the partition and opens whatever it
 	// finds, so a truncated parquet fails every query that touches the
 	// day -- turning a compaction that safely refused into an outage.
 	var writtenKeys []string
+	cleanupWritten := true
 	defer func() {
-		if err == nil {
+		if err == nil || !cleanupWritten {
 			return
 		}
 		for _, k := range writtenKeys {
@@ -218,7 +241,7 @@ func (c *Compactor) CompactDay(ctx context.Context, day time.Time) (res Result, 
 		// is where the zero padding in rewrite becomes load-bearing:
 		// these strings go straight into the object key the reader
 		// prunes on, and "month=7" is a directory no query will match.
-		key := c.keyPrefix(w.partition() + fmt.Sprintf("/compact-%d.parquet", stamp))
+		key := c.keyPrefix(w.partition() + "/compact-" + runID + ".parquet")
 		if err = c.Store.Write(ctx, key, body); err != nil {
 			// Nothing has been deleted yet, so a failure here costs a
 			// stray object and no data. The next run overwrites it.
@@ -238,7 +261,7 @@ func (c *Compactor) CompactDay(ctx context.Context, day time.Time) (res Result, 
 	// every earlier step -- and the next step deletes the only other
 	// copy.
 	var written Fingerprint
-	written, err = c.fingerprint(ctx, c.url(fmt.Sprintf("year=*/month=*/day=*/account=*/compact-%d.parquet", stamp)))
+	written, err = c.fingerprint(ctx, c.url("year=*/month=*/day=*/account=*/compact-"+runID+".parquet"))
 	if err != nil {
 		// Unreadable is as disqualifying as different, and says the same
 		// thing to the operator: the originals are still the only good
@@ -260,6 +283,12 @@ func (c *Compactor) CompactDay(ctx context.Context, day time.Time) (res Result, 
 		if err = c.Store.Delete(ctx, key); err != nil {
 			return res, fmt.Errorf("delete %s: %w", key, err)
 		}
+		// Once any original has been removed, deleting the verified
+		// replacement is the data-loss path. Keep it even if a later
+		// original delete fails. If the very first delete fails, every
+		// original is still intact and the defer can remove the
+		// replacement to avoid duplicate query results.
+		cleanupWritten = false
 	}
 	return res, nil
 }
@@ -369,6 +398,14 @@ func (c *Compactor) now() time.Time {
 	return time.Now()
 }
 
+func (c *Compactor) runID() (string, error) {
+	var suffix [8]byte
+	if _, err := rand.Read(suffix[:]); err != nil {
+		return "", fmt.Errorf("compact: random run id: %w", err)
+	}
+	return fmt.Sprintf("%d-%s", c.now().UTC().UnixNano(), hex.EncodeToString(suffix[:])), nil
+}
+
 // output is one file DuckDB's PARTITION_BY produced, with its partition
 // read back out of the directory it landed in.
 //
@@ -459,7 +496,7 @@ func sourceAccount(key, dayPrefix string) (string, bool) {
 
 // quote single-quotes a path for DuckDB, doubling any quote inside it.
 // Paths come from operator configuration, never from request input, so
-// this is defence in depth rather than a live hole -- the same posture
+// this is defense in depth rather than a live hole -- the same posture
 // the reader takes.
 func quote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "''") + "'"

--- a/flow/store/archive/compact/compact.go
+++ b/flow/store/archive/compact/compact.go
@@ -336,6 +336,13 @@ func (c *Compactor) isAlreadyCompact(ctx context.Context, glob string, sources [
 // unpadded directory would be silently excluded from every query whose
 // window it should match.
 func (c *Compactor) rewrite(ctx context.Context, glob, outDir string) error {
+	// #nosec G202 -- glob and outDir are not request input. They are
+	// built from operator configuration and a date this command was
+	// given, and both go through quote(), which doubles any single
+	// quote. DuckDB resolves a file list while binding a statement, so a
+	// parameter in this position leaves the binder nothing to expand --
+	// that failure shipped once already (openzro#185) and is why these
+	// are interpolated at all.
 	_, err := c.DB.ExecContext(ctx, `COPY (
 		SELECT * EXCLUDE (year, month, day, account),
 		       printf('%04d', year(received_at))  AS year,
@@ -347,7 +354,7 @@ func (c *Compactor) rewrite(ctx context.Context, glob, outDir string) error {
 	return err
 }
 
-// fingerprint reads a glob and summarises its rows. See Fingerprint for
+// fingerprint reads a glob and summarizes its rows. See Fingerprint for
 // why it is three numbers and why the partition columns are excluded.
 func (c *Compactor) fingerprint(ctx context.Context, glob string) (Fingerprint, error) {
 	var f Fingerprint

--- a/flow/store/archive/compact/compact_test.go
+++ b/flow/store/archive/compact/compact_test.go
@@ -236,7 +236,8 @@ func TestCompactDayRefusesToDeleteWhenRowsAreLost(t *testing.T) {
 
 	_, err := c.CompactDay(context.Background(), time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "read 10 rows, rewrote 9")
+	require.Contains(t, err.Error(), "rows=10")
+	require.Contains(t, err.Error(), "rows=9")
 	require.Contains(t, err.Error(), "originals left untouched")
 	require.Empty(t, fs.deleted, "a short rewrite must not cost the originals")
 	require.Equal(t, 10, fs.count("flows"))
@@ -281,4 +282,60 @@ func TestCompactDayFilesRowsByTheirOwnDate(t *testing.T) {
 			"/flows/year=*/month=*/day=*/account=*/*.parquet', hive_partitioning=true) "+
 			"WHERE day(received_at) <> CAST(day AS INTEGER)").Scan(&stray))
 	require.Zero(t, stray, "no row may sit under a day other than its own")
+}
+
+// A row count catches loss and nothing else. This is the case it cannot
+// see: the rewrite emits exactly as many rows as it read, with one of
+// them changed. For an archive read back as audit evidence, silently
+// altered history is worse than missing history -- it is wrong and it
+// looks right.
+//
+// The substituted rewrite is not a strawman. A wrong join, a cast that
+// truncates an ID, a column mapped to its neighbour: all of them
+// preserve the count.
+func TestCompactDayRefusesWhenContentChangesButCountDoesNot(t *testing.T) {
+	c, fs, db := newFixture(t)
+	for i := range 10 {
+		seed(t, db, fs.root, "acct-A", "acct-A", day29+" 10:00:00", i)
+	}
+
+	c.rewriteFn = func(ctx context.Context, glob, outDir string) error {
+		dir := filepath.Join(outDir, "year=2026", "month=07", "day=29", "account=acct-A")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+		// Ten rows in, ten rows out, one peer_id rewritten.
+		_, err := db.ExecContext(ctx,
+			"COPY (SELECT * REPLACE (CASE WHEN event_id = 'ev-3' THEN 'tampered' ELSE peer_id END AS peer_id) "+
+				"FROM read_parquet("+quote(glob)+", hive_partitioning=true)) TO '"+
+				filepath.Join(dir, "same-count.parquet")+"' (FORMAT PARQUET)")
+		return err
+	}
+
+	_, err := c.CompactDay(context.Background(), time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
+	require.Error(t, err, "a count-preserving corruption must still be refused")
+	require.Contains(t, err.Error(), "rows=10", "both sides read ten rows; the count agreed")
+	require.Contains(t, err.Error(), "originals left untouched")
+	require.Empty(t, fs.deleted)
+	require.Equal(t, 10, fs.count("flows"))
+}
+
+// The fingerprint must not fire on the reordering compaction always
+// does. Merging 150 files into one changes row order by construction, so
+// an order-sensitive check would refuse every correct run and the guard
+// would be turned off within a week.
+func TestFingerprintIgnoresRowOrder(t *testing.T) {
+	c, fs, db := newFixture(t)
+	for i := range 12 {
+		acct := "acct-A"
+		if i%3 == 0 {
+			acct = "acct-B"
+		}
+		seed(t, db, fs.root, acct, acct, day29+fmt.Sprintf(" %02d:00:00", i), i)
+	}
+	res, err := c.CompactDay(context.Background(), time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err, "compaction reorders rows; that must not read as corruption")
+	require.Equal(t, int64(12), res.Rows)
+	require.NotEmpty(t, res.Fingerprint.XOR)
+	require.NotEmpty(t, res.Fingerprint.Sum)
 }

--- a/flow/store/archive/compact/compact_test.go
+++ b/flow/store/archive/compact/compact_test.go
@@ -1,0 +1,284 @@
+//go:build archive_duckdb
+
+package compact
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	_ "github.com/marcboeker/go-duckdb"
+	"github.com/stretchr/testify/require"
+)
+
+const day29 = "2026-07-29"
+
+func newFixture(t *testing.T) (*Compactor, *fsStore, *sql.DB) {
+	t.Helper()
+	db, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	root := t.TempDir()
+	fs := &fsStore{root: root}
+	return &Compactor{
+		DB:        db,
+		Store:     fs,
+		ReadRoot:  root + "/flows",
+		KeyPrefix: "flows",
+		Now:       func() time.Time { return time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC) },
+	}, fs, db
+}
+
+// seed writes one tiny object, the shape the sink produces: the account
+// in the path and the account in the row are separate facts, so they can
+// be made to disagree.
+func seed(t *testing.T, db *sql.DB, root, pathAccount, rowAccount, ts string, n int) {
+	t.Helper()
+	dir := filepath.Join(root, "flows", "year=2026", "month=07", "day=29", "account="+pathAccount)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	file := filepath.Join(dir, fmt.Sprintf("%d-%s.parquet", n, rowAccount))
+	_, err := db.ExecContext(context.Background(), fmt.Sprintf(
+		`COPY (SELECT TIMESTAMP '%s' AS received_at, '%s' AS account_id,
+		        'peer-%d' AS peer_id, 'ev-%d' AS event_id)
+		 TO '%s' (FORMAT PARQUET)`, ts, rowAccount, n, n, file))
+	require.NoError(t, err)
+}
+
+// The headline: many tiny objects become one per account, and no row is
+// lost doing it. 40 objects of a few hundred bytes is the production
+// shape in miniature -- a real day held ~150.
+func TestCompactDayMergesIntoOneObjectPerAccount(t *testing.T) {
+	c, fs, db := newFixture(t)
+	for i := range 40 {
+		acct := "acct-A"
+		if i%4 == 0 {
+			acct = "acct-B"
+		}
+		seed(t, db, fs.root, acct, acct, day29+fmt.Sprintf(" %02d:00:00", i%24), i)
+	}
+	require.Equal(t, 40, fs.count("flows"))
+
+	res, err := c.CompactDay(context.Background(), time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	require.False(t, res.Skipped)
+	require.Equal(t, 40, res.ObjectsBefore)
+	require.Equal(t, 2, res.ObjectsAfter, "one object per account, not per flush")
+	require.Equal(t, int64(40), res.Rows, "every row survives the rewrite")
+	require.Equal(t, 2, fs.count("flows"), "the originals are gone, the replacements are not")
+}
+
+// The layout has to match what the sink writes and what the reader
+// prunes on. DuckDB's PARTITION_BY writes month=7; the sinks write
+// month=07; the reader compares them as strings, where '7' sorts after
+// '07'. An unpadded directory would be silently excluded from every
+// query whose window it should match -- compaction would have broken
+// reads while appearing to succeed.
+func TestCompactDayWritesZeroPaddedPartitions(t *testing.T) {
+	c, fs, db := newFixture(t)
+	for i := range 4 {
+		seed(t, db, fs.root, "acct-A", "acct-A", day29+" 10:00:00", i)
+	}
+	_, err := c.CompactDay(context.Background(), time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+
+	keys, err := fs.List(context.Background(), "flows")
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	require.Contains(t, keys[0], "year=2026/month=07/day=29/account=acct-A/",
+		"got %q -- an unpadded month or day is invisible to the reader's partition filter", keys[0])
+}
+
+// Rows written under the wrong account before the sinks split batches
+// (openzro#186) must come back under the account that owns them. This is
+// the half that closing the leak could not do: the reader globs by
+// account, so a misfiled object is never opened by its rightful owner.
+func TestCompactDayRepartitionsMisfiledRows(t *testing.T) {
+	c, fs, db := newFixture(t)
+	// Ten objects filed under acct-A; three of them hold acct-B's rows.
+	for i := range 10 {
+		rowAcct := "acct-A"
+		if i < 3 {
+			rowAcct = "acct-B"
+		}
+		seed(t, db, fs.root, "acct-A", rowAcct, day29+" 10:00:00", i)
+	}
+
+	res, err := c.CompactDay(context.Background(), time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"acct-A", "acct-B"}, res.Accounts)
+
+	keys, err := fs.List(context.Background(), "flows")
+	require.NoError(t, err)
+	require.Len(t, keys, 2)
+
+	var rows int64
+	require.NoError(t, db.QueryRow(
+		"SELECT count(*) FROM read_parquet('"+fs.root+
+			"/flows/year=*/month=*/day=*/account=acct-B/*.parquet', hive_partitioning=true) "+
+			"WHERE account_id = 'acct-B'").Scan(&rows))
+	require.Equal(t, int64(3), rows, "acct-B's rows must now live under acct-B's path")
+
+	// And the path must no longer contradict the rows inside it, which
+	// is the invariant the whole layout rests on.
+	var mismatched int64
+	require.NoError(t, db.QueryRow(
+		"SELECT count(*) FROM read_parquet('"+fs.root+
+			"/flows/year=*/month=*/day=*/account=*/*.parquet', hive_partitioning=true) "+
+			"WHERE account_id <> account").Scan(&mismatched))
+	require.Zero(t, mismatched)
+}
+
+// The safety property, stated as a property rather than hoped for: a Put
+// that fails must leave every original in place. Compaction is the one
+// operation here that deletes data, so the failure mode that matters is
+// deleting before the replacement exists.
+func TestCompactDayKeepsOriginalsWhenWriteFails(t *testing.T) {
+	c, fs, db := newFixture(t)
+	for i := range 8 {
+		seed(t, db, fs.root, "acct-A", "acct-A", day29+" 10:00:00", i)
+	}
+	fs.putErr = errors.New("bucket refused the write")
+
+	_, err := c.CompactDay(context.Background(), time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
+	require.Error(t, err)
+	require.Empty(t, fs.deleted, "nothing may be deleted before the replacement is written")
+	require.Equal(t, 8, fs.count("flows"), "every original must still be there")
+}
+
+// A day that is already one object per account must cost nothing to
+// revisit. Without this a nightly job would rewrite and re-delete the
+// same data forever, and a rerun after a partial failure would churn
+// rather than converge.
+func TestCompactDayIsIdempotent(t *testing.T) {
+	c, fs, db := newFixture(t)
+	for i := range 6 {
+		seed(t, db, fs.root, "acct-A", "acct-A", day29+" 10:00:00", i)
+	}
+	d := time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC)
+
+	first, err := c.CompactDay(context.Background(), d)
+	require.NoError(t, err)
+	require.Equal(t, 1, first.ObjectsAfter)
+
+	second, err := c.CompactDay(context.Background(), d)
+	require.NoError(t, err)
+	require.True(t, second.Skipped, "a compacted day must be recognised as compacted")
+	require.Empty(t, second.Accounts)
+	require.Equal(t, 1, fs.count("flows"))
+	require.Len(t, fs.put, 1, "the second run must not write anything")
+}
+
+// A day with nothing in it is not an error. The nightly job will meet
+// plenty of them.
+func TestCompactDayEmptyIsNotAnError(t *testing.T) {
+	c, _, _ := newFixture(t)
+	res, err := c.CompactDay(context.Background(), time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	require.True(t, res.Skipped)
+	require.Zero(t, res.ObjectsBefore)
+}
+
+// Compaction must not touch the neighbours. A job running for the 29th
+// while the sink writes the 30th has to leave the 30th alone.
+func TestCompactDayLeavesOtherDaysAlone(t *testing.T) {
+	c, fs, db := newFixture(t)
+	for i := range 5 {
+		seed(t, db, fs.root, "acct-A", "acct-A", day29+" 10:00:00", i)
+	}
+	other := filepath.Join(fs.root, "flows", "year=2026", "month=07", "day=30", "account=acct-A")
+	require.NoError(t, os.MkdirAll(other, 0o755))
+	_, err := db.Exec("COPY (SELECT TIMESTAMP '2026-07-30 10:00:00' AS received_at, " +
+		"'acct-A' AS account_id, 'p' AS peer_id, 'e' AS event_id) TO '" +
+		filepath.Join(other, "x.parquet") + "' (FORMAT PARQUET)")
+	require.NoError(t, err)
+
+	_, err = c.CompactDay(context.Background(), time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+
+	require.Equal(t, 1, fs.count("flows/year=2026/month=07/day=30"),
+		"the next day belongs to the sink, not to this job")
+	for _, d := range fs.deleted {
+		require.NotContains(t, d, "day=30")
+	}
+}
+
+// The row-count check is the only thing between a bad rewrite and
+// deleted history, so it gets a test that makes it fire. A guard nobody
+// has seen trip is a guard nobody has tested.
+//
+// The substituted rewrite drops rows the way a subtly wrong COPY would:
+// it produces a valid, well-formed, correctly-partitioned output that is
+// simply short. That is the shape that would otherwise be discovered
+// months later as missing history, with the originals long gone.
+func TestCompactDayRefusesToDeleteWhenRowsAreLost(t *testing.T) {
+	c, fs, db := newFixture(t)
+	for i := range 10 {
+		seed(t, db, fs.root, "acct-A", "acct-A", day29+" 10:00:00", i)
+	}
+
+	c.rewriteFn = func(ctx context.Context, glob, outDir string) error {
+		dir := filepath.Join(outDir, "year=2026", "month=07", "day=29", "account=acct-A")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return err
+		}
+		// Nine rows where ten were read.
+		_, err := db.ExecContext(ctx,
+			"COPY (SELECT * FROM read_parquet("+quote(glob)+", hive_partitioning=true) LIMIT 9) TO '"+
+				filepath.Join(dir, "short.parquet")+"' (FORMAT PARQUET)")
+		return err
+	}
+
+	_, err := c.CompactDay(context.Background(), time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "read 10 rows, rewrote 9")
+	require.Contains(t, err.Error(), "originals left untouched")
+	require.Empty(t, fs.deleted, "a short rewrite must not cost the originals")
+	require.Equal(t, 10, fs.count("flows"))
+}
+
+// A day's objects can hold rows belonging to another day: before the
+// sinks split a batch by date, a flush crossing midnight filed its later
+// events under the earlier day. Compaction has to put those rows where
+// their timestamps say they go, not where they were found.
+//
+// Writing them back under the requested day would move the misfiling
+// instead of undoing it, and the result would look correct at every
+// level except the one that matters -- the reader prunes by these
+// directories, so the rows would stay unfindable by date.
+func TestCompactDayFilesRowsByTheirOwnDate(t *testing.T) {
+	c, fs, db := newFixture(t)
+	// Nine rows genuinely on the 29th, one that belongs to the 28th but
+	// was filed under the 29th by a batch that began before midnight.
+	for i := range 9 {
+		seed(t, db, fs.root, "acct-A", "acct-A", day29+" 10:00:00", i)
+	}
+	seed(t, db, fs.root, "acct-A", "acct-A", "2026-07-28 23:58:00", 99)
+
+	_, err := c.CompactDay(context.Background(), time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+
+	keys, err := fs.List(context.Background(), "flows")
+	require.NoError(t, err)
+	require.Len(t, keys, 2, "two dates in, two partitions out")
+
+	var got []string
+	for _, k := range keys {
+		got = append(got, k[:len("flows/year=2026/month=07/day=29")])
+	}
+	require.ElementsMatch(t,
+		[]string{"flows/year=2026/month=07/day=28", "flows/year=2026/month=07/day=29"},
+		got, "the row from the 28th must land under the 28th")
+
+	var stray int64
+	require.NoError(t, db.QueryRow(
+		"SELECT count(*) FROM read_parquet('"+fs.root+
+			"/flows/year=*/month=*/day=*/account=*/*.parquet', hive_partitioning=true) "+
+			"WHERE day(received_at) <> CAST(day AS INTEGER)").Scan(&stray))
+	require.Zero(t, stray, "no row may sit under a day other than its own")
+}

--- a/flow/store/archive/compact/compact_test.go
+++ b/flow/store/archive/compact/compact_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -173,6 +174,72 @@ func TestCompactDayKeepsOriginalsWhenWriteFails(t *testing.T) {
 	require.Equal(t, 8, fs.count("flows"), "every original must still be there")
 }
 
+func TestCompactDayKeepsVerifiedReplacementsWhenOriginalDeleteFails(t *testing.T) {
+	c, fs, db := newFixture(t)
+	for i := range 4 {
+		seed(t, db, fs.root, "acct-A", "acct-A", day29+" 10:00:00", i)
+	}
+	fs.deleteErr = errors.New("bucket refused the delete")
+	fs.deleteErrAfter = 1
+
+	_, err := c.CompactDay(context.Background(), time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "delete")
+
+	keys, err := fs.List(context.Background(), "flows")
+	require.NoError(t, err)
+	replacement := false
+	for _, k := range keys {
+		if strings.HasPrefix(k, "flows/year=2026/month=07/day=29/account=acct-A/compact-") {
+			replacement = true
+		}
+	}
+	require.True(t, replacement, "the verified replacement must survive; an original may already be gone")
+	require.Len(t, fs.deleted, 1, "the injected failure fires after one original delete")
+}
+
+func TestCompactDayRemovesReplacementWhenNoOriginalWasDeleted(t *testing.T) {
+	c, fs, db := newFixture(t)
+	for i := range 4 {
+		seed(t, db, fs.root, "acct-A", "acct-A", day29+" 10:00:00", i)
+	}
+	fs.deleteErr = errors.New("bucket refused the delete")
+	fs.deleteErrAfter = 0
+
+	_, err := c.CompactDay(context.Background(), time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "delete")
+
+	keys, err := fs.List(context.Background(), "flows")
+	require.NoError(t, err)
+	for _, k := range keys {
+		require.NotContains(t, k, "/compact-",
+			"if no original was removed, the replacement can be cleaned up without risking data loss")
+	}
+	require.Equal(t, 4, fs.count("flows"), "all originals must still be present")
+	require.Len(t, fs.deleted, 1, "only the cleaned-up replacement should be recorded as deleted")
+}
+
+func TestCompactDayDryRunDoesNotWriteOrDelete(t *testing.T) {
+	c, fs, db := newFixture(t)
+	c.DryRun = true
+	for i := range 8 {
+		seed(t, db, fs.root, "acct-A", "acct-A", day29+" 10:00:00", i)
+	}
+
+	res, err := c.CompactDay(context.Background(), time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	require.True(t, res.DryRun)
+	require.False(t, res.Skipped)
+	require.Equal(t, 8, res.ObjectsBefore)
+	require.Equal(t, 1, res.ObjectsAfter, "dry-run still reports the compacted shape")
+	require.Equal(t, int64(8), res.Rows)
+	require.NotZero(t, res.BytesWritten, "dry-run measures the bytes it would write")
+	require.Empty(t, fs.put, "dry-run must not write replacements")
+	require.Empty(t, fs.deleted, "dry-run must not delete originals")
+	require.Equal(t, 8, fs.count("flows"), "dry-run leaves source objects in place")
+}
+
 // A day that is already one object per account must cost nothing to
 // revisit. Without this a nightly job would rewrite and re-delete the
 // same data forever, and a rerun after a partial failure would churn
@@ -194,7 +261,7 @@ func TestCompactDayIsIdempotent(t *testing.T) {
 
 	second, err := c.CompactDay(context.Background(), d)
 	require.NoError(t, err)
-	require.True(t, second.Skipped, "a compacted day must be recognised as compacted")
+	require.True(t, second.Skipped, "a compacted day must be recognized as compacted")
 	require.Empty(t, second.Accounts)
 	require.Equal(t, 2, fs.count("flows"))
 	require.Len(t, fs.put, 2, "the second run must not write anything")
@@ -210,7 +277,7 @@ func TestCompactDayEmptyIsNotAnError(t *testing.T) {
 	require.Zero(t, res.ObjectsBefore)
 }
 
-// Compaction must not touch the neighbours. A job running for the 29th
+// Compaction must not touch the neighbors. A job running for the 29th
 // while the sink writes the 30th has to leave the 30th alone.
 func TestCompactDayLeavesOtherDaysAlone(t *testing.T) {
 	c, fs, db := newFixture(t)
@@ -234,9 +301,9 @@ func TestCompactDayLeavesOtherDaysAlone(t *testing.T) {
 	}
 }
 
-// The row-count check is the only thing between a bad rewrite and
-// deleted history, so it gets a test that makes it fire. A guard nobody
-// has seen trip is a guard nobody has tested.
+// The fingerprint check is the only thing between a bad rewrite and
+// deleted history, so it gets a test that makes the row-count part fire.
+// A guard nobody has seen trip is a guard nobody has tested.
 //
 // The substituted rewrite drops rows the way a subtly wrong COPY would:
 // it produces a valid, well-formed, correctly-partitioned output that is
@@ -360,7 +427,7 @@ func TestCompactDayLeavesParquetOutsideAccountPartitionAlone(t *testing.T) {
 // looks right.
 //
 // The substituted rewrite is not a strawman. A wrong join, a cast that
-// truncates an ID, a column mapped to its neighbour: all of them
+// truncates an ID, a column mapped to its neighbor: all of them
 // preserve the count.
 func TestCompactDayRefusesWhenContentChangesButCountDoesNot(t *testing.T) {
 	c, fs, db := newFixture(t)

--- a/flow/store/archive/compact/compact_test.go
+++ b/flow/store/archive/compact/compact_test.go
@@ -134,6 +134,28 @@ func TestCompactDayRepartitionsMisfiledRows(t *testing.T) {
 	require.Zero(t, mismatched)
 }
 
+func TestCompactDayRepartitionsSingleMisfiledObject(t *testing.T) {
+	c, fs, db := newFixture(t)
+	seed(t, db, fs.root, "acct-A", "acct-B", day29+" 10:00:00", 1)
+
+	res, err := c.CompactDay(context.Background(), time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	require.False(t, res.Skipped, "one source object can still be misfiled and need repair")
+	require.ElementsMatch(t, []string{"acct-B"}, res.Accounts)
+
+	keys, err := fs.List(context.Background(), "flows")
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	require.Contains(t, keys[0], "account=acct-B/")
+
+	var mismatched int64
+	require.NoError(t, db.QueryRow(
+		"SELECT count(*) FROM read_parquet('"+fs.root+
+			"/flows/year=*/month=*/day=*/account=*/*.parquet', hive_partitioning=true) "+
+			"WHERE account_id <> account").Scan(&mismatched))
+	require.Zero(t, mismatched)
+}
+
 // The safety property, stated as a property rather than hoped for: a Put
 // that fails must leave every original in place. Compaction is the one
 // operation here that deletes data, so the failure mode that matters is
@@ -158,20 +180,24 @@ func TestCompactDayKeepsOriginalsWhenWriteFails(t *testing.T) {
 func TestCompactDayIsIdempotent(t *testing.T) {
 	c, fs, db := newFixture(t)
 	for i := range 6 {
-		seed(t, db, fs.root, "acct-A", "acct-A", day29+" 10:00:00", i)
+		acct := "acct-A"
+		if i%2 == 0 {
+			acct = "acct-B"
+		}
+		seed(t, db, fs.root, acct, acct, day29+" 10:00:00", i)
 	}
 	d := time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC)
 
 	first, err := c.CompactDay(context.Background(), d)
 	require.NoError(t, err)
-	require.Equal(t, 1, first.ObjectsAfter)
+	require.Equal(t, 2, first.ObjectsAfter)
 
 	second, err := c.CompactDay(context.Background(), d)
 	require.NoError(t, err)
 	require.True(t, second.Skipped, "a compacted day must be recognised as compacted")
 	require.Empty(t, second.Accounts)
-	require.Equal(t, 1, fs.count("flows"))
-	require.Len(t, fs.put, 1, "the second run must not write anything")
+	require.Equal(t, 2, fs.count("flows"))
+	require.Len(t, fs.put, 2, "the second run must not write anything")
 }
 
 // A day with nothing in it is not an error. The nightly job will meet
@@ -282,6 +308,49 @@ func TestCompactDayFilesRowsByTheirOwnDate(t *testing.T) {
 			"/flows/year=*/month=*/day=*/account=*/*.parquet', hive_partitioning=true) "+
 			"WHERE day(received_at) <> CAST(day AS INTEGER)").Scan(&stray))
 	require.Zero(t, stray, "no row may sit under a day other than its own")
+}
+
+func TestCompactDayFilesSingleObjectRowsByTheirOwnDate(t *testing.T) {
+	c, fs, db := newFixture(t)
+	seed(t, db, fs.root, "acct-A", "acct-A", "2026-07-28 23:58:00", 99)
+
+	res, err := c.CompactDay(context.Background(), time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	require.False(t, res.Skipped, "one source object can still belong under a different day")
+
+	keys, err := fs.List(context.Background(), "flows")
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	require.Contains(t, keys[0], "year=2026/month=07/day=28/account=acct-A/")
+
+	var stray int64
+	require.NoError(t, db.QueryRow(
+		"SELECT count(*) FROM read_parquet('"+fs.root+
+			"/flows/year=*/month=*/day=*/account=*/*.parquet', hive_partitioning=true) "+
+			"WHERE day(received_at) <> CAST(day AS INTEGER)").Scan(&stray))
+	require.Zero(t, stray)
+}
+
+func TestCompactDayLeavesParquetOutsideAccountPartitionAlone(t *testing.T) {
+	c, fs, db := newFixture(t)
+	seed(t, db, fs.root, "acct-A", "acct-A", day29+" 10:00:00", 1)
+
+	strayDir := filepath.Join(fs.root, "flows", "year=2026", "month=07", "day=29")
+	stray := filepath.Join(strayDir, "stray.parquet")
+	_, err := db.Exec("COPY (SELECT TIMESTAMP '2026-07-29 10:00:00' AS received_at, " +
+		"'acct-A' AS account_id, 'p' AS peer_id, 'e' AS event_id) TO '" +
+		stray + "' (FORMAT PARQUET)")
+	require.NoError(t, err)
+
+	res, err := c.CompactDay(context.Background(), time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	require.True(t, res.Skipped, "the compactable object is already valid")
+
+	_, err = os.Stat(stray)
+	require.NoError(t, err, "objects outside account partitions are not read and must not be deleted")
+	for _, d := range fs.deleted {
+		require.NotContains(t, d, "stray.parquet")
+	}
 }
 
 // A row count catches loss and nothing else. This is the case it cannot

--- a/flow/store/archive/compact/compact_test.go
+++ b/flow/store/archive/compact/compact_test.go
@@ -339,3 +339,28 @@ func TestFingerprintIgnoresRowOrder(t *testing.T) {
 	require.NotEmpty(t, res.Fingerprint.XOR)
 	require.NotEmpty(t, res.Fingerprint.Sum)
 }
+
+// Everything before this proves the rewrite was right. This proves the
+// write was. A Write that reports success while storing something else
+// -- truncated, empty, a different object -- looks identical to success
+// at every earlier step, and the next step deletes the only other copy.
+//
+// The store here accepts the bytes and keeps a truncated prefix of them,
+// which is what a partial upload leaves behind.
+func TestCompactDayRefusesWhenTheStoredObjectDiffers(t *testing.T) {
+	c, fs, db := newFixture(t)
+	for i := range 10 {
+		seed(t, db, fs.root, "acct-A", "acct-A", day29+" 10:00:00", i)
+	}
+	fs.truncateWrites = true
+
+	_, err := c.CompactDay(context.Background(), time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
+	require.Error(t, err, "what landed in the store has to be checked, not what was sent to it")
+	require.Contains(t, err.Error(), "originals left untouched")
+	require.Equal(t, 10, fs.count("flows"),
+		"the originals must survive, and the bad replacement must not be left behind")
+	for _, k := range fs.deleted {
+		require.Contains(t, k, "compact-",
+			"only this run's own replacements may be removed; no original may be")
+	}
+}

--- a/flow/store/archive/compact/fsstore_test.go
+++ b/flow/store/archive/compact/fsstore_test.go
@@ -1,0 +1,87 @@
+//go:build archive_duckdb
+
+package compact
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// fsStore is an ObjectStore over a directory, so the compaction logic
+// can be exercised end to end without a cloud account. DuckDB reads
+// local paths and gs:// paths through the same code path, so the only
+// thing this substitutes is the SDK half.
+type fsStore struct {
+	root string
+
+	mu        sync.Mutex
+	putErr    error // injected: fail the next Put
+	deleteErr error // injected: fail the next Delete
+	deleted   []string
+	put       []string
+}
+
+func (f *fsStore) List(_ context.Context, prefix string) ([]string, error) {
+	var out []string
+	base := filepath.Join(f.root, filepath.FromSlash(prefix))
+	err := filepath.Walk(base, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) {
+				return nil
+			}
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(f.root, p)
+		if err != nil {
+			return err
+		}
+		out = append(out, filepath.ToSlash(rel))
+		return nil
+	})
+	return out, err
+}
+
+func (f *fsStore) Put(_ context.Context, key string, body []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.putErr != nil {
+		return f.putErr
+	}
+	p := filepath.Join(f.root, filepath.FromSlash(key))
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return err
+	}
+	f.put = append(f.put, key)
+	return os.WriteFile(p, body, 0o644)
+}
+
+func (f *fsStore) Delete(_ context.Context, key string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.deleteErr != nil {
+		return f.deleteErr
+	}
+	f.deleted = append(f.deleted, key)
+	err := os.Remove(filepath.Join(f.root, filepath.FromSlash(key)))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+func (f *fsStore) count(prefix string) int {
+	keys, _ := f.List(context.Background(), prefix)
+	n := 0
+	for _, k := range keys {
+		if strings.HasSuffix(k, ".parquet") {
+			n++
+		}
+	}
+	return n
+}

--- a/flow/store/archive/compact/fsstore_test.go
+++ b/flow/store/archive/compact/fsstore_test.go
@@ -17,11 +17,12 @@ import (
 type fsStore struct {
 	root string
 
-	mu        sync.Mutex
-	putErr    error // injected: fail the next Put
-	deleteErr error // injected: fail the next Delete
-	deleted   []string
-	put       []string
+	mu             sync.Mutex
+	putErr         error // injected: fail the next Write
+	truncateWrites bool  // injected: store a short prefix of the bytes
+	deleteErr      error // injected: fail the next Delete
+	deleted        []string
+	put            []string
 }
 
 func (f *fsStore) List(_ context.Context, prefix string) ([]string, error) {
@@ -47,7 +48,7 @@ func (f *fsStore) List(_ context.Context, prefix string) ([]string, error) {
 	return out, err
 }
 
-func (f *fsStore) Put(_ context.Context, key string, body []byte) error {
+func (f *fsStore) Write(_ context.Context, key string, body []byte) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if f.putErr != nil {
@@ -58,7 +59,14 @@ func (f *fsStore) Put(_ context.Context, key string, body []byte) error {
 		return err
 	}
 	f.put = append(f.put, key)
+	if f.truncateWrites && len(body) > 8 {
+		body = body[:len(body)/2]
+	}
 	return os.WriteFile(p, body, 0o644)
+}
+
+func (f *fsStore) Read(_ context.Context, key string) ([]byte, error) {
+	return os.ReadFile(filepath.Join(f.root, filepath.FromSlash(key)))
 }
 
 func (f *fsStore) Delete(_ context.Context, key string) error {

--- a/flow/store/archive/compact/fsstore_test.go
+++ b/flow/store/archive/compact/fsstore_test.go
@@ -12,7 +12,7 @@ import (
 
 // fsStore is an ObjectStore over a directory, so the compaction logic
 // can be exercised end to end without a cloud account. DuckDB reads
-// local paths and gs:// paths through the same code path, so the only
+// local paths and gcs:// paths through the same code path, so the only
 // thing this substitutes is the SDK half.
 type fsStore struct {
 	root string
@@ -21,6 +21,8 @@ type fsStore struct {
 	putErr         error // injected: fail the next Write
 	truncateWrites bool  // injected: store a short prefix of the bytes
 	deleteErr      error // injected: fail the next Delete
+	deleteErrAfter int   // injected: allow this many deletes before failing once
+	deleteErrFired bool
 	deleted        []string
 	put            []string
 }
@@ -72,7 +74,8 @@ func (f *fsStore) Read(_ context.Context, key string) ([]byte, error) {
 func (f *fsStore) Delete(_ context.Context, key string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if f.deleteErr != nil {
+	if f.deleteErr != nil && !f.deleteErrFired && len(f.deleted) >= f.deleteErrAfter {
+		f.deleteErrFired = true
 		return f.deleteErr
 	}
 	f.deleted = append(f.deleted, key)

--- a/flow/store/archive/compact/gcs.go
+++ b/flow/store/archive/compact/gcs.go
@@ -5,11 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
+
+	"github.com/openzro/openzro/safedial"
 )
 
 // GCSConfig mirrors the fields flow/sinks.GCSConfig uses for auth, so an
@@ -26,6 +29,7 @@ type GCSConfig struct {
 	Endpoint        string
 	CredentialsJSON []byte
 	CredentialsFile string
+	HTTPClient      *http.Client
 }
 
 // GCSStore is an ObjectStore over a GCS bucket.
@@ -48,7 +52,15 @@ func NewGCS(ctx context.Context, cfg GCSConfig) (*GCSStore, error) {
 		opts = append(opts, option.WithAuthCredentialsFile(option.ServiceAccount, cfg.CredentialsFile))
 	}
 	if cfg.Endpoint != "" {
-		opts = append(opts, option.WithEndpoint(cfg.Endpoint), option.WithoutAuthentication())
+		httpClient := cfg.HTTPClient
+		if httpClient == nil {
+			httpClient = safedial.Client(0)
+		}
+		opts = append(opts,
+			option.WithEndpoint(cfg.Endpoint),
+			option.WithoutAuthentication(),
+			option.WithHTTPClient(httpClient),
+		)
 	}
 	client, err := storage.NewClient(ctx, opts...)
 	if err != nil {

--- a/flow/store/archive/compact/gcs.go
+++ b/flow/store/archive/compact/gcs.go
@@ -1,0 +1,134 @@
+package compact
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+)
+
+// GCSConfig mirrors the fields flow/sinks.GCSConfig uses for auth, so an
+// operator configures the bucket once and the repair tool reaches the
+// same objects the sink wrote.
+//
+// Note what is absent: the HMAC pair the DuckDB reader needs. That is a
+// read-path concern and belongs to whoever builds the DuckDB handle;
+// this half writes and deletes with the service account, exactly as the
+// sink does.
+type GCSConfig struct {
+	Bucket          string
+	Prefix          string
+	Endpoint        string
+	CredentialsJSON []byte
+	CredentialsFile string
+}
+
+// GCSStore is an ObjectStore over a GCS bucket.
+type GCSStore struct {
+	bucket *storage.BucketHandle
+	prefix string
+	client *storage.Client
+}
+
+// NewGCS builds a store for one bucket. The caller closes it.
+func NewGCS(ctx context.Context, cfg GCSConfig) (*GCSStore, error) {
+	if cfg.Bucket == "" {
+		return nil, errors.New("compact: GCS bucket is required")
+	}
+	var opts []option.ClientOption
+	switch {
+	case len(cfg.CredentialsJSON) > 0:
+		opts = append(opts, option.WithAuthCredentialsJSON(option.ServiceAccount, cfg.CredentialsJSON))
+	case cfg.CredentialsFile != "":
+		opts = append(opts, option.WithAuthCredentialsFile(option.ServiceAccount, cfg.CredentialsFile))
+	}
+	if cfg.Endpoint != "" {
+		opts = append(opts, option.WithEndpoint(cfg.Endpoint), option.WithoutAuthentication())
+	}
+	client, err := storage.NewClient(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("compact: new GCS client: %w", err)
+	}
+	return &GCSStore{
+		bucket: client.Bucket(cfg.Bucket),
+		prefix: strings.Trim(cfg.Prefix, "/"),
+		client: client,
+	}, nil
+}
+
+func (g *GCSStore) Close() error { return g.client.Close() }
+
+func (g *GCSStore) List(ctx context.Context, prefix string) ([]string, error) {
+	if err := checkUnderPrefix(prefix, g.prefix); err != nil {
+		return nil, err
+	}
+	var keys []string
+	it := g.bucket.Objects(ctx, &storage.Query{Prefix: prefix})
+	for {
+		attrs, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			return keys, nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("compact: list %q: %w", prefix, err)
+		}
+		// The name is taken as the store reports it. Reconstructing it
+		// from the query prefix plus a suffix is how a delete ends up
+		// aimed at something the listing never saw.
+		keys = append(keys, attrs.Name)
+	}
+}
+
+func (g *GCSStore) Read(ctx context.Context, key string) ([]byte, error) {
+	if err := checkUnderPrefix(key, g.prefix); err != nil {
+		return nil, err
+	}
+	r, err := g.bucket.Object(key).NewReader(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("compact: read %q: %w", key, err)
+	}
+	defer func() { _ = r.Close() }()
+	body, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("compact: read %q: %w", key, err)
+	}
+	return body, nil
+}
+
+func (g *GCSStore) Write(ctx context.Context, key string, body []byte) error {
+	if err := checkUnderPrefix(key, g.prefix); err != nil {
+		return err
+	}
+	w := g.bucket.Object(key).NewWriter(ctx)
+	w.ContentType = "application/vnd.apache.parquet"
+	if _, err := w.Write(body); err != nil {
+		_ = w.Close()
+		return fmt.Errorf("compact: write %q: %w", key, err)
+	}
+	// Close is where GCS reports the failure that matters: the bytes are
+	// not durable until it returns, so a Write that only checked the
+	// io.Writer would report success on an object that never landed.
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("compact: finalize %q: %w", key, err)
+	}
+	return nil
+}
+
+func (g *GCSStore) Delete(ctx context.Context, key string) error {
+	if err := checkUnderPrefix(key, g.prefix); err != nil {
+		return err
+	}
+	err := g.bucket.Object(key).Delete(ctx)
+	// An absent object is the state Delete is asked to produce, so a
+	// retried compaction converges instead of failing on its own
+	// progress.
+	if err != nil && !errors.Is(err, storage.ErrObjectNotExist) {
+		return fmt.Errorf("compact: delete %q: %w", key, err)
+	}
+	return nil
+}

--- a/flow/store/archive/compact/gcs.go
+++ b/flow/store/archive/compact/gcs.go
@@ -62,6 +62,11 @@ func NewGCS(ctx context.Context, cfg GCSConfig) (*GCSStore, error) {
 			option.WithHTTPClient(httpClient),
 		)
 	}
+	// Keep reads on the same JSON API as list/write/delete. The default
+	// XML read path is a separate code path in the Go client and is not
+	// what fake-gcs-server emulates; JSON reads are also the client
+	// library's recommended direction.
+	opts = append(opts, storage.WithJSONReads())
 	client, err := storage.NewClient(ctx, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("compact: new GCS client: %w", err)

--- a/flow/store/archive/compact/gcs.go
+++ b/flow/store/archive/compact/gcs.go
@@ -127,9 +127,9 @@ func (g *GCSStore) Write(ctx context.Context, key string, body []byte) error {
 		_ = w.Close()
 		return fmt.Errorf("compact: write %q: %w", key, err)
 	}
-	// Close is where GCS reports the failure that matters: the bytes are
-	// not durable until it returns, so a Write that only checked the
-	// io.Writer would report success on an object that never landed.
+	// Close is where the storage client can still report upload failure.
+	// CompactDay does not trust this alone: it re-reads and fingerprints
+	// replacement objects from the store before deleting originals.
 	if err := w.Close(); err != nil {
 		return fmt.Errorf("compact: finalize %q: %w", key, err)
 	}

--- a/flow/store/archive/compact/gcs_integration_test.go
+++ b/flow/store/archive/compact/gcs_integration_test.go
@@ -1,0 +1,119 @@
+//go:build archive_duckdb
+
+package compact_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/openzro/openzro/flow/store/archive/compact"
+)
+
+const (
+	fakeGCSTestBucket = "flow-archive-gcs"
+	fakeGCSTestPrefix = "flows"
+)
+
+func startFakeGCS(t *testing.T) string {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("integration test; needs a container runtime")
+	}
+
+	ctx := context.Background()
+	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			// Pinned for the same reason as the MinIO image: the fake
+			// server is part of the contract this test is exercising.
+			Image:        "fsouza/fake-gcs-server:1.52.3",
+			ExposedPorts: []string{"4443/tcp"},
+			Cmd:          []string{"-scheme", "http", "-port", "4443", "-backend", "memory"},
+			WaitingFor: wait.ForHTTP("/storage/v1/b").
+				WithPort("4443/tcp").WithStartupTimeout(90 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		t.Fatalf("failed to start fake-gcs-server container: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Terminate(context.Background()) })
+
+	host, err := c.Host(ctx)
+	require.NoError(t, err)
+	port, err := c.MappedPort(ctx, "4443/tcp")
+	require.NoError(t, err)
+	endpoint := "http://" + host + ":" + port.Port()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		endpoint+"/storage/v1/b?project=openzro-test",
+		bytes.NewBufferString(`{"name":"`+fakeGCSTestBucket+`"}`))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create fake GCS bucket: status=%d body=%s", resp.StatusCode, body)
+	}
+	return endpoint + "/storage/v1/"
+}
+
+func newFakeGCSStore(t *testing.T) *compact.GCSStore {
+	t.Helper()
+	st, err := compact.NewGCS(context.Background(), compact.GCSConfig{
+		Bucket:   fakeGCSTestBucket,
+		Prefix:   fakeGCSTestPrefix,
+		Endpoint: startFakeGCS(t),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = st.Close() })
+	return st
+}
+
+func TestGCSStoreAgainstFakeServer(t *testing.T) {
+	st := newFakeGCSStore(t)
+	ctx := context.Background()
+	key := fakeGCSTestPrefix + "/year=2026/month=07/day=29/account=acct-A/one.parquet"
+	body := bytes.Repeat([]byte("parquet-ish"), 8)
+
+	require.NoError(t, st.Write(ctx, key, body))
+	got, err := st.Read(ctx, key)
+	require.NoError(t, err)
+	require.Equal(t, body, got, "Write must be durable by the time it returns")
+
+	keys, err := st.List(ctx, fakeGCSTestPrefix+"/year=2026/month=07/day=29")
+	require.NoError(t, err)
+	require.Equal(t, []string{key}, keys)
+
+	require.NoError(t, st.Delete(ctx, key))
+	require.NoError(t, st.Delete(ctx, key), "deleting an absent object must converge")
+	keys, err = st.List(ctx, fakeGCSTestPrefix+"/year=2026/month=07/day=29")
+	require.NoError(t, err)
+	require.Empty(t, keys)
+}
+
+func TestGCSListPagesPastTheThousandKeyLimit(t *testing.T) {
+	st := newFakeGCSStore(t)
+	ctx := context.Background()
+	const objects = 1005
+	prefix := fakeGCSTestPrefix + "/year=2026/month=07/day=30/account=acct-A"
+	body := []byte("x")
+	for i := range objects {
+		require.NoError(t, st.Write(ctx, fmt.Sprintf("%s/%04d.parquet", prefix, i), body))
+	}
+
+	keys, err := st.List(ctx, fakeGCSTestPrefix+"/year=2026/month=07/day=30")
+	require.NoError(t, err)
+	require.Len(t, keys, objects,
+		"a List that stops at the first page leaves GCS originals undeleted while their rows are copied into the replacement")
+}

--- a/flow/store/archive/compact/minio_integration_test.go
+++ b/flow/store/archive/compact/minio_integration_test.go
@@ -1,0 +1,271 @@
+//go:build archive_duckdb
+
+package compact_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	_ "github.com/marcboeker/go-duckdb"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	flowArchive "github.com/openzro/openzro/flow/store/archive"
+	"github.com/openzro/openzro/flow/store/archive/compact"
+)
+
+// Everything else in this package runs the compaction over a local
+// directory, which proves the logic and proves nothing about the object
+// store. These assumptions had never been executed anywhere:
+//
+//   - that List pages past the 1000-key limit,
+//   - that Delete of an absent key succeeds rather than erroring,
+//   - that Write is durable by the time it returns,
+//   - that DuckDB can read the objects the SDK wrote, over HTTP, with
+//     the same credentials.
+//
+// Four defects on this read path shipped to production having passed
+// tests: a non-existent extension, a parameter that could not bind,
+// absent partition pruning, and file sizes nobody measured. The
+// difference here is that this command deletes data.
+//
+// MinIO is S3-compatible and is the image this repository already uses
+// for S3 integration work.
+
+const (
+	minioAccessKey = "minioadmin"
+	minioSecretKey = "minioadmin"
+	testBucket     = "flow-archive"
+	testPrefix     = "flows"
+)
+
+func startMinIO(t *testing.T) string {
+	t.Helper()
+	ctx := context.Background()
+	c, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			// Pinned rather than :latest, for the reason the existing
+			// MinIO test gives: rolling tags ship behavior changes.
+			Image:        "minio/minio:RELEASE.2025-04-22T22-12-26Z",
+			ExposedPorts: []string{"9000/tcp"},
+			Cmd:          []string{"server", "/data"},
+			Env: map[string]string{
+				"MINIO_ROOT_USER":     minioAccessKey,
+				"MINIO_ROOT_PASSWORD": minioSecretKey,
+			},
+			WaitingFor: wait.ForHTTP("/minio/health/ready").
+				WithPort("9000/tcp").WithStartupTimeout(90 * time.Second),
+		},
+		Started: true,
+	})
+	if err != nil {
+		t.Skipf("MinIO container unavailable: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Terminate(context.Background()) })
+
+	host, err := c.Host(ctx)
+	require.NoError(t, err)
+	port, err := c.MappedPort(ctx, "9000/tcp")
+	require.NoError(t, err)
+	endpoint := "http://" + host + ":" + port.Port()
+
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx,
+		awsconfig.WithRegion("us-east-1"),
+		awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(minioAccessKey, minioSecretKey, "")))
+	require.NoError(t, err)
+	client := s3.NewFromConfig(awsCfg, func(o *s3.Options) {
+		o.BaseEndpoint = aws.String(endpoint)
+		o.UsePathStyle = true
+	})
+	_, err = client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: aws.String(testBucket)})
+	require.NoError(t, err)
+	return endpoint
+}
+
+// harness wires the two halves the way the CLI does: DuckDB reads the
+// bucket, the SDK writes and deletes it.
+type harness struct {
+	store    *compact.S3Store
+	db       *sql.DB
+	local    *sql.DB
+	endpoint string
+	tmp      string
+}
+
+func newHarness(t *testing.T) *harness {
+	t.Helper()
+	endpoint := startMinIO(t)
+	ctx := context.Background()
+
+	store, err := compact.NewS3(ctx, compact.S3Config{
+		Bucket: testBucket, Prefix: testPrefix, Region: "us-east-1",
+		Endpoint: endpoint, AccessKey: minioAccessKey, SecretKey: minioSecretKey,
+	})
+	require.NoError(t, err)
+
+	db, err := flowArchive.OpenParquetDB(ctx, flowArchive.Config{
+		Provider: "s3", Bucket: testBucket, Prefix: testPrefix, Region: "us-east-1",
+		Endpoint: endpoint, AccessKeyID: minioAccessKey, SecretAccessKey: minioSecretKey,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	local, err := sql.Open("duckdb", "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = local.Close() })
+
+	return &harness{store: store, db: db, local: local, endpoint: endpoint, tmp: t.TempDir()}
+}
+
+// seed builds a parquet locally and puts the bytes through the store --
+// the same order the sink uses, so the object under test is the one
+// production would have produced.
+func (h *harness) seed(t *testing.T, day, account, rowAccount, ts string, n int) string {
+	t.Helper()
+	path := filepath.Join(h.tmp, fmt.Sprintf("seed-%d.parquet", n))
+	_, err := h.local.ExecContext(context.Background(), fmt.Sprintf(
+		`COPY (SELECT TIMESTAMP '%s' AS received_at, '%s' AS account_id,
+		        'peer-%d' AS peer_id, 'ev-%d' AS event_id) TO '%s' (FORMAT PARQUET)`,
+		ts, rowAccount, n, n, path))
+	require.NoError(t, err)
+	body, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	key := fmt.Sprintf("%s/year=2026/month=07/day=%s/account=%s/%d.parquet", testPrefix, day, account, n)
+	require.NoError(t, h.store.Write(context.Background(), key, body))
+	return key
+}
+
+func (h *harness) compactor(dryRun bool) *compact.Compactor {
+	return &compact.Compactor{
+		DB:        h.db,
+		Store:     h.store,
+		ReadRoot:  "s3://" + testBucket + "/" + testPrefix,
+		KeyPrefix: testPrefix,
+		DryRun:    dryRun,
+	}
+}
+
+func (h *harness) list(t *testing.T, prefix string) []string {
+	t.Helper()
+	keys, err := h.store.List(context.Background(), prefix)
+	require.NoError(t, err)
+	return keys
+}
+
+// The whole cycle against a real object store: many small objects in,
+// one per account out, originals gone, and every row still readable
+// through the archive reader afterwards.
+func TestCompactDayAgainstObjectStore(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test; needs a container runtime")
+	}
+	h := newHarness(t)
+	ctx := context.Background()
+
+	for i := range 40 {
+		account := "acct-A"
+		if i%4 == 0 {
+			account = "acct-B"
+		}
+		h.seed(t, "29", account, account, fmt.Sprintf("2026-07-29 %02d:00:00", i%24), i)
+	}
+	require.Len(t, h.list(t, testPrefix+"/year=2026/month=07/day=29"), 40)
+
+	res, err := h.compactor(false).CompactDay(ctx, time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	require.Equal(t, 40, res.ObjectsBefore)
+	require.Equal(t, 2, res.ObjectsAfter, "one object per account")
+	require.Equal(t, int64(40), res.Rows)
+
+	after := h.list(t, testPrefix+"/year=2026/month=07/day=29")
+	require.Len(t, after, 2, "the originals must be gone from the bucket, not merely replaced")
+
+	// And the reader still answers, which is the only thing an operator
+	// actually cares about after a compaction.
+	var rows int64
+	require.NoError(t, h.db.QueryRowContext(ctx,
+		`SELECT count(*) FROM read_parquet(
+			's3://`+testBucket+`/`+testPrefix+`/year=*/month=*/day=*/account=*/*.parquet',
+			hive_partitioning=true)`).Scan(&rows))
+	require.Equal(t, int64(40), rows)
+}
+
+// List pages at 1000 keys. Nothing had ever exercised the second page,
+// and a List that silently stopped there would leave objects
+// uncompacted -- and, worse, undeleted while their rows were copied into
+// a replacement, producing duplicates in every later query.
+func TestListPagesPastTheThousandKeyLimit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test; needs a container runtime")
+	}
+	h := newHarness(t)
+
+	// One payload, reused: this test is about the listing, not the
+	// contents.
+	path := filepath.Join(h.tmp, "one.parquet")
+	_, err := h.local.Exec(
+		`COPY (SELECT TIMESTAMP '2026-07-30 10:00:00' AS received_at, 'acct-A' AS account_id) TO '` +
+			path + `' (FORMAT PARQUET)`)
+	require.NoError(t, err)
+	body, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	const objects = 1005
+	prefix := testPrefix + "/year=2026/month=07/day=30/account=acct-A"
+	for i := range objects {
+		require.NoError(t, h.store.Write(context.Background(),
+			fmt.Sprintf("%s/%04d.parquet", prefix, i), body))
+	}
+
+	keys := h.list(t, testPrefix+"/year=2026/month=07/day=30")
+	require.Len(t, keys, objects,
+		"a List that stops at the first page leaves objects undeleted while their rows are copied into the replacement")
+}
+
+// Delete of an absent key is treated as success throughout the
+// compactor, so a retried run converges instead of failing on its own
+// earlier progress. That was an assumption about the SDK, never checked.
+func TestDeleteAbsentKeyIsNotAnError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test; needs a container runtime")
+	}
+	h := newHarness(t)
+	require.NoError(t, h.store.Delete(context.Background(),
+		testPrefix+"/year=2026/month=07/day=31/account=acct-A/never-written.parquet"))
+}
+
+// A dry-run must leave the bucket exactly as it found it. This is the
+// promise the CLI makes by defaulting to it.
+func TestDryRunAgainstObjectStoreWritesNothing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test; needs a container runtime")
+	}
+	h := newHarness(t)
+	ctx := context.Background()
+
+	var seeded []string
+	for i := range 6 {
+		seeded = append(seeded, h.seed(t, "28", "acct-A", "acct-A", "2026-07-28 10:00:00", i))
+	}
+
+	res, err := h.compactor(true).CompactDay(ctx, time.Date(2026, 7, 28, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	require.True(t, res.DryRun)
+	require.Equal(t, 6, res.ObjectsBefore)
+
+	after := h.list(t, testPrefix+"/year=2026/month=07/day=28")
+	require.ElementsMatch(t, seeded, after,
+		"a dry-run must not add, replace or remove a single object")
+}

--- a/flow/store/archive/compact/minio_integration_test.go
+++ b/flow/store/archive/compact/minio_integration_test.go
@@ -69,7 +69,7 @@ func startMinIO(t *testing.T) string {
 		Started: true,
 	})
 	if err != nil {
-		t.Skipf("MinIO container unavailable: %v", err)
+		t.Fatalf("failed to start MinIO container: %v", err)
 	}
 	t.Cleanup(func() { _ = c.Terminate(context.Background()) })
 

--- a/flow/store/archive/compact/objectstore.go
+++ b/flow/store/archive/compact/objectstore.go
@@ -1,0 +1,44 @@
+// Package compact rewrites an archive day's many small objects into one
+// object per account.
+//
+// The sinks flush every fifteen minutes, and a low-traffic account
+// produces a parquet file of a few kilobytes each time. Measured on a
+// production bucket: 13,185 objects averaging 7 KB, roughly 150 per day
+// per account. Reading a single day meant opening ~150 objects, and with
+// the reader's partition margin a one-day question opened 579 -- about
+// 2,000 HTTP round trips to move 10 MB, which took 64 to 81 seconds.
+//
+// The bytes were never the problem. Parquet is built for files in the
+// tens of megabytes, where the footer read that precedes every file is
+// amortised over a lot of data; at 7 KB the round trip is the whole
+// cost. Compaction does not make the archive smaller, it makes it
+// answerable: one file per account-day turns 579 opens into 4.
+//
+// It also repartitions. Objects written before the sinks split a batch
+// by account carry rows for accounts other than the one in their path
+// (see openzro#186), and rewriting groups every row under the account it
+// actually belongs to -- which is the only way those events become
+// reachable again from the account that owns them.
+package compact
+
+import "context"
+
+// ObjectStore is the write half of compaction. Reads go through DuckDB,
+// which already knows how to glob and authenticate against the archive;
+// this covers what DuckDB is not used for, deliberately.
+//
+// Writing through the same SDK the sinks write with, rather than through
+// DuckDB's httpfs, is a choice about what is already proven. The sinks
+// have been writing this bucket for months. Whether httpfs can write to
+// GCS through an S3-compatible endpoint with HMAC credentials is a
+// question nobody here has answered, and compaction is not the place to
+// find out: it is the one operation in this codebase that deletes data.
+type ObjectStore interface {
+	// List returns every object key under prefix, in any order.
+	List(ctx context.Context, prefix string) ([]string, error)
+	// Put writes body at key, overwriting whatever is there.
+	Put(ctx context.Context, key string, body []byte) error
+	// Delete removes key. Deleting an absent key is not an error, so a
+	// retried compaction converges instead of failing.
+	Delete(ctx context.Context, key string) error
+}

--- a/flow/store/archive/compact/objectstore.go
+++ b/flow/store/archive/compact/objectstore.go
@@ -23,9 +23,9 @@ package compact
 
 import "context"
 
-// ObjectStore is the write half of compaction. Reads go through DuckDB,
-// which already knows how to glob and authenticate against the archive;
-// this covers what DuckDB is not used for, deliberately.
+// ObjectStore is the object half of compaction. Analytical reads go
+// through DuckDB, which already knows how to glob and authenticate
+// against the archive; this covers everything else.
 //
 // Writing through the same SDK the sinks write with, rather than through
 // DuckDB's httpfs, is a choice about what is already proven. The sinks
@@ -33,11 +33,21 @@ import "context"
 // GCS through an S3-compatible endpoint with HMAC credentials is a
 // question nobody here has answered, and compaction is not the place to
 // find out: it is the one operation in this codebase that deletes data.
+//
+// Keys are opaque strings. Implementations must validate that a key sits
+// under the prefix they were configured with and otherwise pass it
+// through untouched -- no cleaning, no rejoining, no re-deriving a key
+// from its parts. Recomposing paths from components is exactly the
+// mistake this whole area is being repaired for: the sinks built an
+// object's path out of one event's fields and got the account and the
+// date wrong for every other event in the batch.
 type ObjectStore interface {
 	// List returns every object key under prefix, in any order.
 	List(ctx context.Context, prefix string) ([]string, error)
-	// Put writes body at key, overwriting whatever is there.
-	Put(ctx context.Context, key string, body []byte) error
+	// Read returns the object's bytes.
+	Read(ctx context.Context, key string) ([]byte, error)
+	// Write puts body at key, overwriting whatever is there.
+	Write(ctx context.Context, key string, body []byte) error
 	// Delete removes key. Deleting an absent key is not an error, so a
 	// retried compaction converges instead of failing.
 	Delete(ctx context.Context, key string) error

--- a/flow/store/archive/compact/objectstore.go
+++ b/flow/store/archive/compact/objectstore.go
@@ -10,7 +10,7 @@
 //
 // The bytes were never the problem. Parquet is built for files in the
 // tens of megabytes, where the footer read that precedes every file is
-// amortised over a lot of data; at 7 KB the round trip is the whole
+// amortized over a lot of data; at 7 KB the round trip is the whole
 // cost. Compaction does not make the archive smaller, it makes it
 // answerable: one file per account-day turns 579 opens into 4.
 //

--- a/flow/store/archive/compact/prefix.go
+++ b/flow/store/archive/compact/prefix.go
@@ -1,0 +1,56 @@
+package compact
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ErrOutsidePrefix is returned when a key does not sit under the prefix
+// its store was configured with. Callers check it with errors.Is; the
+// operator sees which key was refused.
+type ErrOutsidePrefix struct {
+	Key    string
+	Prefix string
+}
+
+func (e *ErrOutsidePrefix) Error() string {
+	return fmt.Sprintf("key %q is not under prefix %q", e.Key, e.Prefix)
+}
+
+// checkUnderPrefix is the only thing standing between a bug in key
+// construction and a delete somewhere else in the bucket. It runs on
+// every operation, not only Delete, because a Write to the wrong place
+// is how a later Delete finds the wrong thing to remove.
+//
+// The key is not cleaned, rewritten, or rejoined -- it is checked and
+// then used exactly as given. Rebuilding a path from its parts is the
+// mistake this whole area is being repaired for.
+//
+// A prefix boundary is a path boundary: "flows" covers "flows/a" and
+// does not cover "flowsomething". Object stores have no directories, so
+// nothing else enforces that.
+//
+// Dot segments are refused rather than resolved. Object stores treat
+// them as ordinary characters, so "flows/../x" is a real key that no
+// traversal occurs on -- but it reads as an escape, and any layer that
+// ever normalises it becomes one. Refusing costs nothing: nothing in
+// this archive's layout produces such a key.
+func checkUnderPrefix(key, prefix string) error {
+	fail := func() error { return &ErrOutsidePrefix{Key: key, Prefix: prefix} }
+	if key == "" || strings.HasPrefix(key, "/") {
+		return fail()
+	}
+	for _, seg := range strings.Split(key, "/") {
+		if seg == "" || seg == "." || seg == ".." {
+			return fail()
+		}
+	}
+	prefix = strings.Trim(prefix, "/")
+	if prefix == "" {
+		return nil
+	}
+	if key != prefix && !strings.HasPrefix(key, prefix+"/") {
+		return fail()
+	}
+	return nil
+}

--- a/flow/store/archive/compact/prefix.go
+++ b/flow/store/archive/compact/prefix.go
@@ -33,7 +33,7 @@ func (e *ErrOutsidePrefix) Error() string {
 // Dot segments are refused rather than resolved. Object stores treat
 // them as ordinary characters, so "flows/../x" is a real key that no
 // traversal occurs on -- but it reads as an escape, and any layer that
-// ever normalises it becomes one. Refusing costs nothing: nothing in
+// ever normalizes it becomes one. Refusing costs nothing: nothing in
 // this archive's layout produces such a key.
 func checkUnderPrefix(key, prefix string) error {
 	fail := func() error { return &ErrOutsidePrefix{Key: key, Prefix: prefix} }

--- a/flow/store/archive/compact/prefix_test.go
+++ b/flow/store/archive/compact/prefix_test.go
@@ -1,0 +1,55 @@
+package compact
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The guard exists for Delete, so its failures are tested as data loss
+// rather than as string handling.
+func TestCheckUnderPrefix(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		key    string
+		prefix string
+		ok     bool
+	}{
+		{"exact prefix", "flows", "flows", true},
+		{"under prefix", "flows/year=2026/x.parquet", "flows", true},
+		{"prefix with trailing slash", "flows/x.parquet", "flows/", true},
+		{"empty prefix allows any key", "anything/x.parquet", "", true},
+
+		// The one that matters: a boundary that is not a path boundary.
+		// Object stores have no directories, so "flows" would otherwise
+		// match "flowsomething" and a delete would walk into a
+		// neighbouring dataset.
+		{"sibling sharing a name prefix", "flowsomething/x.parquet", "flows", false},
+		{"different tree", "other/x.parquet", "flows", false},
+		{"parent of the prefix", "x.parquet", "flows", false},
+
+		// Refused rather than resolved. These are legal object keys that
+		// no traversal happens on, but they read as an escape and any
+		// layer that ever normalises them becomes one.
+		{"dot dot segment", "flows/../other/x.parquet", "flows", false},
+		{"dot segment", "flows/./x.parquet", "flows", false},
+		{"double slash", "flows//x.parquet", "flows", false},
+		{"leading slash", "/flows/x.parquet", "flows", false},
+		{"empty key", "", "flows", false},
+		{"empty key, empty prefix", "", "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkUnderPrefix(tc.key, tc.prefix)
+			if tc.ok {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			var outside *ErrOutsidePrefix
+			require.True(t, errors.As(err, &outside),
+				"the refusal must be typed so a caller can tell it from an outage")
+			require.Equal(t, tc.key, outside.Key)
+		})
+	}
+}

--- a/flow/store/archive/compact/prefix_test.go
+++ b/flow/store/archive/compact/prefix_test.go
@@ -32,8 +32,8 @@ func TestCheckUnderPrefix(t *testing.T) {
 		// Refused rather than resolved. These are legal object keys that
 		// no traversal happens on, but they read as an escape and any
 		// layer that ever normalizes them becomes one.
-		{"dot dot segment", "flows/../other/x.parquet", "flows", false},
-		{"dot segment", "flows/./x.parquet", "flows", false},
+		{"parent segment", "flows/../other/x.parquet", "flows", false},
+		{"current-directory segment", "flows/./x.parquet", "flows", false},
 		{"double slash", "flows//x.parquet", "flows", false},
 		{"leading slash", "/flows/x.parquet", "flows", false},
 		{"empty key", "", "flows", false},

--- a/flow/store/archive/compact/prefix_test.go
+++ b/flow/store/archive/compact/prefix_test.go
@@ -24,14 +24,14 @@ func TestCheckUnderPrefix(t *testing.T) {
 		// The one that matters: a boundary that is not a path boundary.
 		// Object stores have no directories, so "flows" would otherwise
 		// match "flowsomething" and a delete would walk into a
-		// neighbouring dataset.
+		// neighboring dataset.
 		{"sibling sharing a name prefix", "flowsomething/x.parquet", "flows", false},
 		{"different tree", "other/x.parquet", "flows", false},
 		{"parent of the prefix", "x.parquet", "flows", false},
 
 		// Refused rather than resolved. These are legal object keys that
 		// no traversal happens on, but they read as an escape and any
-		// layer that ever normalises them becomes one.
+		// layer that ever normalizes them becomes one.
 		{"dot dot segment", "flows/../other/x.parquet", "flows", false},
 		{"dot segment", "flows/./x.parquet", "flows", false},
 		{"double slash", "flows//x.parquet", "flows", false},

--- a/flow/store/archive/compact/s3.go
+++ b/flow/store/archive/compact/s3.go
@@ -1,0 +1,144 @@
+package compact
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+// S3Config mirrors the auth fields flow/sinks.S3Config uses, so the
+// repair tool reaches the same objects the sink wrote. Covers any
+// S3-compatible service: AWS, MinIO, R2, B2.
+type S3Config struct {
+	Bucket    string
+	Prefix    string
+	Region    string
+	Endpoint  string
+	AccessKey string
+	SecretKey string
+}
+
+// S3Store is an ObjectStore over an S3 bucket.
+type S3Store struct {
+	client *s3.Client
+	bucket string
+	prefix string
+}
+
+// NewS3 builds a store for one bucket.
+func NewS3(ctx context.Context, cfg S3Config) (*S3Store, error) {
+	if cfg.Bucket == "" {
+		return nil, errors.New("compact: S3 bucket is required")
+	}
+	loadOpts := []func(*awsconfig.LoadOptions) error{}
+	if cfg.Region != "" {
+		loadOpts = append(loadOpts, awsconfig.WithRegion(cfg.Region))
+	}
+	if cfg.AccessKey != "" {
+		loadOpts = append(loadOpts, awsconfig.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(cfg.AccessKey, cfg.SecretKey, ""),
+		))
+	}
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, loadOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("compact: load aws config: %w", err)
+	}
+	var clientOpts []func(*s3.Options)
+	if cfg.Endpoint != "" {
+		clientOpts = append(clientOpts, func(o *s3.Options) {
+			o.BaseEndpoint = aws.String(cfg.Endpoint)
+			o.UsePathStyle = true // MinIO and most non-AWS S3 want path style
+		})
+	}
+	return &S3Store{
+		client: s3.NewFromConfig(awsCfg, clientOpts...),
+		bucket: cfg.Bucket,
+		prefix: strings.Trim(cfg.Prefix, "/"),
+	}, nil
+}
+
+func (s *S3Store) List(ctx context.Context, prefix string) ([]string, error) {
+	if err := checkUnderPrefix(prefix, s.prefix); err != nil {
+		return nil, err
+	}
+	var keys []string
+	p := s3.NewListObjectsV2Paginator(s.client, &s3.ListObjectsV2Input{
+		Bucket: aws.String(s.bucket),
+		Prefix: aws.String(prefix),
+	})
+	for p.HasMorePages() {
+		page, err := p.NextPage(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("compact: list %q: %w", prefix, err)
+		}
+		for _, o := range page.Contents {
+			if o.Key == nil {
+				continue
+			}
+			// As reported by the store, never rebuilt from the query.
+			keys = append(keys, *o.Key)
+		}
+	}
+	return keys, nil
+}
+
+func (s *S3Store) Read(ctx context.Context, key string) ([]byte, error) {
+	if err := checkUnderPrefix(key, s.prefix); err != nil {
+		return nil, err
+	}
+	out, err := s.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("compact: read %q: %w", key, err)
+	}
+	defer func() { _ = out.Body.Close() }()
+	body, err := io.ReadAll(out.Body)
+	if err != nil {
+		return nil, fmt.Errorf("compact: read %q: %w", key, err)
+	}
+	return body, nil
+}
+
+func (s *S3Store) Write(ctx context.Context, key string, body []byte) error {
+	if err := checkUnderPrefix(key, s.prefix); err != nil {
+		return err
+	}
+	_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      aws.String(s.bucket),
+		Key:         aws.String(key),
+		Body:        bytes.NewReader(body),
+		ContentType: aws.String("application/vnd.apache.parquet"),
+	})
+	if err != nil {
+		return fmt.Errorf("compact: write %q: %w", key, err)
+	}
+	return nil
+}
+
+func (s *S3Store) Delete(ctx context.Context, key string) error {
+	if err := checkUnderPrefix(key, s.prefix); err != nil {
+		return err
+	}
+	_, err := s.client.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+	})
+	// Same reasoning as the GCS store: absent is the state being asked
+	// for, so a retry converges rather than failing on its own progress.
+	var missing *types.NoSuchKey
+	if err != nil && !errors.As(err, &missing) {
+		return fmt.Errorf("compact: delete %q: %w", key, err)
+	}
+	return nil
+}

--- a/flow/store/archive/compact/s3.go
+++ b/flow/store/archive/compact/s3.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -13,18 +14,21 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+
+	"github.com/openzro/openzro/safedial"
 )
 
 // S3Config mirrors the auth fields flow/sinks.S3Config uses, so the
 // repair tool reaches the same objects the sink wrote. Covers any
 // S3-compatible service: AWS, MinIO, R2, B2.
 type S3Config struct {
-	Bucket    string
-	Prefix    string
-	Region    string
-	Endpoint  string
-	AccessKey string
-	SecretKey string
+	Bucket     string
+	Prefix     string
+	Region     string
+	Endpoint   string
+	AccessKey  string
+	SecretKey  string
+	HTTPClient *http.Client
 }
 
 // S3Store is an ObjectStore over an S3 bucket.
@@ -47,6 +51,11 @@ func NewS3(ctx context.Context, cfg S3Config) (*S3Store, error) {
 		loadOpts = append(loadOpts, awsconfig.WithCredentialsProvider(
 			credentials.NewStaticCredentialsProvider(cfg.AccessKey, cfg.SecretKey, ""),
 		))
+	}
+	if cfg.HTTPClient != nil {
+		loadOpts = append(loadOpts, awsconfig.WithHTTPClient(cfg.HTTPClient))
+	} else if cfg.Endpoint != "" {
+		loadOpts = append(loadOpts, awsconfig.WithHTTPClient(safedial.Client(0)))
 	}
 	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, loadOpts...)
 	if err != nil {

--- a/flow/store/archive/compact/store_contract_test.go
+++ b/flow/store/archive/compact/store_contract_test.go
@@ -1,0 +1,64 @@
+package compact
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Both real stores must refuse a key outside their prefix before the SDK
+// is reached, on every operation and not only Delete: a Write to the
+// wrong place is how a later Delete finds the wrong thing to remove.
+//
+// These construct the stores without contacting anything. If the guard
+// were missing, the call would reach the SDK and fail differently -- so
+// the assertion is on the type, not merely on there being an error.
+func TestStoresRefuseKeysOutsideTheirPrefix(t *testing.T) {
+	ctx := context.Background()
+
+	gcs := &GCSStore{prefix: "flows"}
+	s3s := &S3Store{prefix: "flows", bucket: "b"}
+
+	for name, st := range map[string]ObjectStore{"gcs": gcs, "s3": s3s} {
+		t.Run(name, func(t *testing.T) {
+			for _, key := range []string{
+				"other/x.parquet",
+				"flowsomething/x.parquet",
+				"flows/../other/x.parquet",
+				"",
+			} {
+				t.Run("delete "+key, func(t *testing.T) {
+					err := st.Delete(ctx, key)
+					var outside *ErrOutsidePrefix
+					require.True(t, errors.As(err, &outside),
+						"delete %q must be refused before the SDK, got %v", key, err)
+				})
+				t.Run("write "+key, func(t *testing.T) {
+					err := st.Write(ctx, key, []byte("x"))
+					var outside *ErrOutsidePrefix
+					require.True(t, errors.As(err, &outside),
+						"write %q must be refused before the SDK, got %v", key, err)
+				})
+				t.Run("read "+key, func(t *testing.T) {
+					_, err := st.Read(ctx, key)
+					var outside *ErrOutsidePrefix
+					require.True(t, errors.As(err, &outside))
+				})
+				t.Run("list "+key, func(t *testing.T) {
+					_, err := st.List(ctx, key)
+					var outside *ErrOutsidePrefix
+					require.True(t, errors.As(err, &outside))
+				})
+			}
+		})
+	}
+}
+
+// The fsStore used by the compaction tests and the two real stores must
+// satisfy the same interface, so a change to it cannot leave one behind.
+var (
+	_ ObjectStore = (*GCSStore)(nil)
+	_ ObjectStore = (*S3Store)(nil)
+)

--- a/flow/store/archive/compact/store_contract_test.go
+++ b/flow/store/archive/compact/store_contract_test.go
@@ -3,6 +3,7 @@ package compact
 import (
 	"context"
 	"errors"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -62,3 +63,14 @@ var (
 	_ ObjectStore = (*GCSStore)(nil)
 	_ ObjectStore = (*S3Store)(nil)
 )
+
+func TestCustomEndpointsUseSafeDialer(t *testing.T) {
+	for _, file := range []string{"gcs.go", "s3.go"} {
+		t.Run(file, func(t *testing.T) {
+			src, err := os.ReadFile(file)
+			require.NoError(t, err)
+			require.Contains(t, string(src), "safedial.Client(0)",
+				"custom archive endpoints must keep the same SSRF dial guard as the sinks")
+		})
+	}
+}

--- a/flow/store/archive/duckdb.go
+++ b/flow/store/archive/duckdb.go
@@ -59,19 +59,63 @@ type duckdbStore struct {
 // DuckDB connection opens lazily on each Query so a transient bucket
 // outage does not bring management down on boot.
 func New(cfg Config) (store.Store, error) {
+	cfg, err := normalizeConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &duckdbStore{
+		cfg: cfg,
+		sem: make(chan struct{}, cfg.MaxConcurrentQueries),
+	}, nil
+}
+
+// OpenParquetDB opens a DuckDB handle configured like the archive reader.
+// The compaction tool needs direct SQL access for COPY/read_parquet while
+// still sharing the reader's auth, memory and thread setup.
+func OpenParquetDB(ctx context.Context, cfg Config) (*sql.DB, error) {
+	cfg, err := normalizeConfig(configWithRuntimeEnv(cfg))
+	if err != nil {
+		return nil, err
+	}
+	conn, err := openDuckDB()
+	if err != nil {
+		return nil, err
+	}
+	d := &duckdbStore{cfg: cfg}
+	if err := d.bootstrapConn(ctx, conn); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return conn, nil
+}
+
+func openDuckDB() (*sql.DB, error) {
+	conn, err := sql.Open("duckdb", "")
+	if err != nil {
+		return nil, fmt.Errorf("flow archive store: open duckdb: %w", err)
+	}
+	// bootstrapConn installs SETs and SECRETs on this handle. Keep the
+	// handle to one physical connection so a later Query/COPY cannot land
+	// on a fresh connection that never saw them.
+	conn.SetMaxOpenConns(1)
+	conn.SetMaxIdleConns(1)
+	return conn, nil
+}
+
+func normalizeConfig(cfg Config) (Config, error) {
 	if cfg.Bucket == "" {
-		return nil, fmt.Errorf("flow archive store: Bucket is required")
+		return Config{}, fmt.Errorf("flow archive store: Bucket is required")
 	}
 	if cfg.Provider == "" {
-		return nil, fmt.Errorf("flow archive store: Provider is required (s3 | gcs)")
+		return Config{}, fmt.Errorf("flow archive store: Provider is required (s3 | gcs)")
 	}
 	switch cfg.Provider {
 	case "s3", "gcs":
 	default:
-		return nil, fmt.Errorf("flow archive store: unsupported provider %q (want s3 | gcs)", cfg.Provider)
+		return Config{}, fmt.Errorf("flow archive store: unsupported provider %q (want s3 | gcs)", cfg.Provider)
 	}
 	if cfg.Provider == "gcs" && (cfg.AccessKeyID == "" || cfg.SecretAccessKey == "") {
-		return nil, newGCSHMACCredentialsError()
+		return Config{}, newGCSHMACCredentialsError()
 	}
 	if cfg.QueryTimeout <= 0 {
 		cfg.QueryTimeout = defaultQueryTimeout
@@ -85,10 +129,7 @@ func New(cfg Config) (store.Store, error) {
 	if cfg.MaxConcurrentQueries <= 0 {
 		cfg.MaxConcurrentQueries = defaultMaxConcurrentQueries
 	}
-	return &duckdbStore{
-		cfg: cfg,
-		sem: make(chan struct{}, cfg.MaxConcurrentQueries),
-	}, nil
+	return cfg, nil
 }
 
 // Save is a no-op: the archive is populated by the FlowService fan-out
@@ -136,9 +177,9 @@ func (d *duckdbStore) Query(ctx context.Context, f store.Filter) ([]*store.Event
 		return nil, ctx.Err()
 	}
 
-	conn, err := sql.Open("duckdb", "")
+	conn, err := openDuckDB()
 	if err != nil {
-		return nil, fmt.Errorf("flow archive store: open duckdb: %w", err)
+		return nil, err
 	}
 	defer conn.Close()
 
@@ -633,7 +674,7 @@ func quoteString(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }
 
-// stripScheme normalises endpoints DuckDB expects without a scheme
+// stripScheme normalizes endpoints DuckDB expects without a scheme
 // (it manages http vs https via USE_SSL). Operators set
 // `https://...` for production and `http://localhost:9000` for
 // MinIO; we feed DuckDB the host portion either way.

--- a/flow/store/archive/duckdb_stub.go
+++ b/flow/store/archive/duckdb_stub.go
@@ -4,6 +4,7 @@ package archive
 
 import (
 	"context"
+	"database/sql"
 	"time"
 
 	"github.com/openzro/openzro/flow/store"
@@ -14,6 +15,10 @@ import (
 // ErrUnavailable and falls back to hot-only behavior — same UX as
 // the v0.53.x line before ADR-0012.
 func New(_ Config) (store.Store, error) {
+	return nil, ErrUnavailable
+}
+
+func OpenParquetDB(_ context.Context, _ Config) (*sql.DB, error) {
 	return nil, ErrUnavailable
 }
 

--- a/flow/store/archive/duckdb_test.go
+++ b/flow/store/archive/duckdb_test.go
@@ -59,6 +59,15 @@ func TestNewParquet_GCSUsesHMACEnv(t *testing.T) {
 		"the write-side credential can remain on the config, but DuckDB reads with HMAC")
 }
 
+func TestOpenDuckDBUsesOnePhysicalConnection(t *testing.T) {
+	db, err := openDuckDB()
+	require.NoError(t, err)
+	defer db.Close()
+
+	require.Equal(t, 1, db.Stats().MaxOpenConnections,
+		"DuckDB SETs and SECRETs are connection-local; queries must use the bootstrapped connection")
+}
+
 // TestBuildQuery_AccountIDOnly produces the simplest viable query —
 // just `WHERE 1=1 ORDER BY ... LIMIT MaxRowsPerQuery`. Verifies the
 // glob URL and the safety-net LIMIT both land in the SQL.

--- a/flow/store/archive/factory.go
+++ b/flow/store/archive/factory.go
@@ -79,7 +79,7 @@ const (
 // In practice an operator picks one, so the precedence rarely
 // matters.
 func NewFromEnv() (store.Store, error) {
-	cfg, ok := configFromEnv()
+	cfg, ok := ConfigFromEnv()
 	if !ok {
 		// No bucket configured → operator opted out, not a failure.
 		return nil, nil
@@ -108,6 +108,17 @@ func NewFromEnv() (store.Store, error) {
 // GCS dashboard rows still write through service-account credentials;
 // the DuckDB reader takes its HMAC interoperability pair from env.
 func NewParquet(cfg Config) (store.Store, error) {
+	return New(configWithRuntimeEnv(cfg))
+}
+
+// ConfigFromEnv returns the archive bucket configuration from the
+// OPENZRO_FLOW_ARCHIVE_* environment variables, without checking the
+// effective archive format.
+func ConfigFromEnv() (Config, bool) {
+	return configFromEnv()
+}
+
+func configWithRuntimeEnv(cfg Config) Config {
 	cfg.QueryTimeout = parseTimeout(os.Getenv(envQueryTimeout))
 	cfg.MemoryLimit = os.Getenv(envMemoryLimit)
 	cfg.Threads = parseInt(os.Getenv(envThreads))
@@ -120,7 +131,7 @@ func NewParquet(cfg Config) (store.Store, error) {
 			cfg.SecretAccessKey = os.Getenv(envGCSHMACSecret)
 		}
 	}
-	return New(cfg)
+	return cfg
 }
 
 // parseInt parses an env-supplied integer, returning 0 on empty or

--- a/flow/store/archive/query_bind_test.go
+++ b/flow/store/archive/query_bind_test.go
@@ -59,7 +59,7 @@ func TestBuildQueryPreparesWithFilters(t *testing.T) {
 
 // A path holding a single quote must not break the statement, since the glob
 // is now interpolated. Bucket and prefix come from operator configuration
-// rather than request input, so this is defence in depth, not a live hole.
+// rather than request input, so this is defense in depth, not a live hole.
 func TestBuildQueryQuotesTheGlob(t *testing.T) {
 	q, args := buildQuery("gcs://bucket/it's/**/*.parquet", store.Filter{AccountID: "acct-1"}, 1)
 	require.Contains(t, q, "it''s", "a single quote has to be doubled for DuckDB")

--- a/management/cmd/flow_archive_compact.go
+++ b/management/cmd/flow_archive_compact.go
@@ -1,0 +1,403 @@
+//go:build archive_duckdb
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	flowArchive "github.com/openzro/openzro/flow/store/archive"
+	archiveCompact "github.com/openzro/openzro/flow/store/archive/compact"
+)
+
+type flowArchiveCompactOptions struct {
+	from            string
+	to              string
+	manifest        string
+	deleteOriginals bool
+	concurrency     int
+
+	provider           string
+	bucket             string
+	prefix             string
+	endpoint           string
+	region             string
+	gcsCredentialsFile string
+}
+
+func init() {
+	rootCmd.AddCommand(newFlowArchiveCommand())
+}
+
+func newFlowArchiveCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "flow-archive",
+		Short:        "Operate on archived flow traffic",
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newFlowArchiveCompactCommand())
+	return cmd
+}
+
+func newFlowArchiveCompactCommand() *cobra.Command {
+	opts := &flowArchiveCompactOptions{concurrency: 1}
+	cmd := &cobra.Command{
+		Use:   "compact --from YYYY-MM-DD --to YYYY-MM-DD --manifest FILE [--delete-originals]",
+		Short: "Compact and repartition archived flow Parquet objects",
+		Long: "Compact and repartition archived flow Parquet objects.\n\n" +
+			"Archive bucket settings default to OPENZRO_FLOW_ARCHIVE_* environment variables. " +
+			"Credentials stay in that env/file contract rather than command-line flags, so they do not land in shell history.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runFlowArchiveCompact(cmd, opts)
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVar(&opts.from, "from", "", "first UTC day to process, inclusive (YYYY-MM-DD)")
+	flags.StringVar(&opts.to, "to", "", "last UTC day to process, inclusive (YYYY-MM-DD)")
+	flags.StringVar(&opts.manifest, "manifest", "", "path for the JSONL manifest; must not already exist")
+	flags.BoolVar(&opts.deleteOriginals, "delete-originals", false, "delete originals after replacements are verified; omitted means dry-run")
+	flags.IntVar(&opts.concurrency, "concurrency", 1, "number of days to process at once")
+
+	flags.StringVar(&opts.provider, "provider", "", "archive provider override (s3 or gcs); defaults to OPENZRO_FLOW_ARCHIVE_*")
+	flags.StringVar(&opts.bucket, "bucket", "", "archive bucket override")
+	flags.StringVar(&opts.prefix, "prefix", "", "archive key prefix override")
+	flags.StringVar(&opts.endpoint, "endpoint", "", "object store endpoint override")
+	flags.StringVar(&opts.region, "region", "", "S3 region override")
+	flags.StringVar(&opts.gcsCredentialsFile, "gcs-credentials-file", "", "GCS service-account credentials file for writes/deletes")
+
+	_ = cmd.MarkFlagRequired("from")
+	_ = cmd.MarkFlagRequired("to")
+	_ = cmd.MarkFlagRequired("manifest")
+	return cmd
+}
+
+func runFlowArchiveCompact(cmd *cobra.Command, opts *flowArchiveCompactOptions) error {
+	from, to, err := parseCompactRange(opts.from, opts.to)
+	if err != nil {
+		return err
+	}
+	if opts.concurrency <= 0 {
+		return fmt.Errorf("flow archive compact: --concurrency must be greater than zero")
+	}
+
+	cfg, err := flowArchiveCompactConfig(cmd, opts)
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(opts.manifest); err == nil {
+		return fmt.Errorf("flow archive compact: manifest %s already exists", opts.manifest)
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("flow archive compact: check manifest %s: %w", opts.manifest, err)
+	}
+
+	// Fail configuration/bootstrap errors before creating the manifest.
+	// Workers open their own handles below; this one proves the shared
+	// auth and DuckDB setup are viable so an operator can retry with the
+	// same manifest path after fixing configuration.
+	db, err := flowArchive.OpenParquetDB(cmd.Context(), cfg)
+	if err != nil {
+		return err
+	}
+	_ = db.Close()
+
+	objStore, closeStore, err := flowArchiveCompactStore(cmd.Context(), cfg)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = closeStore() }()
+
+	manifest, err := os.OpenFile(opts.manifest, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("flow archive compact: create manifest %s: %w", opts.manifest, err)
+	}
+	defer func() { _ = manifest.Close() }()
+	enc := json.NewEncoder(manifest)
+
+	dryRun := !opts.deleteOriginals
+	days, skipped := compactDays(from, to, time.Now().UTC(), dryRun)
+	for _, entry := range skipped {
+		if err := enc.Encode(entry); err != nil {
+			return fmt.Errorf("flow archive compact: write manifest: %w", err)
+		}
+		cmd.Printf("%s skipped: %s\n", entry.Day, entry.SkippedBecause)
+	}
+	if len(days) == 0 {
+		return nil
+	}
+
+	if dryRun {
+		cmd.PrintErrln("flow archive compact: dry-run; no replacements will be written and no originals will be deleted")
+	}
+
+	ctx, cancel := context.WithCancel(cmd.Context())
+	defer cancel()
+
+	jobs := make(chan time.Time)
+	results := make(chan flowArchiveCompactManifestEntry)
+	var wg sync.WaitGroup
+	workers := opts.concurrency
+	if workers > len(days) {
+		workers = len(days)
+	}
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			flowArchiveCompactWorker(ctx, cfg, objStore, dryRun, jobs, results)
+		}()
+	}
+	go func() {
+		defer close(jobs)
+		for _, day := range days {
+			select {
+			case jobs <- day:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	return writeFlowArchiveCompactResults(cmd, enc, results, dryRun, cancel)
+}
+
+func writeFlowArchiveCompactResults(
+	cmd *cobra.Command,
+	enc *json.Encoder,
+	results <-chan flowArchiveCompactManifestEntry,
+	dryRun bool,
+	cancel context.CancelFunc,
+) error {
+	var firstErr error
+	for entry := range results {
+		if err := enc.Encode(entry); err != nil {
+			cancel()
+			return fmt.Errorf("flow archive compact: write manifest: %w", err)
+		}
+		if entry.Error != "" && firstErr == nil {
+			firstErr = errors.New(entry.Error)
+			if !dryRun {
+				cancel()
+			}
+		}
+		if entry.Error != "" {
+			cmd.Printf("%s failed: %s\n", entry.Day, entry.Error)
+			continue
+		}
+		if entry.Skipped {
+			cmd.Printf("%s skipped: %s\n", entry.Day, entry.SkippedBecause)
+			continue
+		}
+		cmd.Printf("%s objects %d -> %d rows=%d dry_run=%t\n",
+			entry.Day, entry.ObjectsBefore, entry.ObjectsAfter, entry.Rows, entry.DryRun)
+	}
+	return firstErr
+}
+
+func flowArchiveCompactWorker(
+	ctx context.Context,
+	cfg flowArchive.Config,
+	objStore archiveCompact.ObjectStore,
+	dryRun bool,
+	jobs <-chan time.Time,
+	results chan<- flowArchiveCompactManifestEntry,
+) {
+	db, err := flowArchive.OpenParquetDB(ctx, cfg)
+	if err != nil {
+		for day := range jobs {
+			results <- flowArchiveCompactManifestEntry{Day: formatCompactDay(day), DryRun: dryRun, Error: err.Error()}
+		}
+		return
+	}
+	defer func() { _ = db.Close() }()
+
+	compactor := &archiveCompact.Compactor{
+		DB:        db,
+		Store:     objStore,
+		ReadRoot:  archiveRootURL(cfg),
+		KeyPrefix: strings.Trim(cfg.Prefix, "/"),
+		DryRun:    dryRun,
+	}
+	for day := range jobs {
+		res, err := compactor.CompactDay(ctx, day)
+		entry := flowArchiveCompactEntry(res)
+		if err != nil {
+			entry.Error = err.Error()
+		}
+		results <- entry
+		if err != nil && !dryRun {
+			return
+		}
+	}
+}
+
+type flowArchiveCompactManifestEntry struct {
+	Day            string                     `json:"day"`
+	DryRun         bool                       `json:"dry_run"`
+	Skipped        bool                       `json:"skipped"`
+	SkippedBecause string                     `json:"skipped_because,omitempty"`
+	ObjectsBefore  int                        `json:"objects_before"`
+	ObjectsAfter   int                        `json:"objects_after"`
+	Rows           int64                      `json:"rows"`
+	BytesWritten   int64                      `json:"bytes_written"`
+	BytesPlanned   int64                      `json:"bytes_planned,omitempty"`
+	Accounts       []string                   `json:"accounts,omitempty"`
+	Orphans        []string                   `json:"orphans,omitempty"`
+	Fingerprint    archiveCompact.Fingerprint `json:"fingerprint"`
+	Error          string                     `json:"error,omitempty"`
+}
+
+func flowArchiveCompactEntry(res archiveCompact.Result) flowArchiveCompactManifestEntry {
+	bytesWritten := res.BytesWritten
+	var bytesPlanned int64
+	if res.DryRun {
+		bytesPlanned = res.BytesWritten
+		bytesWritten = 0
+	}
+	return flowArchiveCompactManifestEntry{
+		Day:            formatCompactDay(res.Day),
+		DryRun:         res.DryRun,
+		Skipped:        res.Skipped,
+		SkippedBecause: res.SkippedBecause,
+		ObjectsBefore:  res.ObjectsBefore,
+		ObjectsAfter:   res.ObjectsAfter,
+		Rows:           res.Rows,
+		BytesWritten:   bytesWritten,
+		BytesPlanned:   bytesPlanned,
+		Accounts:       res.Accounts,
+		Orphans:        res.Orphans,
+		Fingerprint:    res.Fingerprint,
+	}
+}
+
+func compactDays(from, to, now time.Time, dryRun bool) ([]time.Time, []flowArchiveCompactManifestEntry) {
+	today := utcDay(now)
+	yesterday := today.AddDate(0, 0, -1)
+	var days []time.Time
+	var skipped []flowArchiveCompactManifestEntry
+	for d := from; !d.After(to); d = d.AddDate(0, 0, 1) {
+		if !d.Before(yesterday) {
+			skipped = append(skipped, flowArchiveCompactManifestEntry{
+				Day:            formatCompactDay(d),
+				DryRun:         dryRun,
+				Skipped:        true,
+				SkippedBecause: "today and yesterday may still be receiving archive writes",
+			})
+			continue
+		}
+		days = append(days, d)
+	}
+	return days, skipped
+}
+
+func parseCompactRange(from, to string) (time.Time, time.Time, error) {
+	start, err := parseCompactDay(from)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("flow archive compact: --from: %w", err)
+	}
+	end, err := parseCompactDay(to)
+	if err != nil {
+		return time.Time{}, time.Time{}, fmt.Errorf("flow archive compact: --to: %w", err)
+	}
+	if end.Before(start) {
+		return time.Time{}, time.Time{}, fmt.Errorf("flow archive compact: --to must be on or after --from")
+	}
+	return start, end, nil
+}
+
+func parseCompactDay(s string) (time.Time, error) {
+	d, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("expected YYYY-MM-DD")
+	}
+	return utcDay(d), nil
+}
+
+func utcDay(t time.Time) time.Time {
+	t = t.UTC()
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+}
+
+func formatCompactDay(t time.Time) string {
+	return utcDay(t).Format("2006-01-02")
+}
+
+func flowArchiveCompactConfig(cmd *cobra.Command, opts *flowArchiveCompactOptions) (flowArchive.Config, error) {
+	cfg, _ := flowArchive.ConfigFromEnv()
+	flags := cmd.Flags()
+	if flags.Changed("provider") {
+		cfg.Provider = opts.provider
+	}
+	if flags.Changed("bucket") {
+		cfg.Bucket = opts.bucket
+	}
+	if flags.Changed("prefix") {
+		cfg.Prefix = opts.prefix
+	}
+	if flags.Changed("endpoint") {
+		cfg.Endpoint = opts.endpoint
+	}
+	if flags.Changed("region") {
+		cfg.Region = opts.region
+	}
+	if flags.Changed("gcs-credentials-file") {
+		cfg.CredentialsFile = opts.gcsCredentialsFile
+	}
+	if cfg.Provider == "" || cfg.Bucket == "" {
+		return flowArchive.Config{}, fmt.Errorf(
+			"flow archive compact: archive provider and bucket are required; set OPENZRO_FLOW_ARCHIVE_* or pass --provider and --bucket")
+	}
+	return cfg, nil
+}
+
+func flowArchiveCompactStore(ctx context.Context, cfg flowArchive.Config) (archiveCompact.ObjectStore, func() error, error) {
+	switch cfg.Provider {
+	case "gcs":
+		st, err := archiveCompact.NewGCS(ctx, archiveCompact.GCSConfig{
+			Bucket:          cfg.Bucket,
+			Prefix:          cfg.Prefix,
+			Endpoint:        cfg.Endpoint,
+			CredentialsJSON: cfg.CredentialsJSON,
+			CredentialsFile: cfg.CredentialsFile,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		return st, st.Close, nil
+	case "s3":
+		st, err := archiveCompact.NewS3(ctx, archiveCompact.S3Config{
+			Bucket:    cfg.Bucket,
+			Prefix:    cfg.Prefix,
+			Region:    cfg.Region,
+			Endpoint:  cfg.Endpoint,
+			AccessKey: cfg.AccessKeyID,
+			SecretKey: cfg.SecretAccessKey,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		return st, func() error { return nil }, nil
+	default:
+		return nil, nil, fmt.Errorf("flow archive compact: unsupported provider %q (want s3 | gcs)", cfg.Provider)
+	}
+}
+
+func archiveRootURL(cfg flowArchive.Config) string {
+	root := fmt.Sprintf("%s://%s", cfg.Provider, cfg.Bucket)
+	if prefix := strings.Trim(cfg.Prefix, "/"); prefix != "" {
+		root += "/" + prefix
+	}
+	return root
+}

--- a/management/cmd/flow_archive_compact_stub.go
+++ b/management/cmd/flow_archive_compact_stub.go
@@ -1,0 +1,47 @@
+//go:build !archive_duckdb
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	flowArchive "github.com/openzro/openzro/flow/store/archive"
+)
+
+func init() {
+	archiveCmd := &cobra.Command{
+		Use:          "flow-archive",
+		Short:        "Operate on archived flow traffic",
+		SilenceUsage: true,
+	}
+	compactCmd := &cobra.Command{
+		Use:   "compact --from YYYY-MM-DD --to YYYY-MM-DD --manifest FILE [--delete-originals]",
+		Short: "Compact and repartition archived flow Parquet objects",
+		Long: "Compact and repartition archived flow Parquet objects.\n\n" +
+			"Archive bucket settings default to OPENZRO_FLOW_ARCHIVE_* environment variables. " +
+			"Credentials stay in that env/file contract rather than command-line flags, so they do not land in shell history.",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fmt.Errorf("%w: flow archive compaction requires a binary built with -tags=archive_duckdb", flowArchive.ErrUnavailable)
+		},
+	}
+	var ignoredString string
+	var ignoredBool bool
+	var ignoredInt int
+	flags := compactCmd.Flags()
+	flags.StringVar(&ignoredString, "from", "", "first UTC day to process, inclusive (YYYY-MM-DD)")
+	flags.StringVar(&ignoredString, "to", "", "last UTC day to process, inclusive (YYYY-MM-DD)")
+	flags.StringVar(&ignoredString, "manifest", "", "path for the JSONL manifest; must not already exist")
+	flags.BoolVar(&ignoredBool, "delete-originals", false, "delete originals after replacements are verified; omitted means dry-run")
+	flags.IntVar(&ignoredInt, "concurrency", 1, "number of days to process at once")
+	flags.StringVar(&ignoredString, "provider", "", "archive provider override (s3 or gcs); defaults to OPENZRO_FLOW_ARCHIVE_*")
+	flags.StringVar(&ignoredString, "bucket", "", "archive bucket override")
+	flags.StringVar(&ignoredString, "prefix", "", "archive key prefix override")
+	flags.StringVar(&ignoredString, "endpoint", "", "object store endpoint override")
+	flags.StringVar(&ignoredString, "region", "", "S3 region override")
+	flags.StringVar(&ignoredString, "gcs-credentials-file", "", "GCS service-account credentials file for writes/deletes")
+	archiveCmd.AddCommand(compactCmd)
+	rootCmd.AddCommand(archiveCmd)
+}

--- a/management/cmd/flow_archive_compact_test.go
+++ b/management/cmd/flow_archive_compact_test.go
@@ -1,0 +1,269 @@
+//go:build archive_duckdb
+
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	flowArchive "github.com/openzro/openzro/flow/store/archive"
+	archiveCompact "github.com/openzro/openzro/flow/store/archive/compact"
+)
+
+func TestParseCompactRange(t *testing.T) {
+	from, to, err := parseCompactRange("2026-07-01", "2026-07-03")
+	require.NoError(t, err)
+	require.Equal(t, "2026-07-01", formatCompactDay(from))
+	require.Equal(t, "2026-07-03", formatCompactDay(to))
+
+	_, _, err = parseCompactRange("2026-07-03", "2026-07-01")
+	require.ErrorContains(t, err, "--to must be on or after --from")
+
+	_, _, err = parseCompactRange("07/01/2026", "2026-07-03")
+	require.ErrorContains(t, err, "--from")
+}
+
+func TestCompactDaysSkipsTodayAndYesterday(t *testing.T) {
+	from := time.Date(2026, 7, 27, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 7, 30, 0, 0, 0, 0, time.UTC)
+	now := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
+
+	days, skipped := compactDays(from, to, now, true)
+	require.Equal(t, []string{"2026-07-27", "2026-07-28"}, compactDayStrings(days))
+	require.Len(t, skipped, 2)
+	require.Equal(t, "2026-07-29", skipped[0].Day)
+	require.Equal(t, "2026-07-30", skipped[1].Day)
+	for _, entry := range skipped {
+		require.True(t, entry.Skipped)
+		require.True(t, entry.DryRun)
+		require.Contains(t, entry.SkippedBecause, "today and yesterday")
+	}
+}
+
+func TestArchiveRootURL(t *testing.T) {
+	require.Equal(t, "s3://bucket/flows", archiveRootURL(flowArchive.Config{
+		Provider: "s3",
+		Bucket:   "bucket",
+		Prefix:   "/flows/",
+	}))
+	require.Equal(t, "gcs://bucket", archiveRootURL(flowArchive.Config{
+		Provider: "gcs",
+		Bucket:   "bucket",
+	}))
+}
+
+func TestFlowArchiveCompactEntrySeparatesPlannedAndWrittenBytes(t *testing.T) {
+	day := time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC)
+
+	dryRun := flowArchiveCompactEntry(archiveCompact.Result{
+		Day:          day,
+		DryRun:       true,
+		BytesWritten: 1234,
+	})
+	require.Zero(t, dryRun.BytesWritten, "dry-run writes nothing to the bucket")
+	require.Equal(t, int64(1234), dryRun.BytesPlanned)
+
+	apply := flowArchiveCompactEntry(archiveCompact.Result{
+		Day:          day,
+		DryRun:       false,
+		BytesWritten: 1234,
+	})
+	require.Equal(t, int64(1234), apply.BytesWritten)
+	require.Zero(t, apply.BytesPlanned)
+}
+
+func TestFlowArchiveCompactDryRunWritesEveryResultAfterError(t *testing.T) {
+	results := make(chan flowArchiveCompactManifestEntry, 2)
+	results <- flowArchiveCompactManifestEntry{Day: "2026-07-01", DryRun: true, Error: "bad parquet"}
+	results <- flowArchiveCompactManifestEntry{Day: "2026-07-02", DryRun: true, Skipped: true, SkippedBecause: "no source objects"}
+	close(results)
+
+	var manifest bytes.Buffer
+	canceled := false
+	err := writeFlowArchiveCompactResults(&cobra.Command{}, json.NewEncoder(&manifest), results, true, func() {
+		canceled = true
+	})
+	require.ErrorContains(t, err, "bad parquet")
+	require.False(t, canceled, "dry-run is a survey; one bad day must not hide the rest of the range")
+
+	var entries []flowArchiveCompactManifestEntry
+	for _, line := range bytes.Split(bytes.TrimSpace(manifest.Bytes()), []byte("\n")) {
+		var entry flowArchiveCompactManifestEntry
+		require.NoError(t, json.Unmarshal(line, &entry))
+		entries = append(entries, entry)
+	}
+	require.Len(t, entries, 2, "every day result must remain visible in the manifest")
+	require.Equal(t, "2026-07-01", entries[0].Day)
+	require.Equal(t, "bad parquet", entries[0].Error)
+	require.Equal(t, "2026-07-02", entries[1].Day)
+	require.True(t, entries[1].Skipped)
+}
+
+func TestFlowArchiveCompactDeleteRunCancelsOnFirstError(t *testing.T) {
+	results := make(chan flowArchiveCompactManifestEntry, 1)
+	results <- flowArchiveCompactManifestEntry{Day: "2026-07-01", Error: "delete failed"}
+	close(results)
+
+	canceled := false
+	err := writeFlowArchiveCompactResults(&cobra.Command{}, json.NewEncoder(&bytes.Buffer{}), results, false, func() {
+		canceled = true
+	})
+	require.ErrorContains(t, err, "delete failed")
+	require.True(t, canceled, "a destructive run must stop on the first failed day")
+}
+
+func TestFlowArchiveCompactWorkerStopsDestructiveRunAfterDayError(t *testing.T) {
+	jobs := make(chan time.Time, 2)
+	jobs <- time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	jobs <- time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC)
+	close(jobs)
+	results := make(chan flowArchiveCompactManifestEntry, 2)
+	st := &listErrorObjectStore{err: errors.New("bucket refused list")}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		flowArchiveCompactWorker(context.Background(), testArchiveConfig(), st, false, jobs, results)
+	}()
+
+	requireWorkerDone(t, done)
+	require.Len(t, st.prefixes, 1, "after a destructive day error the worker must not consume an already queued next day")
+	require.Len(t, jobs, 1, "the next day must remain untouched for the canceled run to stop cleanly")
+
+	got := drainCompactResults(results)
+	require.Len(t, got, 1)
+	require.Equal(t, "2026-07-01", got[0].Day)
+	require.ErrorContains(t, errors.New(got[0].Error), "bucket refused list")
+}
+
+func TestFlowArchiveCompactWorkerContinuesDryRunAfterDayError(t *testing.T) {
+	jobs := make(chan time.Time, 2)
+	jobs <- time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	jobs <- time.Date(2026, 7, 2, 0, 0, 0, 0, time.UTC)
+	close(jobs)
+	results := make(chan flowArchiveCompactManifestEntry, 2)
+	st := &listErrorObjectStore{err: errors.New("bucket refused list")}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		flowArchiveCompactWorker(context.Background(), testArchiveConfig(), st, true, jobs, results)
+	}()
+
+	requireWorkerDone(t, done)
+	require.Len(t, st.prefixes, 2, "dry-run is a survey and should report every queued day")
+	require.Len(t, jobs, 0)
+
+	got := drainCompactResults(results)
+	require.Len(t, got, 2)
+	require.Equal(t, "2026-07-01", got[0].Day)
+	require.Equal(t, "2026-07-02", got[1].Day)
+	require.True(t, got[0].DryRun)
+	require.True(t, got[1].DryRun)
+}
+
+func TestFlowArchiveCompactDoesNotCreateManifestWhenStoreConfigFails(t *testing.T) {
+	manifest := t.TempDir() + "/manifest.jsonl"
+	cmd := newFlowArchiveCompactCommand()
+	cmd.SetArgs([]string{
+		"--from", "2026-07-01",
+		"--to", "2026-07-01",
+		"--manifest", manifest,
+		"--provider", "unsupported",
+		"--bucket", "bucket",
+	})
+
+	err := cmd.Execute()
+	require.ErrorContains(t, err, "unsupported provider")
+
+	_, statErr := os.Stat(manifest)
+	require.True(t, errors.Is(statErr, os.ErrNotExist), "a config failure must not leave an empty manifest that blocks retry")
+}
+
+func TestFlowArchiveCompactDoesNotCreateManifestWhenDuckDBConfigFails(t *testing.T) {
+	t.Setenv("OPENZRO_FLOW_ARCHIVE_GCS_HMAC_KEY_ID", "")
+	t.Setenv("OPENZRO_FLOW_ARCHIVE_GCS_HMAC_SECRET", "")
+	manifest := t.TempDir() + "/manifest.jsonl"
+	cmd := newFlowArchiveCompactCommand()
+	cmd.SetArgs([]string{
+		"--from", "2026-07-01",
+		"--to", "2026-07-01",
+		"--manifest", manifest,
+		"--provider", "gcs",
+		"--bucket", "bucket",
+	})
+
+	err := cmd.Execute()
+	require.ErrorContains(t, err, "GCS archive reads need HMAC credentials")
+
+	_, statErr := os.Stat(manifest)
+	require.True(t, errors.Is(statErr, os.ErrNotExist), "a DuckDB preflight failure must leave the manifest path reusable")
+}
+
+func compactDayStrings(days []time.Time) []string {
+	out := make([]string, 0, len(days))
+	for _, d := range days {
+		out = append(out, formatCompactDay(d))
+	}
+	return out
+}
+
+func testArchiveConfig() flowArchive.Config {
+	return flowArchive.Config{
+		Provider:        "s3",
+		Bucket:          "bucket",
+		AccessKeyID:     "key",
+		SecretAccessKey: "secret",
+	}
+}
+
+type listErrorObjectStore struct {
+	err      error
+	prefixes []string
+}
+
+func (s *listErrorObjectStore) List(_ context.Context, prefix string) ([]string, error) {
+	s.prefixes = append(s.prefixes, prefix)
+	return nil, s.err
+}
+
+func (s *listErrorObjectStore) Read(context.Context, string) ([]byte, error) {
+	return nil, errors.New("unexpected read")
+}
+
+func (s *listErrorObjectStore) Write(context.Context, string, []byte) error {
+	return errors.New("unexpected write")
+}
+
+func (s *listErrorObjectStore) Delete(context.Context, string) error {
+	return errors.New("unexpected delete")
+}
+
+func requireWorkerDone(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("flow archive compact worker did not return")
+	}
+}
+
+func drainCompactResults(results <-chan flowArchiveCompactManifestEntry) []flowArchiveCompactManifestEntry {
+	var out []flowArchiveCompactManifestEntry
+	for {
+		select {
+		case entry := <-results:
+			out = append(out, entry)
+		default:
+			return out
+		}
+	}
+}


### PR DESCRIPTION
Seven commits. A repair and audit tool, not a scheduled job: nothing here runs automatically and nothing is wired into management.

## Why

Measured on a production bucket: **13,185 objects averaging 7 KB**, about 150 per account-day. Reading one day opens about 150 of them, and with the reader's partition margin a one-day question opens **579**: roughly 2,000 HTTP round trips to move 10 MB, measured at **64-93 seconds**.

The bytes were never the problem. Parquet amortizes the footer read that precedes every file over the data in it, and at 7 KB there is nothing to amortize. Compaction does not shrink the archive, it makes it answerable: **579 opens become 4**.

It also repartitions. Rows written under the wrong account before the sinks split a batch (#186) are grouped under the account they actually carry: the half that closing the read-side leak could not do, since the reader globs by account and never opens a misfiled object on its owner's behalf. Rows filed under the wrong day, by a batch that crossed midnight, move likewise.

## Safety, in the order it happens

Nothing is deleted until the replacement is written **and read back out of the store** and its fingerprint matches the sources.

- **Fingerprint, not row count.** A count catches loss and nothing else; a rewrite that emits as many rows as it read with one of them changed passes it. `count + bit_xor(hash) + sum(hash)`, and the third exists because the second was measured rather than trusted: identical rows cancel under XOR, so a lost matched pair leaves it unchanged. Order-independent, which it must be, because merging 150 files into one reorders by construction. Partition columns are excluded on both sides, since repartitioning changes them on purpose.
- **Verified where it landed, not where it was sent.** A `Write` that reports success while storing something truncated is indistinguishable from success at every earlier step.
- **Cleanup is phase-aware.** Before the first original is deleted, a failure removes the replacement. A half-written parquet is not inert: the reader opens whatever the glob finds. After the first original is gone, the replacement is kept even if a later delete fails because it is the only complete copy.
- **Only the keys listed at the start** are deleted, so anything the sink writes mid-run survives. A re-listed prefix at the end would be a way to delete data nobody inspected.
- **Keys are opaque.** Stores validate that a key sits under their configured prefix and pass it through untouched. `flows` covers `flows/a` and not `flowsomething`; object stores have no directories and nothing else enforces that.

## The CLI

`openzro-mgmt flow-archive compact`, behind `-tags=archive_duckdb`.

Dry-run by default; deletes only with `--delete-originals`. `--from`, `--to`, and `--manifest` are required. Today and yesterday are skipped. No secret flags, so nothing lands in shell history or the process list. The manifest is JSONL, refuses to overwrite, and is written per day as results arrive.

A dry-run reports **every** day even after one fails: it is a survey, and a missing day in the manifest is indistinguishable from a day with nothing to do. A destructive run stops at the first failure, in both layers: the collector stops queueing and the worker stops consuming. Both directions are pinned by tests, because the first version had the worker and the collector expressing opposite intents.

## Object-store coverage

The S3 path now has an end-to-end compaction test against MinIO, using the same SDK path the S3 store uses in production. It seeds **1005 objects** to cross the pagination boundary, verifies that dry-run leaves the bucket untouched, verifies that absent deletes are successful, and proves DuckDB can read over HTTP what the SDK wrote.

The GCS store now runs against `fsouza/fake-gcs-server`: positive `Write`, `Read`, paginated `List` past 1000 objects, `Delete`, and absent `Delete` are covered through the Google Cloud Storage SDK. It does not induce an upload-finalization failure on `Writer.Close`; destructive safety still comes from the engine re-reading and fingerprinting replacement objects before deleting originals.

The fake server also forced the production store onto `storage.WithJSONReads()`. That is a supported client path and keeps reads on the same JSON API family as list/write/delete, but it is still emulator coverage, not validation against real GCS behavior.

This still is not a production-bucket rehearsal. Before running `--delete-originals` against real history, run a dry-run first, inspect the manifest, and preferably run the destructive command against a staging copy of the bucket.

## Two defects found by mutating tests rather than writing them

- DuckDB's `PARTITION_BY` writes `month=7` where the sinks write `month=07`, and the reader compares those as strings, where `'7'` sorts after `'07'`. Compaction would have hidden every day it touched while reporting success.
- Keying output by the requested day rather than by the partition DuckDB derived would have moved midnight-straddling rows instead of correcting them: right at every level except the one the reader prunes on.

Refs #186
