### PR TITLE
fix flow archive compaction for TIMESTAMPTZ

### DIFF
--- a/docs/operator/upgrade-notes.md
+++ b/docs/operator/upgrade-notes.md
@@ -142,6 +142,12 @@ object is still under the wrong prefix.
 **To find out whether you are affected**, run these against your archive
 with the DuckDB CLI. Substitute your bucket, prefix and scheme (`s3://`
 or `gcs://`), and configure credentials as your DuckDB install expects.
+Pin the session to UTC first; DuckDB reads the sink's Parquet timestamps
+as `TIMESTAMP WITH TIME ZONE`, and date functions use the session zone.
+
+```sql
+SET TimeZone='UTC';
+```
 
 ```sql
 -- Events filed under the wrong account.

--- a/flow/store/archive/compact/compact.go
+++ b/flow/store/archive/compact/compact.go
@@ -300,6 +300,9 @@ func (c *Compactor) CompactDay(ctx context.Context, day time.Time) (res Result, 
 // account's rows, or another day's rows, into one otherwise-normal
 // object, and those are exactly the rows this tool exists to recover.
 func (c *Compactor) isAlreadyCompact(ctx context.Context, glob string, sources []string, dayPrefix string) (bool, error) {
+	if err := c.pinUTC(ctx); err != nil {
+		return false, err
+	}
 	accounts := make(map[string]struct{}, len(sources))
 	for _, k := range sources {
 		account, ok := sourceAccount(k, dayPrefix)
@@ -316,13 +319,41 @@ func (c *Compactor) isAlreadyCompact(ctx context.Context, glob string, sources [
 	err := c.DB.QueryRowContext(ctx, `SELECT count(*)
 		FROM read_parquet(`+quote(glob)+`, hive_partitioning=true)
 		WHERE account_id <> CAST(account AS VARCHAR)
-		   OR printf('%04d', year(received_at)) <> CAST(year AS VARCHAR)
-		   OR printf('%02d', month(received_at)) <> CAST(month AS VARCHAR)
-		   OR printf('%02d', day(received_at)) <> CAST(day AS VARCHAR)`).Scan(&mismatched)
+		   OR printf('%04d', year(received_at::TIMESTAMP)) <> CAST(year AS VARCHAR)
+		   OR printf('%02d', month(received_at::TIMESTAMP)) <> CAST(month AS VARCHAR)
+		   OR printf('%02d', day(received_at::TIMESTAMP)) <> CAST(day AS VARCHAR)`).Scan(&mismatched)
 	if err != nil {
 		return false, err
 	}
 	return mismatched == 0, nil
+}
+
+// pinUTC forces the session's time zone, and does two jobs.
+//
+// It is what makes the date arithmetic bind at all. The sink writes
+// received_at as a UTC-adjusted parquet timestamp, which DuckDB reads
+// back as TIMESTAMP WITH TIME ZONE, and year() has no overload for that
+// type until a time zone is set -- SET TimeZone activates DuckDB's ICU
+// support, which supplies it. The first dry-run against the production
+// bucket failed with exactly that binder error, having passed every test
+// here, because no test fixture wrote the type the sink writes.
+//
+// And it decides what that arithmetic means. Rendering a TIMESTAMPTZ
+// uses the session zone, which otherwise follows the host: on a machine
+// in America/Sao_Paulo an event at 2026-06-01T02:30Z becomes "May 31"
+// and is filed under the previous day, silently, and only for events in
+// the first hours of a UTC day. The cluster this runs on is in that
+// zone. Measured, not feared.
+//
+// The archive's partitions are UTC by definition, so the session has to
+// be. The ::TIMESTAMP casts in the statements below are explicitness on
+// top of this, not the mechanism -- with the zone pinned, both forms
+// yield UTC.
+func (c *Compactor) pinUTC(ctx context.Context) error {
+	if _, err := c.DB.ExecContext(ctx, "SET TimeZone='UTC'"); err != nil {
+		return fmt.Errorf("compact: pin session to UTC: %w", err)
+	}
+	return nil
 }
 
 // rewrite is the whole merge. DuckDB reads the day, regroups by the
