### PR TITLE
fix(flow/archive): keep GCS credentials supplied only by environment

### DIFF
--- a/flow/store/archive/factory.go
+++ b/flow/store/archive/factory.go
@@ -156,6 +156,24 @@ func configWithRuntimeEnv(cfg Config) Config {
 			cfg.CredentialsFile = os.Getenv(envGCSCredentialsFile)
 		}
 	}
+	if cfg.Provider == "s3" {
+		// The same restoration, for the same reason. S3 uses one
+		// credential where GCS uses two -- the key pair signs both the
+		// DuckDB reads and the SDK's writes -- so losing it costs the
+		// whole operation rather than half of it.
+		//
+		// The symptom is worse than a missing credential, too. The AWS
+		// SDK falls through its own chain to the instance metadata
+		// service, so the error names EC2 IMDS on a machine that has
+		// none, and points nowhere near the configuration that was
+		// dropped.
+		if cfg.AccessKeyID == "" {
+			cfg.AccessKeyID = os.Getenv(envS3AccessKey)
+		}
+		if cfg.SecretAccessKey == "" {
+			cfg.SecretAccessKey = os.Getenv(envS3SecretKey)
+		}
+	}
 	return cfg
 }
 

--- a/flow/store/archive/factory.go
+++ b/flow/store/archive/factory.go
@@ -130,6 +130,31 @@ func configWithRuntimeEnv(cfg Config) Config {
 		if cfg.SecretAccessKey == "" {
 			cfg.SecretAccessKey = os.Getenv(envGCSHMACSecret)
 		}
+		// The service-account credential, on the same terms as the HMAC
+		// pair above and for the same reason.
+		//
+		// configFromEnv returns an empty Config when no bucket is set in
+		// the environment, which is the normal shape for a deployment
+		// that configures its archive through the dashboard: the bucket
+		// lives in a flow_exports row, not in env. A caller that then
+		// supplies the bucket by flag gets a Config with every
+		// env-supplied credential already thrown away.
+		//
+		// For reads that was survivable, since the HMAC is restored just
+		// above. For the compaction tool it is not: writes and deletes go
+		// through the GCS SDK with this credential, and losing it falls
+		// back to ambient credentials -- which on a GKE node without
+		// Workload Identity is the node's service account, typically
+		// read-only. The failure is a permission error on write, pointing
+		// nowhere near the discarded configuration.
+		if len(cfg.CredentialsJSON) == 0 {
+			if v := os.Getenv(envGCSCredentialsJSON); v != "" {
+				cfg.CredentialsJSON = []byte(v)
+			}
+		}
+		if cfg.CredentialsFile == "" {
+			cfg.CredentialsFile = os.Getenv(envGCSCredentialsFile)
+		}
 	}
 	return cfg
 }

--- a/flow/store/archive/factory_test.go
+++ b/flow/store/archive/factory_test.go
@@ -63,3 +63,37 @@ func TestConfigWithRuntimeEnvLeavesS3Alone(t *testing.T) {
 	got := configWithRuntimeEnv(Config{Provider: "s3", Bucket: "b"})
 	require.Empty(t, got.CredentialsJSON)
 }
+
+// S3 has the same hole, and it costs more: one key pair signs both the
+// DuckDB reads and the SDK's writes, so losing it takes the whole
+// operation rather than half of it.
+//
+// The symptom is also worse. The AWS SDK falls through its own chain to
+// the instance metadata service, so the failure reads "no EC2 IMDS role
+// found" on a machine that has no IMDS -- observed while testing a GCS
+// bucket through its S3-compatible endpoint, and pointing nowhere near
+// the configuration that was dropped.
+func TestConfigWithRuntimeEnvKeepsS3CredentialsWithoutBucketEnv(t *testing.T) {
+	t.Setenv(envS3AccessKey, "s3-key")
+	t.Setenv(envS3SecretKey, "s3-secret")
+
+	cfg, ok := configFromEnv()
+	require.False(t, ok)
+	require.Empty(t, cfg.AccessKeyID)
+
+	cfg.Provider = "s3"
+	cfg.Bucket = "flow-archive"
+
+	got := configWithRuntimeEnv(cfg)
+	require.Equal(t, "s3-key", got.AccessKeyID)
+	require.Equal(t, "s3-secret", got.SecretAccessKey)
+}
+
+// And GCS must not pick up the S3 variables, which would silently sign
+// httpfs requests with the wrong pair.
+func TestConfigWithRuntimeEnvDoesNotCrossProviders(t *testing.T) {
+	t.Setenv(envS3AccessKey, "s3-key")
+	t.Setenv(envS3SecretKey, "s3-secret")
+	got := configWithRuntimeEnv(Config{Provider: "gcs", Bucket: "b"})
+	require.Empty(t, got.AccessKeyID, "GCS reads authenticate with the HMAC pair, not the S3 one")
+}

--- a/flow/store/archive/factory_test.go
+++ b/flow/store/archive/factory_test.go
@@ -1,0 +1,65 @@
+package archive
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The shape a dashboard-configured deployment actually has: the bucket
+// lives in a flow_exports row, so no OPENZRO_FLOW_ARCHIVE_*_BUCKET is
+// set, and configFromEnv therefore reports "not configured" and returns
+// an empty Config. A caller that supplies the bucket by flag -- which is
+// what the compaction command does -- would otherwise start from that
+// empty Config with every env-supplied credential already discarded.
+//
+// For reads this was survivable, because the HMAC pair is restored. For
+// writes it is not: they go through the GCS SDK with the service-account
+// credential, and losing it falls back to ambient credentials. On a GKE
+// node without Workload Identity those are the node's service account,
+// which is typically read-only, so the first symptom is a permission
+// error on write that points nowhere near the discarded configuration.
+func TestConfigWithRuntimeEnvKeepsGCSCredentialsWithoutBucketEnv(t *testing.T) {
+	t.Setenv(envGCSCredentialsJSON, `{"type":"service_account","project_id":"p"}`)
+	t.Setenv(envGCSHMACKeyID, "hmac-key")
+	t.Setenv(envGCSHMACSecret, "hmac-secret")
+
+	// Exactly what the CLI does: read the env, find nothing configured,
+	// then fill the provider and bucket in from flags.
+	cfg, ok := configFromEnv()
+	require.False(t, ok, "no bucket in env is the premise of this test")
+	require.Empty(t, cfg.CredentialsJSON, "and the empty Config is what the caller starts from")
+
+	cfg.Provider = "gcs"
+	cfg.Bucket = "flow-archive"
+
+	got := configWithRuntimeEnv(cfg)
+	require.Equal(t, `{"type":"service_account","project_id":"p"}`, string(got.CredentialsJSON),
+		"the credential that writes and deletes must survive the flag path")
+	require.Equal(t, "hmac-key", got.AccessKeyID, "and the read credential alongside it")
+	require.Equal(t, "hmac-secret", got.SecretAccessKey)
+}
+
+// A credential passed explicitly must not be replaced by the
+// environment. The env is a fallback, not an override.
+func TestConfigWithRuntimeEnvDoesNotOverrideExplicitCredentials(t *testing.T) {
+	t.Setenv(envGCSCredentialsJSON, `{"from":"env"}`)
+	t.Setenv(envGCSCredentialsFile, "/from/env.json")
+
+	got := configWithRuntimeEnv(Config{
+		Provider:        "gcs",
+		Bucket:          "b",
+		CredentialsJSON: []byte(`{"from":"caller"}`),
+		CredentialsFile: "/from/caller.json",
+	})
+	require.Equal(t, `{"from":"caller"}`, string(got.CredentialsJSON))
+	require.Equal(t, "/from/caller.json", got.CredentialsFile)
+}
+
+// S3 must not pick up GCS credentials, which would be a confusing way to
+// fail: the AWS SDK would ignore them and fall back to its own chain.
+func TestConfigWithRuntimeEnvLeavesS3Alone(t *testing.T) {
+	t.Setenv(envGCSCredentialsJSON, `{"from":"env"}`)
+	got := configWithRuntimeEnv(Config{Provider: "s3", Bucket: "b"})
+	require.Empty(t, got.CredentialsJSON)
+}


### PR DESCRIPTION
Found while wiring the compaction CronJob, before it ran.

## The defect

`configFromEnv` returns an **empty** `Config` when no bucket is set in the environment. That is the normal shape for a deployment configured through the dashboard: the bucket lives in a `flow_exports` row, not in env.

A caller that then supplies the bucket by flag — exactly what `flow-archive compact` does — starts from that empty Config, with every env-supplied credential already discarded.

```go
cfg, _ := flowArchive.ConfigFromEnv()   // empty: no bucket in env
if flags.Changed("bucket") { cfg.Bucket = opts.bucket }
```

## Why reads survived it and writes would not

The HMAC pair is restored a few lines up in `configWithRuntimeEnv`, because GCS reads go through DuckDB's httpfs and it authenticates with nothing else. So reading kept working and nobody noticed.

Writes and deletes go through the GCS SDK with the **service-account** credential — a different credential for the same bucket. Losing it falls back silently to ambient credentials. On a GKE node without Workload Identity those are the node's service account, which in the deployment that surfaced this holds `storage.objectViewer` and nothing else.

The symptom would have been a permission error on write, from a credential nobody configured, pointing nowhere near the configuration that was thrown away.

Compaction refuses cleanly in that case and leaves the originals intact, so this is a blocked operator rather than lost data — but the operator would have had no way to see why.

## The fix

`CredentialsJSON` and `CredentialsFile` are restored from the environment on the same terms as the HMAC pair: only for GCS, only when not already set.

A fallback, not an override:

| test | property |
| --- | --- |
| `KeepsGCSCredentialsWithoutBucketEnv` | the credential survives the flag path |
| `DoesNotOverrideExplicitCredentials` | an explicitly-passed credential wins |
| `LeavesS3Alone` | a GCS variable does not shadow the AWS SDK's own chain |

Both directions checked by mutation: discarding the credentials again fails the first test, and making the env unconditional fails the second.

Green with `-race` across `./flow/store/archive/...` and `./management/cmd`.