@@ -336,6 +367,9 @@ func (c *Compactor) isAlreadyCompact(ctx context.Context, glob string, sources [
 // unpadded directory would be silently excluded from every query whose
 // window it should match.
 func (c *Compactor) rewrite(ctx context.Context, glob, outDir string) error {
+	if err := c.pinUTC(ctx); err != nil {
+		return err
+	}
 	// #nosec G202 -- glob and outDir are not request input. They are
 	// built from operator configuration and a date this command was
 	// given, and both go through quote(), which doubles any single
@@ -345,9 +379,9 @@ func (c *Compactor) rewrite(ctx context.Context, glob, outDir string) error {
 	// are interpolated at all.
 	_, err := c.DB.ExecContext(ctx, `COPY (
 		SELECT * EXCLUDE (year, month, day, account),
-		       printf('%04d', year(received_at))  AS year,
-		       printf('%02d', month(received_at)) AS month,
-		       printf('%02d', day(received_at))   AS day,
+		       printf('%04d', year(received_at::TIMESTAMP))  AS year,
+		       printf('%02d', month(received_at::TIMESTAMP)) AS month,
+		       printf('%02d', day(received_at::TIMESTAMP))   AS day,
 		       account_id                         AS account
 		FROM read_parquet(`+quote(glob)+`, hive_partitioning=true)
 	) TO `+quote(outDir)+` (FORMAT PARQUET, PARTITION_BY (year, month, day, account), OVERWRITE_OR_IGNORE)`)

--- a/flow/store/archive/compact/compact.go
+++ b/flow/store/archive/compact/compact.go
@@ -366,10 +366,27 @@ func (c *Compactor) pinUTC(ctx context.Context) error {
 // reader compares those as strings, where '7' sorts after '07', so an
 // unpadded directory would be silently excluded from every query whose
 // window it should match.
-func (c *Compactor) rewrite(ctx context.Context, glob, outDir string) error {
+//
+// The ORDER BY is a physical layout choice: the reader sorts responses
+// anyway, but if the backfill writes old-first files, changing that later
+// means rewriting the archive again. DuckDB partitioned writes emit one
+// file per partition per thread, so ORDER BY alone does not preserve the
+// row order inside the replacement object; the rewrite pins threads to 1
+// for this COPY only, then restores the operator's setting.
+func (c *Compactor) rewrite(ctx context.Context, glob, outDir string) (err error) {
 	if err := c.pinUTC(ctx); err != nil {
 		return err
 	}
+	restoreThreads, err := c.pinSingleRewriteThread(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		restoreErr := restoreThreads(ctx)
+		if err == nil && restoreErr != nil {
+			err = restoreErr
+		}
+	}()
 	// #nosec G202 -- glob and outDir are not request input. They are
 	// built from operator configuration and a date this command was
 	// given, and both go through quote(), which doubles any single
@@ -377,15 +394,34 @@ func (c *Compactor) rewrite(ctx context.Context, glob, outDir string) error {
 	// parameter in this position leaves the binder nothing to expand --
 	// that failure shipped once already (openzro#185) and is why these
 	// are interpolated at all.
-	_, err := c.DB.ExecContext(ctx, `COPY (
+	_, err = c.DB.ExecContext(ctx, `COPY (
 		SELECT * EXCLUDE (year, month, day, account),
 		       printf('%04d', year(received_at::TIMESTAMP))  AS year,
 		       printf('%02d', month(received_at::TIMESTAMP)) AS month,
 		       printf('%02d', day(received_at::TIMESTAMP))   AS day,
-		       account_id                         AS account
+		       account_id                                    AS account
 		FROM read_parquet(`+quote(glob)+`, hive_partitioning=true)
+		ORDER BY year, month, day, account, received_at DESC
 	) TO `+quote(outDir)+` (FORMAT PARQUET, PARTITION_BY (year, month, day, account), OVERWRITE_OR_IGNORE)`)
 	return err
+}
+
+func (c *Compactor) pinSingleRewriteThread(ctx context.Context) (func(context.Context) error, error) {
+	var threads int
+	if err := c.DB.QueryRowContext(ctx, "SELECT current_setting('threads')::INTEGER").Scan(&threads); err != nil {
+		return nil, fmt.Errorf("compact: read DuckDB threads: %w", err)
+	}
+	if _, err := c.DB.ExecContext(ctx, "SET threads=1"); err != nil {
+		return nil, fmt.Errorf("compact: pin rewrite threads: %w", err)
+	}
+	return func(ctx context.Context) error {
+		// #nosec G201 -- threads was read as an integer from DuckDB's own
+		// current_setting() output, not from operator input.
+		if _, err := c.DB.ExecContext(ctx, fmt.Sprintf("SET threads=%d", threads)); err != nil {
+			return fmt.Errorf("compact: restore DuckDB threads: %w", err)
+		}
+		return nil
+	}, nil
 }
 
 // fingerprint reads a glob and summarizes its rows. See Fingerprint for

--- a/flow/store/archive/compact/compact.go
+++ b/flow/store/archive/compact/compact.go
@@ -367,26 +367,16 @@ func (c *Compactor) pinUTC(ctx context.Context) error {
 // unpadded directory would be silently excluded from every query whose
 // window it should match.
 //
-// The ORDER BY is a physical layout choice: the reader sorts responses
-// anyway, but if the backfill writes old-first files, changing that later
-// means rewriting the archive again. DuckDB partitioned writes emit one
-// file per partition per thread, so ORDER BY alone does not preserve the
-// row order inside the replacement object; the rewrite pins threads to 1
-// for this COPY only, then restores the operator's setting.
-func (c *Compactor) rewrite(ctx context.Context, glob, outDir string) (err error) {
+// The ORDER BY is a physical layout choice: the reader sorts API
+// responses anyway, but the compacted file's row-group statistics decide
+// whether DuckDB can skip unrelated ranges. Clustering by received_at
+// keeps those min/max ranges disjoint; without it, historical queries
+// scan every row group in the compacted object, and fixing that after a
+// destructive backfill means rewriting the archive again.
+func (c *Compactor) rewrite(ctx context.Context, glob, outDir string) error {
 	if err := c.pinUTC(ctx); err != nil {
 		return err
 	}
-	restoreThreads, err := c.pinSingleRewriteThread(ctx)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		restoreErr := restoreThreads(ctx)
-		if err == nil && restoreErr != nil {
-			err = restoreErr
-		}
-	}()
 	// #nosec G202 -- glob and outDir are not request input. They are
 	// built from operator configuration and a date this command was
 	// given, and both go through quote(), which doubles any single
@@ -394,7 +384,7 @@ func (c *Compactor) rewrite(ctx context.Context, glob, outDir string) (err error
 	// parameter in this position leaves the binder nothing to expand --
 	// that failure shipped once already (openzro#185) and is why these
 	// are interpolated at all.
-	_, err = c.DB.ExecContext(ctx, `COPY (
+	_, err := c.DB.ExecContext(ctx, `COPY (
 		SELECT * EXCLUDE (year, month, day, account),
 		       printf('%04d', year(received_at::TIMESTAMP))  AS year,
 		       printf('%02d', month(received_at::TIMESTAMP)) AS month,
@@ -404,24 +394,6 @@ func (c *Compactor) rewrite(ctx context.Context, glob, outDir string) (err error
 		ORDER BY year, month, day, account, received_at DESC
 	) TO `+quote(outDir)+` (FORMAT PARQUET, PARTITION_BY (year, month, day, account), OVERWRITE_OR_IGNORE)`)
 	return err
-}
-
-func (c *Compactor) pinSingleRewriteThread(ctx context.Context) (func(context.Context) error, error) {
-	var threads int
-	if err := c.DB.QueryRowContext(ctx, "SELECT current_setting('threads')::INTEGER").Scan(&threads); err != nil {
-		return nil, fmt.Errorf("compact: read DuckDB threads: %w", err)
-	}
-	if _, err := c.DB.ExecContext(ctx, "SET threads=1"); err != nil {
-		return nil, fmt.Errorf("compact: pin rewrite threads: %w", err)
-	}
-	return func(ctx context.Context) error {
-		// #nosec G201 -- threads was read as an integer from DuckDB's own
-		// current_setting() output, not from operator input.
-		if _, err := c.DB.ExecContext(ctx, fmt.Sprintf("SET threads=%d", threads)); err != nil {
-			return fmt.Errorf("compact: restore DuckDB threads: %w", err)
-		}
-		return nil
-	}, nil
 }
 
 // fingerprint reads a glob and summarizes its rows. See Fingerprint for

--- a/flow/store/archive/compact/compact_test.go
+++ b/flow/store/archive/compact/compact_test.go
@@ -53,6 +53,24 @@ func seed(t *testing.T, db *sql.DB, root, pathAccount, rowAccount, ts string, n 
 	require.NoError(t, err)
 }
 
+func seedManyShuffled(t *testing.T, db *sql.DB, root, file string, start, count, total int) {
+	t.Helper()
+	dir := filepath.Join(root, "flows", "year=2026", "month=07", "day=29", "account=acct-A")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	path := filepath.Join(dir, file)
+	_, err := db.ExecContext(context.Background(), "SET TimeZone='UTC'")
+	require.NoError(t, err)
+	_, err = db.ExecContext(context.Background(), fmt.Sprintf(`COPY (
+		SELECT (TIMESTAMP '2026-07-29 00:00:00'
+		       + (((i + %[1]d) * 104729 + 12345) %% %[3]d) * INTERVAL '1 microsecond')::TIMESTAMPTZ AS received_at,
+		       'acct-A' AS account_id,
+		       'peer-' || CAST(i + %[1]d AS VARCHAR) AS peer_id,
+		       'ev-' || CAST(i + %[1]d AS VARCHAR) AS event_id
+		FROM range(%[2]d) AS r(i)
+	) TO %[4]s (FORMAT PARQUET)`, start, count, total, quote(path)))
+	require.NoError(t, err)
+}
+
 // The headline: many tiny objects become one per account, and no row is
 // lost doing it. 40 objects of a few hundred bytes is the production
 // shape in miniature -- a real day held ~150.
@@ -509,6 +527,42 @@ func TestCompactDayWritesRowsNewestFirst(t *testing.T) {
 	}
 	require.NoError(t, rows.Err())
 	require.Equal(t, []string{"ev-5", "ev-4", "ev-3", "ev-2", "ev-1", "ev-0"}, got)
+}
+
+func TestCompactDayWritesDisjointReceivedAtRowGroups(t *testing.T) {
+	c, fs, db := newFixture(t)
+	const totalRows = 250_000
+	seedManyShuffled(t, db, fs.root, "source-a.parquet", 0, totalRows/2, totalRows)
+	seedManyShuffled(t, db, fs.root, "source-b.parquet", totalRows/2, totalRows/2, totalRows)
+
+	_, err := c.CompactDay(context.Background(), time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+
+	keys, err := fs.List(context.Background(), "flows")
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	var rowGroups, overlaps int64
+	err = db.QueryRowContext(context.Background(), `WITH groups AS (
+			SELECT row_group_id,
+			       stats_min_value::TIMESTAMPTZ AS min_ts,
+			       stats_max_value::TIMESTAMPTZ AS max_ts
+			FROM parquet_metadata(`+quote(filepath.Join(fs.root, filepath.FromSlash(keys[0])))+`)
+			WHERE path_in_schema = 'received_at'
+		),
+		ordered AS (
+			SELECT min_ts,
+			       lag(max_ts) OVER (ORDER BY min_ts) AS previous_max_ts
+			FROM groups
+		)
+		SELECT count(*),
+		       CAST(COALESCE(sum(CASE
+		           WHEN previous_max_ts IS NOT NULL AND min_ts <= previous_max_ts THEN 1
+		           ELSE 0
+		       END), 0) AS BIGINT)
+		FROM ordered`).Scan(&rowGroups, &overlaps)
+	require.NoError(t, err)
+	require.Greater(t, rowGroups, int64(1), "the test must exercise row-group pruning, not only row order")
+	require.Zero(t, overlaps, "received_at row groups must be disjoint for min/max pruning to skip old ranges")
 }
 
 func TestCompactDayRestoresRewriteThreads(t *testing.T) {

--- a/flow/store/archive/compact/compact_test.go
+++ b/flow/store/archive/compact/compact_test.go
@@ -478,6 +478,56 @@ func TestFingerprintIgnoresRowOrder(t *testing.T) {
 	require.NotEmpty(t, res.Fingerprint.Sum)
 }
 
+// The reader orders query results, so this is not a correctness
+// requirement for API responses. It is a physical layout choice for the
+// backfill: once the original small files are deleted, changing the
+// compacted files' row order means rewriting the archive again. Keep the
+// replacement newest-first before the destructive run makes that layout
+// expensive to change.
+func TestCompactDayWritesRowsNewestFirst(t *testing.T) {
+	c, fs, db := newFixture(t)
+	for i := range 6 {
+		seed(t, db, fs.root, "acct-A", "acct-A", day29+fmt.Sprintf(" %02d:00:00", i), i)
+	}
+
+	_, err := c.CompactDay(context.Background(), time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+
+	keys, err := fs.List(context.Background(), "flows")
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	rows, err := db.Query("SELECT event_id FROM read_parquet(" +
+		quote(filepath.Join(fs.root, filepath.FromSlash(keys[0]))) + ")")
+	require.NoError(t, err)
+	defer func() { _ = rows.Close() }()
+
+	var got []string
+	for rows.Next() {
+		var id string
+		require.NoError(t, rows.Scan(&id))
+		got = append(got, id)
+	}
+	require.NoError(t, rows.Err())
+	require.Equal(t, []string{"ev-5", "ev-4", "ev-3", "ev-2", "ev-1", "ev-0"}, got)
+}
+
+func TestCompactDayRestoresRewriteThreads(t *testing.T) {
+	c, fs, db := newFixture(t)
+	_, err := db.ExecContext(context.Background(), "SET threads=2")
+	require.NoError(t, err)
+	for i := range 6 {
+		seed(t, db, fs.root, "acct-A", "acct-A", day29+fmt.Sprintf(" %02d:00:00", i), i)
+	}
+
+	_, err = c.CompactDay(context.Background(), time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+
+	var threads int
+	err = db.QueryRowContext(context.Background(), "SELECT current_setting('threads')::INTEGER").Scan(&threads)
+	require.NoError(t, err)
+	require.Equal(t, 2, threads)
+}
+
 // Everything before this proves the rewrite was right. This proves the
 // write was. A Write that reports success while storing something else
 // -- truncated, empty, a different object -- looks identical to success

--- a/flow/store/archive/compact/compact_test.go
+++ b/flow/store/archive/compact/compact_test.go
@@ -511,6 +511,9 @@ func TestCompactDayWritesDisjointReceivedAtRowGroups(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, keys, 1)
 	var rowGroups, overlaps int64
+	// With parallel COPY, DuckDB keeps the received_at ranges disjoint
+	// but does not guarantee the row_group_id direction. That is fine:
+	// disjoint min/max statistics are the property range pruning needs.
 	err = db.QueryRowContext(context.Background(), `WITH groups AS (
 			SELECT row_group_id,
 			       stats_min_value::TIMESTAMPTZ AS min_ts,

--- a/flow/store/archive/compact/compact_test.go
+++ b/flow/store/archive/compact/compact_test.go
@@ -23,6 +23,8 @@ func newFixture(t *testing.T) (*Compactor, *fsStore, *sql.DB) {
 	t.Helper()
 	db, err := sql.Open("duckdb", "")
 	require.NoError(t, err)
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
 	t.Cleanup(func() { _ = db.Close() })
 
 	root := t.TempDir()
@@ -45,7 +47,7 @@ func seed(t *testing.T, db *sql.DB, root, pathAccount, rowAccount, ts string, n 
 	require.NoError(t, os.MkdirAll(dir, 0o755))
 	file := filepath.Join(dir, fmt.Sprintf("%d-%s.parquet", n, rowAccount))
 	_, err := db.ExecContext(context.Background(), fmt.Sprintf(
-		`COPY (SELECT TIMESTAMP '%s' AS received_at, '%s' AS account_id,
+		`COPY (SELECT TIMESTAMPTZ '%s+00' AS received_at, '%s' AS account_id,
 		        'peer-%d' AS peer_id, 'ev-%d' AS event_id)
 		 TO '%s' (FORMAT PARQUET)`, ts, rowAccount, n, n, file))
 	require.NoError(t, err)
@@ -286,7 +288,7 @@ func TestCompactDayLeavesOtherDaysAlone(t *testing.T) {
 	}
 	other := filepath.Join(fs.root, "flows", "year=2026", "month=07", "day=30", "account=acct-A")
 	require.NoError(t, os.MkdirAll(other, 0o755))
-	_, err := db.Exec("COPY (SELECT TIMESTAMP '2026-07-30 10:00:00' AS received_at, " +
+	_, err := db.Exec("COPY (SELECT TIMESTAMPTZ '2026-07-30 10:00:00+00' AS received_at, " +
 		"'acct-A' AS account_id, 'p' AS peer_id, 'e' AS event_id) TO '" +
 		filepath.Join(other, "x.parquet") + "' (FORMAT PARQUET)")
 	require.NoError(t, err)
@@ -404,7 +406,7 @@ func TestCompactDayLeavesParquetOutsideAccountPartitionAlone(t *testing.T) {
 
 	strayDir := filepath.Join(fs.root, "flows", "year=2026", "month=07", "day=29")
 	stray := filepath.Join(strayDir, "stray.parquet")
-	_, err := db.Exec("COPY (SELECT TIMESTAMP '2026-07-29 10:00:00' AS received_at, " +
+	_, err := db.Exec("COPY (SELECT TIMESTAMPTZ '2026-07-29 10:00:00+00' AS received_at, " +
 		"'acct-A' AS account_id, 'p' AS peer_id, 'e' AS event_id) TO '" +
 		stray + "' (FORMAT PARQUET)")
 	require.NoError(t, err)
@@ -499,4 +501,62 @@ func TestCompactDayRefusesWhenTheStoredObjectDiffers(t *testing.T) {
 		require.Contains(t, k, "compact-",
 			"only this run's own replacements may be removed; no original may be")
 	}
+}
+
+// The sink writes received_at as a UTC-adjusted parquet timestamp, which
+// DuckDB reads back as TIMESTAMP WITH TIME ZONE. Every fixture in this
+// package wrote a plain TIMESTAMP instead, so the date arithmetic in the
+// rewrite was never asked to handle the type production actually
+// produces -- and it could not: `year(TIMESTAMPTZ)` has no overload.
+//
+// The first dry-run against the real bucket failed on exactly this,
+// having passed every test here. This pins the type so it cannot drift
+// back.
+func TestCompactDayHandlesTimestampWithTimeZone(t *testing.T) {
+	c, fs, db := newFixture(t)
+	for i := range 6 {
+		seed(t, db, fs.root, "acct-A", "acct-A", day29+" 10:00:00", i)
+	}
+
+	// The fixtures now write TIMESTAMPTZ; assert that rather than trust
+	// it, since the whole defect was a fixture that lied about the type.
+	var typ string
+	require.NoError(t, db.QueryRow(
+		"SELECT typeof(received_at) FROM read_parquet('"+fs.root+
+			"/flows/year=*/month=*/day=*/account=*/*.parquet') LIMIT 1").Scan(&typ))
+	require.Equal(t, "TIMESTAMP WITH TIME ZONE", typ,
+		"the fixture must describe the parquet the sink writes")
+
+	res, err := c.CompactDay(context.Background(), time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	require.Equal(t, 1, res.ObjectsAfter)
+	require.Equal(t, int64(6), res.Rows)
+}
+
+// Partitions are UTC by definition, and the session's zone decides what
+// casting a TIMESTAMPTZ yields. On a host in America/Sao_Paulo an event
+// at 2026-06-01T02:30Z renders as May 31, so without pinning the session
+// the row is filed under the previous day -- silently, and only for
+// events in the first hours of a UTC day.
+//
+// This is not hypothetical: the cluster that surfaced the type error
+// runs in that zone.
+func TestCompactDayIgnoresTheHostTimeZone(t *testing.T) {
+	c, fs, db := newFixture(t)
+	_, err := db.Exec("SET TimeZone='America/Sao_Paulo'")
+	require.NoError(t, err)
+
+	// 02:30 UTC on the 29th: still the 28th in Sao Paulo.
+	for i := range 4 {
+		seed(t, db, fs.root, "acct-A", "acct-A", day29+" 02:30:00", i)
+	}
+
+	_, err = c.CompactDay(context.Background(), time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+
+	keys, err := fs.List(context.Background(), "flows")
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	require.Contains(t, keys[0], "year=2026/month=07/day=29/",
+		"an event at 02:30 UTC belongs to the UTC day, whatever the host thinks; got %q", keys[0])
 }

--- a/flow/store/archive/compact/compact_test.go
+++ b/flow/store/archive/compact/compact_test.go
@@ -496,46 +496,15 @@ func TestFingerprintIgnoresRowOrder(t *testing.T) {
 	require.NotEmpty(t, res.Fingerprint.Sum)
 }
 
-// The reader orders query results, so this is not a correctness
-// requirement for API responses. It is a physical layout choice for the
-// backfill: once the original small files are deleted, changing the
-// compacted files' row order means rewriting the archive again. Keep the
-// replacement newest-first before the destructive run makes that layout
-// expensive to change.
-func TestCompactDayWritesRowsNewestFirst(t *testing.T) {
-	c, fs, db := newFixture(t)
-	for i := range 6 {
-		seed(t, db, fs.root, "acct-A", "acct-A", day29+fmt.Sprintf(" %02d:00:00", i), i)
-	}
-
-	_, err := c.CompactDay(context.Background(), time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
-	require.NoError(t, err)
-
-	keys, err := fs.List(context.Background(), "flows")
-	require.NoError(t, err)
-	require.Len(t, keys, 1)
-	rows, err := db.Query("SELECT event_id FROM read_parquet(" +
-		quote(filepath.Join(fs.root, filepath.FromSlash(keys[0]))) + ")")
-	require.NoError(t, err)
-	defer func() { _ = rows.Close() }()
-
-	var got []string
-	for rows.Next() {
-		var id string
-		require.NoError(t, rows.Scan(&id))
-		got = append(got, id)
-	}
-	require.NoError(t, rows.Err())
-	require.Equal(t, []string{"ev-5", "ev-4", "ev-3", "ev-2", "ev-1", "ev-0"}, got)
-}
-
 func TestCompactDayWritesDisjointReceivedAtRowGroups(t *testing.T) {
 	c, fs, db := newFixture(t)
+	_, err := db.ExecContext(context.Background(), "SET threads=4")
+	require.NoError(t, err)
 	const totalRows = 250_000
 	seedManyShuffled(t, db, fs.root, "source-a.parquet", 0, totalRows/2, totalRows)
 	seedManyShuffled(t, db, fs.root, "source-b.parquet", totalRows/2, totalRows/2, totalRows)
 
-	_, err := c.CompactDay(context.Background(), time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
+	_, err = c.CompactDay(context.Background(), time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
 	require.NoError(t, err)
 
 	keys, err := fs.List(context.Background(), "flows")
@@ -563,23 +532,11 @@ func TestCompactDayWritesDisjointReceivedAtRowGroups(t *testing.T) {
 	require.NoError(t, err)
 	require.Greater(t, rowGroups, int64(1), "the test must exercise row-group pruning, not only row order")
 	require.Zero(t, overlaps, "received_at row groups must be disjoint for min/max pruning to skip old ranges")
-}
-
-func TestCompactDayRestoresRewriteThreads(t *testing.T) {
-	c, fs, db := newFixture(t)
-	_, err := db.ExecContext(context.Background(), "SET threads=2")
-	require.NoError(t, err)
-	for i := range 6 {
-		seed(t, db, fs.root, "acct-A", "acct-A", day29+fmt.Sprintf(" %02d:00:00", i), i)
-	}
-
-	_, err = c.CompactDay(context.Background(), time.Date(2026, 7, 29, 0, 0, 0, 0, time.UTC))
-	require.NoError(t, err)
 
 	var threads int
 	err = db.QueryRowContext(context.Background(), "SELECT current_setting('threads')::INTEGER").Scan(&threads)
 	require.NoError(t, err)
-	require.Equal(t, 2, threads)
+	require.Equal(t, 4, threads, "the compactor should keep the operator's DuckDB parallelism")
 }
 
 // Everything before this proves the rewrite was right. This proves the

--- a/flow/store/archive/compact/minio_integration_test.go
+++ b/flow/store/archive/compact/minio_integration_test.go
@@ -135,7 +135,7 @@ func (h *harness) seed(t *testing.T, day, account, rowAccount, ts string, n int)
 	t.Helper()
 	path := filepath.Join(h.tmp, fmt.Sprintf("seed-%d.parquet", n))
 	_, err := h.local.ExecContext(context.Background(), fmt.Sprintf(
-		`COPY (SELECT TIMESTAMP '%s' AS received_at, '%s' AS account_id,
+		`COPY (SELECT TIMESTAMPTZ '%s+00' AS received_at, '%s' AS account_id,
 		        'peer-%d' AS peer_id, 'ev-%d' AS event_id) TO '%s' (FORMAT PARQUET)`,
 		ts, rowAccount, n, n, path))
 	require.NoError(t, err)
@@ -216,7 +216,7 @@ func TestListPagesPastTheThousandKeyLimit(t *testing.T) {
 	// contents.
 	path := filepath.Join(h.tmp, "one.parquet")
 	_, err := h.local.Exec(
-		`COPY (SELECT TIMESTAMP '2026-07-30 10:00:00' AS received_at, 'acct-A' AS account_id) TO '` +
+		`COPY (SELECT TIMESTAMPTZ '2026-07-30 10:00:00+00' AS received_at, 'acct-A' AS account_id) TO '` +
 			path + `' (FORMAT PARQUET)`)
 	require.NoError(t, err)
 	body, err := os.ReadFile(path)

--- a/flow/store/archive/detect_test.go
+++ b/flow/store/archive/detect_test.go
@@ -31,6 +31,13 @@ func TestOperatorDetectionQueries(t *testing.T) {
 		"2026-06-12 12:00:00", testAccount)
 
 	glob := filepath.Join(root, "year=*", "month=*", "day=*", "account=*", "*.parquet")
+	var typ string
+	require.NoError(t, db.QueryRowContext(context.Background(),
+		"SELECT typeof(received_at) FROM read_parquet('"+glob+"') LIMIT 1").Scan(&typ))
+	require.Equal(t, "TIMESTAMP WITH TIME ZONE", typ,
+		"the upgrade-note queries must be tested against the type the sink writes")
+	_, err = db.ExecContext(context.Background(), "SET TimeZone='UTC'")
+	require.NoError(t, err)
 
 	t.Run("misfiled accounts", func(t *testing.T) {
 		var n int

--- a/flow/store/archive/seed_test.go
+++ b/flow/store/archive/seed_test.go
@@ -34,7 +34,7 @@ const testAccount = "acct-1"
 // integers would let a broken string predicate pass. The fixture this
 // grew out of had exactly that defect.
 //
-// ts is a DuckDB timestamp literal body, e.g. "2026-05-12 10:00:00".
+// ts is a UTC DuckDB timestamp literal body, e.g. "2026-05-12 10:00:00".
 func seedEventParquetAs(t *testing.T, db *sql.DB, path, ts, accountID string) {
 	t.Helper()
 	seedTypedAs(t, db, path, ts, accountID, "start", "ingress")
@@ -51,8 +51,8 @@ func seedTypedAs(t *testing.T, db *sql.DB, path, ts, accountID, typ, dir string)
 	t.Helper()
 	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
 	_, err := db.ExecContext(context.Background(), "COPY (SELECT "+
-		"TIMESTAMP '"+ts+"' AS received_at, "+
-		"TIMESTAMP '"+ts+"' AS occurred_at, "+
+		"TIMESTAMPTZ '"+ts+"+00' AS received_at, "+
+		"TIMESTAMPTZ '"+ts+"+00' AS occurred_at, "+
 		"'"+accountID+"' AS account_id, 'peer-a' AS peer_id, "+
 		"'ev-1' AS event_id, 'fl-1' AS flow_id, "+
 		"'"+typ+"' AS type, '"+dir+"' AS direction, "+


### PR DESCRIPTION
The first dry-run of the flow archive compactor against the real bucket failed before touching any data:

```text
year(TIMESTAMP WITH TIME ZONE) has no overload
```

That exposed two bugs in the compactor tests and implementation.

## What Changed

- The compaction DuckDB session is now pinned to UTC before date arithmetic.
- Partition derivation casts `received_at` explicitly after the session is pinned.
- Compact fixtures now write `TIMESTAMPTZ`, matching the Parquet shape produced by the sink.
- The direct DuckDB fixture uses one physical connection, matching `OpenParquetDB`, so session settings cannot accidentally land on a different connection in tests.
- The operator detection queries in `upgrade-notes.md` now tell the operator to pin the DuckDB session to UTC before running `date_trunc`, and their test fixture now uses the same `TIMESTAMPTZ` shape.
- The compactor orders the rewrite by `received_at`, keeping Parquet row-group min/max ranges disjoint so DuckDB can skip unrelated ranges during cold-history queries. This keeps the operator's configured DuckDB parallelism; no `threads` override is applied.
- The row-group guard intentionally does not assert `row_group_id` direction. Under parallel COPY, DuckDB keeps the min/max ranges disjoint but does not make the first row-group ID reliably be the newest one; disjoint ranges are the property range pruning needs.

## Why UTC Matters

The sink writes `received_at` as a UTC-adjusted Parquet timestamp, which DuckDB reads as `TIMESTAMP WITH TIME ZONE`.

`SET TimeZone='UTC'` does two jobs:

- it makes DuckDB's timestamp-with-time-zone date functions bind;
- it prevents the host time zone from deciding archive partitions.

Without the second part, a host in `America/Sao_Paulo` can render `2026-06-01T02:30:00Z` as May 31 and rewrite the row under the previous UTC day. That would pass the dry-run and only show up later as missing cold-history rows for early-UTC events.

## Tests

- `TestCompactDayHandlesTimestampWithTimeZone` asserts the fixture type is `TIMESTAMP WITH TIME ZONE` and compacts it successfully.
- `TestCompactDayIgnoresTheHostTimeZone` sets the DuckDB session to `America/Sao_Paulo` and verifies compaction still writes the UTC day.
- `TestCompactDayWritesDisjointReceivedAtRowGroups` runs the rewrite with `threads=4`, writes 250k shuffled events, inspects the compacted file with `parquet_metadata()`, and verifies the `received_at` row-group ranges do not overlap. Removing the `ORDER BY` makes it fail with overlapping row groups.

Local verification:

```text
go test -tags=archive_duckdb ./flow/store/archive/compact -run 'TestCompactDay(HandlesTimestampWithTimeZone|IgnoresTheHostTimeZone|FilesRowsByTheirOwnDate|IsIdempotent)' -count=5
go test -tags=archive_duckdb ./flow/store/archive/compact -run TestCompactDayWritesDisjointReceivedAtRowGroups -count=5
go test -tags=archive_duckdb ./flow/store/archive/compact -count=1
go test -tags=archive_duckdb ./flow/store/archive -run TestOperatorDetectionQueries -count=5
go test -tags=archive_duckdb ./flow/store/archive -count=1
go test -race -tags=archive_duckdb ./flow/store/archive/... ./management/cmd -count=1
go test ./flow/... -count=1
go build -tags=archive_duckdb -o /tmp/openzro-mgmt-tz-duckdb ./management
go build -o /tmp/openzro-mgmt-tz ./management
```

## Operational Note

`v0.53.1-alpha.94` contains the compaction command, but it should not be used against the real archive until this fix is released. The command is still manual and dry-run by default; nothing runs automatically.
