### PR TITLE
feat(flow/archive): take compaction config from the dashboard's Integrations

### DIFF
--- a/flow/store/archive/factory.go
+++ b/flow/store/archive/factory.go
@@ -118,6 +118,20 @@ func ConfigFromEnv() (Config, bool) {
 	return configFromEnv()
 }
 
+// ConfigWithRuntimeEnv fills in what the environment supplies on top of
+// a config the caller assembled some other way -- from flags, or from a
+// flow_exports row.
+//
+// The store constructors apply this themselves, so the read path gets it
+// for free. A caller that also builds a *writer* has to ask: the
+// compaction tool authenticates its writes and deletes through the cloud
+// SDK with these same credentials, and a config whose bucket came from a
+// flag would otherwise carry none, because configFromEnv discards
+// everything when no bucket is set in the environment.
+func ConfigWithRuntimeEnv(cfg Config) Config {
+	return configWithRuntimeEnv(cfg)
+}
+
 func configWithRuntimeEnv(cfg Config) Config {
 	cfg.QueryTimeout = parseTimeout(os.Getenv(envQueryTimeout))
 	cfg.MemoryLimit = os.Getenv(envMemoryLimit)

--- a/management/cmd/flow_archive_compact.go
+++ b/management/cmd/flow_archive_compact.go
@@ -55,17 +55,29 @@ func newFlowArchiveCompactCommand(opts *flowArchiveCompactOptions) *cobra.Comman
 		Short: "Compact and repartition archived flow Parquet objects",
 		Long: "Compact and repartition archived flow Parquet objects.\n\n" +
 			"Where the archive is, resolved in this order:\n" +
-			"  1. the destination configured in the dashboard under Integrations,\n" +
-			"  2. OPENZRO_FLOW_ARCHIVE_* environment variables,\n" +
-			"  3. --provider / --bucket / --prefix flags, which win over both.\n\n" +
-			"Reading the dashboard's row means this command uses the same bucket and the\n" +
-			"same credential the sink is already writing with, instead of a second copy\n" +
-			"that drifts the first time one of them is rotated.\n\n" +
-			"GCS needs one thing the row cannot supply: the HMAC interoperability pair,\n" +
-			"in OPENZRO_FLOW_ARCHIVE_GCS_HMAC_KEY_ID and _SECRET. Reads go through\n" +
-			"DuckDB, whose GCS secret accepts those keys and rejects service-account\n" +
-			"JSON. Writes and deletes use the service account from the row. S3 needs no\n" +
-			"such split -- one key pair signs both.\n\n" +
+			"  1. OPENZRO_FLOW_ARCHIVE_* environment variables,\n" +
+			"  2. --provider / --bucket / --prefix / --region / --endpoint, which\n" +
+			"     override individual fields from the environment,\n" +
+			"  3. if provider and bucket are both set by then, nothing else is read --\n" +
+			"     no management config, no database,\n" +
+			"  4. otherwise the archive configured in the dashboard under Integrations,\n" +
+			"     with the flags layered back on top.\n\n" +
+			"The environment is all-or-nothing: without a bucket it describes no archive\n" +
+			"at all, so exporting only a prefix does not override the dashboard. Use a\n" +
+			"flag to change one field.\n\n" +
+			"Step 3 makes the flags an escape hatch rather than a preference. This\n" +
+			"command deletes objects, so pointing it at a copy of the bucket, or working\n" +
+			"around a broken deployment, must not depend on the management config being\n" +
+			"readable or the database being up.\n\n" +
+			"Step 4 is where a normal deployment lands: a cluster that configured its\n" +
+			"bucket in the dashboard has no OPENZRO_FLOW_ARCHIVE_*_BUCKET anywhere and\n" +
+			"its credential exists only as an encrypted row, so reading it is what avoids\n" +
+			"a second copy of the service-account key.\n\n" +
+			"GCS needs one thing no row can supply: the HMAC interoperability pair, in\n" +
+			"OPENZRO_FLOW_ARCHIVE_GCS_HMAC_KEY_ID and _SECRET. Reads go through DuckDB,\n" +
+			"whose GCS secret accepts those keys and rejects service-account JSON. Writes\n" +
+			"and deletes use the service account. S3 needs no such split -- one key pair\n" +
+			"signs both.\n\n" +
 			"Credentials are never flags, so they do not land in shell history or a\n" +
 			"process list.",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -347,37 +359,72 @@ func formatCompactDay(t time.Time) string {
 	return utcDay(t).Format("2006-01-02")
 }
 
-// flowArchiveCompactConfig resolves where the archive is, in the order an
-// operator would expect: what the dashboard was told, then the
-// environment, then the flags.
+// flowArchiveCompactConfig resolves where the archive is.
 //
-// The dashboard comes first because that is where this deployment's
-// archive actually lives. A cluster that configured its bucket under
-// Integrations has no OPENZRO_FLOW_ARCHIVE_*_BUCKET set anywhere, and
-// the credential exists only as an encrypted row -- so without this the
-// command needs its own copy of the service-account key, which then
-// drifts from the console the first time anybody rotates one and not the
-// other.
+// Explicit configuration first, the dashboard second:
 //
-// The environment still supplies what the row cannot. The GCS HMAC pair
-// is the reason: DuckDB reaches GCS through httpfs, whose secret takes
-// interoperability keys and rejects service-account JSON, so reads need a
-// credential the row has no field for. configWithRuntimeEnv restores it.
+//  1. OPENZRO_FLOW_ARCHIVE_* environment variables,
+//  2. --provider / --bucket / --prefix / --region / --endpoint flags,
+//     which override individual fields from the environment,
+//  3. if provider and bucket are BOTH set by then, nothing else is read
+//     -- no management config, no database,
+//  4. otherwise the archive configured in the dashboard under
+//     Integrations becomes the base, with the flags layered back on top.
 //
-// Flags win over both, so an operator can point the command at a copy of
-// the bucket without touching the running configuration.
+// The environment is all-or-nothing, which surprises people: ConfigFromEnv
+// reports "not configured" without a bucket and returns an empty Config,
+// so exporting only a prefix does not override the dashboard. That is how
+// the reader treats these variables everywhere, so it stays that way
+// rather than growing a special case here; a flag overrides one field.
+//
+// Step 3 is what makes the flags an escape hatch rather than a
+// preference. This command deletes objects, and an operator pointing it
+// at a copy of the bucket -- or working around a broken deployment --
+// must not be blocked because the management config is unreadable or the
+// database is down. If the flags say where to go, the command goes.
+//
+// Step 4 is where a normal deployment lands. A cluster that configured
+// its bucket in the dashboard has no OPENZRO_FLOW_ARCHIVE_*_BUCKET set
+// anywhere and its credential exists only as an encrypted row, so
+// reading it is what lets the CronJob run without a second copy of the
+// service-account key.
+//
+// The GCS HMAC pair is not part of this. It comes from the environment
+// in configWithRuntimeEnv, because DuckDB reaches GCS through httpfs,
+// whose secret takes interoperability keys and rejects service-account
+// JSON, and the row has no field for them.
 func flowArchiveCompactConfig(ctx context.Context, cmd *cobra.Command, opts *flowArchiveCompactOptions) (flowArchive.Config, error) {
-	cfg, _ := flowArchive.ConfigFromEnv()
-	if cfg.Bucket == "" {
-		fromRows, source, ok, err := archiveConfigFromIntegrations(ctx)
-		if err != nil {
-			return flowArchive.Config{}, err
-		}
-		if ok {
-			cmd.PrintErrf("flow archive compact: using the archive configured in Integrations (%s)\n", source)
-			cfg = fromRows
-		}
+	envCfg, _ := flowArchive.ConfigFromEnv()
+
+	cfg := envCfg
+	applyArchiveFlags(cmd, opts, &cfg)
+	if cfg.Provider != "" && cfg.Bucket != "" {
+		return cfg, nil
 	}
+
+	fromRows, source, ok, err := archiveConfigFromIntegrations(ctx)
+	if err != nil {
+		return flowArchive.Config{}, err
+	}
+	if ok {
+		cmd.PrintErrf("flow archive compact: using the archive configured in Integrations (%s)\n", source)
+		cfg = fromRows
+		mergeArchiveOverrides(envCfg, &cfg)
+		applyArchiveFlags(cmd, opts, &cfg)
+	}
+
+	if cfg.Provider == "" || cfg.Bucket == "" {
+		return flowArchive.Config{}, fmt.Errorf(
+			"flow archive compact: no archive configured. Set one up under Integrations " +
+				"in the dashboard, or set OPENZRO_FLOW_ARCHIVE_*, or pass --provider and --bucket")
+	}
+	return cfg, nil
+}
+
+// applyArchiveFlags overwrites the fields the operator named on the
+// command line. Only flags that were actually given, so an unset flag
+// does not blank a configured value.
+func applyArchiveFlags(cmd *cobra.Command, opts *flowArchiveCompactOptions, cfg *flowArchive.Config) {
 	flags := cmd.Flags()
 	if flags.Changed("provider") {
 		cfg.Provider = opts.provider
@@ -397,12 +444,34 @@ func flowArchiveCompactConfig(ctx context.Context, cmd *cobra.Command, opts *flo
 	if flags.Changed("gcs-credentials-file") {
 		cfg.CredentialsFile = opts.gcsCredentialsFile
 	}
-	if cfg.Provider == "" || cfg.Bucket == "" {
-		return flowArchive.Config{}, fmt.Errorf(
-			"flow archive compact: no archive configured. Set one up under Integrations " +
-				"in the dashboard, or set OPENZRO_FLOW_ARCHIVE_*, or pass --provider and --bucket")
+}
+
+// mergeArchiveOverrides layers whatever the environment set on top of a
+// base, leaving the base's value wherever the environment was silent.
+// Used to keep env precedence over the dashboard row when the row had to
+// be read to fill something else in.
+func mergeArchiveOverrides(from flowArchive.Config, into *flowArchive.Config) {
+	if from.Provider != "" {
+		into.Provider = from.Provider
 	}
-	return cfg, nil
+	if from.Bucket != "" {
+		into.Bucket = from.Bucket
+	}
+	if from.Prefix != "" {
+		into.Prefix = from.Prefix
+	}
+	if from.Endpoint != "" {
+		into.Endpoint = from.Endpoint
+	}
+	if from.Region != "" {
+		into.Region = from.Region
+	}
+	if len(from.CredentialsJSON) > 0 {
+		into.CredentialsJSON = from.CredentialsJSON
+	}
+	if from.CredentialsFile != "" {
+		into.CredentialsFile = from.CredentialsFile
+	}
 }
 
 func flowArchiveCompactStore(ctx context.Context, cfg flowArchive.Config) (archiveCompact.ObjectStore, func() error, error) {

--- a/management/cmd/flow_archive_compact.go
+++ b/management/cmd/flow_archive_compact.go
@@ -43,18 +43,31 @@ func newFlowArchiveCommand() *cobra.Command {
 		Short:        "Operate on archived flow traffic",
 		SilenceUsage: true,
 	}
-	cmd.AddCommand(newFlowArchiveCompactCommand())
+	cmd.AddCommand(newFlowArchiveCompactCommand(&flowArchiveCompactOptions{concurrency: 1}))
 	return cmd
 }
 
-func newFlowArchiveCompactCommand() *cobra.Command {
-	opts := &flowArchiveCompactOptions{concurrency: 1}
+// newFlowArchiveCompactCommand takes its options rather than making them,
+// so a test can read back what the flags resolved to.
+func newFlowArchiveCompactCommand(opts *flowArchiveCompactOptions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "compact --from YYYY-MM-DD --to YYYY-MM-DD --manifest FILE [--delete-originals]",
 		Short: "Compact and repartition archived flow Parquet objects",
 		Long: "Compact and repartition archived flow Parquet objects.\n\n" +
-			"Archive bucket settings default to OPENZRO_FLOW_ARCHIVE_* environment variables. " +
-			"Credentials stay in that env/file contract rather than command-line flags, so they do not land in shell history.",
+			"Where the archive is, resolved in this order:\n" +
+			"  1. the destination configured in the dashboard under Integrations,\n" +
+			"  2. OPENZRO_FLOW_ARCHIVE_* environment variables,\n" +
+			"  3. --provider / --bucket / --prefix flags, which win over both.\n\n" +
+			"Reading the dashboard's row means this command uses the same bucket and the\n" +
+			"same credential the sink is already writing with, instead of a second copy\n" +
+			"that drifts the first time one of them is rotated.\n\n" +
+			"GCS needs one thing the row cannot supply: the HMAC interoperability pair,\n" +
+			"in OPENZRO_FLOW_ARCHIVE_GCS_HMAC_KEY_ID and _SECRET. Reads go through\n" +
+			"DuckDB, whose GCS secret accepts those keys and rejects service-account\n" +
+			"JSON. Writes and deletes use the service account from the row. S3 needs no\n" +
+			"such split -- one key pair signs both.\n\n" +
+			"Credentials are never flags, so they do not land in shell history or a\n" +
+			"process list.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runFlowArchiveCompact(cmd, opts)
 		},
@@ -89,7 +102,7 @@ func runFlowArchiveCompact(cmd *cobra.Command, opts *flowArchiveCompactOptions) 
 		return fmt.Errorf("flow archive compact: --concurrency must be greater than zero")
 	}
 
-	cfg, err := flowArchiveCompactConfig(cmd, opts)
+	cfg, err := flowArchiveCompactConfig(cmd.Context(), cmd, opts)
 	if err != nil {
 		return err
 	}
@@ -334,8 +347,37 @@ func formatCompactDay(t time.Time) string {
 	return utcDay(t).Format("2006-01-02")
 }
 
-func flowArchiveCompactConfig(cmd *cobra.Command, opts *flowArchiveCompactOptions) (flowArchive.Config, error) {
+// flowArchiveCompactConfig resolves where the archive is, in the order an
+// operator would expect: what the dashboard was told, then the
+// environment, then the flags.
+//
+// The dashboard comes first because that is where this deployment's
+// archive actually lives. A cluster that configured its bucket under
+// Integrations has no OPENZRO_FLOW_ARCHIVE_*_BUCKET set anywhere, and
+// the credential exists only as an encrypted row -- so without this the
+// command needs its own copy of the service-account key, which then
+// drifts from the console the first time anybody rotates one and not the
+// other.
+//
+// The environment still supplies what the row cannot. The GCS HMAC pair
+// is the reason: DuckDB reaches GCS through httpfs, whose secret takes
+// interoperability keys and rejects service-account JSON, so reads need a
+// credential the row has no field for. configWithRuntimeEnv restores it.
+//
+// Flags win over both, so an operator can point the command at a copy of
+// the bucket without touching the running configuration.
+func flowArchiveCompactConfig(ctx context.Context, cmd *cobra.Command, opts *flowArchiveCompactOptions) (flowArchive.Config, error) {
 	cfg, _ := flowArchive.ConfigFromEnv()
+	if cfg.Bucket == "" {
+		fromRows, source, ok, err := archiveConfigFromIntegrations(ctx)
+		if err != nil {
+			return flowArchive.Config{}, err
+		}
+		if ok {
+			cmd.PrintErrf("flow archive compact: using the archive configured in Integrations (%s)\n", source)
+			cfg = fromRows
+		}
+	}
 	flags := cmd.Flags()
 	if flags.Changed("provider") {
 		cfg.Provider = opts.provider
@@ -357,7 +399,8 @@ func flowArchiveCompactConfig(cmd *cobra.Command, opts *flowArchiveCompactOption
 	}
 	if cfg.Provider == "" || cfg.Bucket == "" {
 		return flowArchive.Config{}, fmt.Errorf(
-			"flow archive compact: archive provider and bucket are required; set OPENZRO_FLOW_ARCHIVE_* or pass --provider and --bucket")
+			"flow archive compact: no archive configured. Set one up under Integrations " +
+				"in the dashboard, or set OPENZRO_FLOW_ARCHIVE_*, or pass --provider and --bucket")
 	}
 	return cfg, nil
 }

--- a/management/cmd/flow_archive_compact.go
+++ b/management/cmd/flow_archive_compact.go
@@ -399,7 +399,14 @@ func flowArchiveCompactConfig(ctx context.Context, cmd *cobra.Command, opts *flo
 	cfg := envCfg
 	applyArchiveFlags(cmd, opts, &cfg)
 	if cfg.Provider != "" && cfg.Bucket != "" {
-		return cfg, nil
+		// Credentials the environment holds have to be folded in here as
+		// well, not only inside the store constructors. Writes and
+		// deletes go through the cloud SDK with this config, and
+		// configFromEnv discards everything when no bucket was set in
+		// the environment -- so a bucket named by flag would otherwise
+		// reach the SDK with no credential at all and fall back to
+		// whatever ambient identity the host happens to have.
+		return flowArchive.ConfigWithRuntimeEnv(cfg), nil
 	}
 
 	fromRows, source, ok, err := archiveConfigFromIntegrations(ctx)
@@ -412,6 +419,7 @@ func flowArchiveCompactConfig(ctx context.Context, cmd *cobra.Command, opts *flo
 		mergeArchiveOverrides(envCfg, &cfg)
 		applyArchiveFlags(cmd, opts, &cfg)
 	}
+	cfg = flowArchive.ConfigWithRuntimeEnv(cfg)
 
 	if cfg.Provider == "" || cfg.Bucket == "" {
 		return flowArchive.Config{}, fmt.Errorf(

--- a/management/cmd/flow_archive_compact_config.go
+++ b/management/cmd/flow_archive_compact_config.go
@@ -1,0 +1,82 @@
+//go:build archive_duckdb
+
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+
+	flowArchive "github.com/openzro/openzro/flow/store/archive"
+	flowExports "github.com/openzro/openzro/management/server/flow_exports"
+	mgmtStore "github.com/openzro/openzro/management/server/store"
+	"github.com/openzro/openzro/management/server/types"
+)
+
+// archiveConfigFromIntegrations reads the archive destination the operator
+// configured in the dashboard, under Integrations, and returns it as a
+// reader/writer config.
+//
+// This is the same row the management server reads at startup, decrypted
+// with the same key, so the compaction command writes to the bucket the
+// sink is writing to and with the credential the operator already gave
+// it. The alternative was a second copy of the service-account key,
+// living in a Kubernetes Secret and drifting from the console the moment
+// anybody rotated one and not the other.
+//
+// It deliberately does not supply the HMAC pair. That belongs to reads:
+// DuckDB reaches GCS through httpfs, whose secret accepts interoperability
+// keys and rejects service-account JSON, so the pair has to come from the
+// environment and configWithRuntimeEnv restores it there. The row has no
+// field for it, and inventing one would mean a dashboard change to store a
+// credential that only one consumer needs.
+//
+// Returns ok=false when nothing is configured, which is not an error: the
+// caller falls back to whatever the flags and environment provide.
+func archiveConfigFromIntegrations(ctx context.Context) (cfg flowArchive.Config, source string, ok bool, err error) {
+	// No management config means this is not running beside a management
+	// deployment -- a laptop, a debug container, a CI job. That is not a
+	// failure, it is an absence: the caller falls through to its flags
+	// and environment, and its own error names all three sources. Only a
+	// config that exists and cannot be read is worth reporting, since
+	// that is a real misconfiguration rather than a different context.
+	if _, statErr := os.Stat(types.MgmtConfigPath); errors.Is(statErr, os.ErrNotExist) {
+		return flowArchive.Config{}, "", false, nil
+	}
+
+	mgmtCfg, err := loadMgmtConfig(ctx, types.MgmtConfigPath)
+	if err != nil {
+		return flowArchive.Config{}, "", false, fmt.Errorf(
+			"flow archive compact: read management config from %s: %w", types.MgmtConfigPath, err)
+	}
+
+	// skipMigration: this command reads one row and exits. Running
+	// schema migrations from a CronJob that happens to start while the
+	// server is mid-upgrade is a way to turn a maintenance task into an
+	// outage.
+	store, err := mgmtStore.NewStore(ctx, mgmtCfg.StoreConfig.Engine, mgmtCfg.Datadir, nil, true)
+	if err != nil {
+		return flowArchive.Config{}, "", false, fmt.Errorf("flow archive compact: open store: %w", err)
+	}
+	defer func() { _ = store.Close(ctx) }()
+
+	sqlStore, isSQL := store.(*mgmtStore.SqlStore)
+	if !isSQL {
+		// The file store predates integrations and cannot hold a
+		// flow_exports row, so there is nothing to read rather than
+		// something broken.
+		return flowArchive.Config{}, "", false, nil
+	}
+
+	exports, err := flowExports.NewStore(sqlStore.GetGormDB(), mgmtCfg.DataStoreEncryptionKey)
+	if err != nil {
+		return flowArchive.Config{}, "", false, fmt.Errorf("flow archive compact: flow_exports store: %w", err)
+	}
+
+	cfg, source, ok, err = flowExports.ArchiveConfigFromRows(ctx, exports)
+	if err != nil {
+		return flowArchive.Config{}, "", false, fmt.Errorf("flow archive compact: read archive config: %w", err)
+	}
+	return cfg, source, ok, nil
+}

--- a/management/cmd/flow_archive_compact_integrations_test.go
+++ b/management/cmd/flow_archive_compact_integrations_test.go
@@ -249,3 +249,50 @@ func TestFlowArchiveCompactConfigCompleteEnvWinsOverIntegrations(t *testing.T) {
 	require.Equal(t, "bucket-from-env", cfg.Bucket)
 	require.Equal(t, "prefix-from-env", cfg.Prefix)
 }
+
+// A bucket named by flag with the credential in the environment: the
+// shape a SQLite deployment has to use, since it cannot read the
+// dashboard row.
+//
+// The credential has to reach the config the *store* is built from, not
+// only the one DuckDB reads with. Writes and deletes go through the
+// cloud SDK, and configFromEnv discards everything when no bucket is set
+// in the environment -- so without folding the runtime environment back
+// in, this config reaches the SDK with nothing and falls back to
+// whatever ambient identity the host has. On a GKE node that is a
+// read-only service account, and the first symptom is a permission error
+// naming a credential nobody configured.
+func TestFlowArchiveCompactConfigFlagBucketKeepsEnvCredentials(t *testing.T) {
+	t.Setenv("OPENZRO_FLOW_ARCHIVE_GCS_CREDENTIALS_JSON", `{"type":"service_account"}`)
+	t.Setenv("OPENZRO_FLOW_ARCHIVE_GCS_HMAC_KEY_ID", "hmac-key")
+	t.Setenv("OPENZRO_FLOW_ARCHIVE_GCS_HMAC_SECRET", "hmac-secret")
+
+	opts := &flowArchiveCompactOptions{concurrency: 1}
+	cmd := newFlowArchiveCompactCommand(opts)
+	require.NoError(t, cmd.Flags().Set("provider", "gcs"))
+	require.NoError(t, cmd.Flags().Set("bucket", "named-by-flag"))
+
+	cfg, err := flowArchiveCompactConfig(context.Background(), cmd, opts)
+	require.NoError(t, err)
+	require.Equal(t, "named-by-flag", cfg.Bucket)
+	require.Equal(t, `{"type":"service_account"}`, string(cfg.CredentialsJSON),
+		"the write credential must survive a bucket named by flag")
+	require.Equal(t, "hmac-key", cfg.AccessKeyID, "and the read credential with it")
+}
+
+// The same for S3, where one key pair signs both halves and losing it
+// costs the whole operation.
+func TestFlowArchiveCompactConfigFlagBucketKeepsS3Credentials(t *testing.T) {
+	t.Setenv("OPENZRO_FLOW_ARCHIVE_S3_ACCESS_KEY", "s3-key")
+	t.Setenv("OPENZRO_FLOW_ARCHIVE_S3_SECRET_KEY", "s3-secret")
+
+	opts := &flowArchiveCompactOptions{concurrency: 1}
+	cmd := newFlowArchiveCompactCommand(opts)
+	require.NoError(t, cmd.Flags().Set("provider", "s3"))
+	require.NoError(t, cmd.Flags().Set("bucket", "named-by-flag"))
+
+	cfg, err := flowArchiveCompactConfig(context.Background(), cmd, opts)
+	require.NoError(t, err)
+	require.Equal(t, "s3-key", cfg.AccessKeyID)
+	require.Equal(t, "s3-secret", cfg.SecretAccessKey)
+}

--- a/management/cmd/flow_archive_compact_integrations_test.go
+++ b/management/cmd/flow_archive_compact_integrations_test.go
@@ -54,6 +54,27 @@ func writeMgmtConfig(t *testing.T) string {
 	return dir
 }
 
+// seedArchiveRow writes one enabled GCS archive destination, the way the
+// dashboard would.
+func seedArchiveRow(t *testing.T, ctx context.Context, dir, bucket, prefix string) {
+	t.Helper()
+	store, err := mgmtStore.NewStore(ctx, types.SqliteStoreEngine, dir, nil, false)
+	require.NoError(t, err)
+	sqlStore, ok := store.(*mgmtStore.SqlStore)
+	require.True(t, ok)
+	exports, err := flowExports.NewStore(sqlStore.GetGormDB(), testEncryptionKey)
+	require.NoError(t, err)
+	_, err = exports.Save(ctx, flowExports.SaveInput{
+		Name: "archive", Type: flowExports.TypeGCS, Enabled: true,
+		GCS: &flowExports.GCSDestConfig{
+			Bucket: bucket, Prefix: prefix, Format: "parquet",
+			CredentialsJSON: `{"type":"service_account"}`,
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.Close(ctx))
+}
+
 // The point of reading the dashboard's row: a deployment that configured
 // its archive under Integrations sets no OPENZRO_FLOW_ARCHIVE_*_BUCKET
 // anywhere, and its credential exists only as an encrypted row. Without
@@ -139,4 +160,92 @@ func TestArchiveConfigFromIntegrationsReportsABrokenConfig(t *testing.T) {
 	_, _, found, err := archiveConfigFromIntegrations(context.Background())
 	require.Error(t, err)
 	require.False(t, found)
+}
+
+// The escape hatch. This command deletes objects, so an operator
+// pointing it at a copy of the bucket -- or working around a broken
+// deployment -- must not be blocked because the management config cannot
+// be read. Flags that fully name the archive mean nothing else is
+// consulted at all.
+//
+// The config here exists and is unparseable, which is the case that used
+// to fail: the command returned that error before it ever reached the
+// flags.
+func TestFlowArchiveCompactConfigFlagsSkipABrokenManagementConfig(t *testing.T) {
+	broken := filepath.Join(t.TempDir(), "management.json")
+	require.NoError(t, os.WriteFile(broken, []byte("{not json"), 0o600))
+	old := types.MgmtConfigPath
+	types.MgmtConfigPath = broken
+	t.Cleanup(func() { types.MgmtConfigPath = old })
+
+	opts := &flowArchiveCompactOptions{concurrency: 1}
+	cmd := newFlowArchiveCompactCommand(opts)
+	require.NoError(t, cmd.Flags().Set("provider", "gcs"))
+	require.NoError(t, cmd.Flags().Set("bucket", "a-copy-of-the-bucket"))
+
+	cfg, err := flowArchiveCompactConfig(context.Background(), cmd, opts)
+	require.NoError(t, err, "flags that name the archive must not require a readable config")
+	require.Equal(t, "a-copy-of-the-bucket", cfg.Bucket)
+	require.Equal(t, "gcs", cfg.Provider)
+}
+
+// A flag that only names part of the archive is an override, not an
+// escape hatch: the row still supplies the rest, including the
+// credential.
+func TestFlowArchiveCompactConfigPartialFlagsStillReadIntegrations(t *testing.T) {
+	ctx := context.Background()
+	dir := writeMgmtConfig(t)
+	seedArchiveRow(t, ctx, dir, "bucket-from-console", "flows")
+
+	opts := &flowArchiveCompactOptions{concurrency: 1}
+	cmd := newFlowArchiveCompactCommand(opts)
+	require.NoError(t, cmd.Flags().Set("prefix", "prefix-from-flag"))
+
+	cfg, err := flowArchiveCompactConfig(ctx, cmd, opts)
+	require.NoError(t, err)
+	require.Equal(t, "bucket-from-console", cfg.Bucket, "the row still names the bucket")
+	require.Equal(t, "prefix-from-flag", cfg.Prefix, "and the flag still overrides what it names")
+	require.NotEmpty(t, cfg.CredentialsJSON, "the credential comes with the row")
+}
+
+// The environment is all-or-nothing, and that is worth pinning because
+// it surprises people. ConfigFromEnv reports "not configured" unless a
+// bucket is set, and returns an empty Config -- so exporting only a
+// prefix, expecting it to override the dashboard, does nothing.
+//
+// It is consistent with how the reader treats the same variables
+// everywhere, which is why it stays this way rather than growing a
+// special case. Use a flag to override one field.
+func TestFlowArchiveCompactConfigEnvWithoutBucketDoesNotOverrideIntegrations(t *testing.T) {
+	ctx := context.Background()
+	dir := writeMgmtConfig(t)
+	seedArchiveRow(t, ctx, dir, "bucket-from-console", "flows")
+	t.Setenv("OPENZRO_FLOW_ARCHIVE_GCS_PREFIX", "ignored-without-a-bucket")
+
+	opts := &flowArchiveCompactOptions{concurrency: 1}
+	cmd := newFlowArchiveCompactCommand(opts)
+
+	cfg, err := flowArchiveCompactConfig(ctx, cmd, opts)
+	require.NoError(t, err)
+	require.Equal(t, "bucket-from-console", cfg.Bucket)
+	require.Equal(t, "flows", cfg.Prefix,
+		"a prefix with no bucket beside it is not a configured archive")
+}
+
+// With a bucket beside it, the environment does describe an archive, and
+// it wins outright -- the row is never read.
+func TestFlowArchiveCompactConfigCompleteEnvWinsOverIntegrations(t *testing.T) {
+	ctx := context.Background()
+	dir := writeMgmtConfig(t)
+	seedArchiveRow(t, ctx, dir, "bucket-from-console", "flows")
+	t.Setenv("OPENZRO_FLOW_ARCHIVE_GCS_BUCKET", "bucket-from-env")
+	t.Setenv("OPENZRO_FLOW_ARCHIVE_GCS_PREFIX", "prefix-from-env")
+
+	opts := &flowArchiveCompactOptions{concurrency: 1}
+	cmd := newFlowArchiveCompactCommand(opts)
+
+	cfg, err := flowArchiveCompactConfig(ctx, cmd, opts)
+	require.NoError(t, err)
+	require.Equal(t, "bucket-from-env", cfg.Bucket)
+	require.Equal(t, "prefix-from-env", cfg.Prefix)
 }

--- a/management/cmd/flow_archive_compact_integrations_test.go
+++ b/management/cmd/flow_archive_compact_integrations_test.go
@@ -1,0 +1,142 @@
+//go:build archive_duckdb
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	flowExports "github.com/openzro/openzro/management/server/flow_exports"
+	mgmtStore "github.com/openzro/openzro/management/server/store"
+	"github.com/openzro/openzro/management/server/types"
+)
+
+// testEncryptionKey is a throwaway 32-byte key, base64 as the store
+// expects. Not a secret: it exists only to let the row round-trip.
+const testEncryptionKey = "vCKp1HLogZ09qiOFWAz+mDpieiuPsBRtBSOvZd9d1hk="
+
+// writeMgmtConfig lays down the smallest management config that points at
+// a SQLite store in its own directory, and aims the package-level path at
+// it. Both are restored when the test ends.
+func writeMgmtConfig(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	cfg := map[string]any{
+		"Datadir":                dir,
+		"DataStoreEncryptionKey": testEncryptionKey,
+		"StoreConfig":            map[string]any{"Engine": "sqlite"},
+		// loadMgmtConfig dereferences HttpConfig unconditionally, so an
+		// empty object is the floor for a loadable config.
+		"HttpConfig": map[string]any{},
+	}
+	body, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	path := filepath.Join(dir, "management.json")
+	require.NoError(t, os.WriteFile(path, body, 0o600))
+
+	oldPath := types.MgmtConfigPath
+	types.MgmtConfigPath = path
+	// loadMgmtConfig overrides Datadir with the --datadir flag whenever
+	// it is set, and the flag defaults to /var/lib/openzro. Point it at
+	// the temp dir so the config it returns describes this test.
+	oldDir := mgmtDataDir
+	mgmtDataDir = dir
+	t.Cleanup(func() {
+		types.MgmtConfigPath = oldPath
+		mgmtDataDir = oldDir
+	})
+	return dir
+}
+
+// The point of reading the dashboard's row: a deployment that configured
+// its archive under Integrations sets no OPENZRO_FLOW_ARCHIVE_*_BUCKET
+// anywhere, and its credential exists only as an encrypted row. Without
+// this the command needs a second copy of the service-account key, which
+// drifts from the console the first time one of them is rotated.
+func TestArchiveConfigFromIntegrationsReadsTheDashboardRow(t *testing.T) {
+	ctx := context.Background()
+	dir := writeMgmtConfig(t)
+
+	store, err := mgmtStore.NewStore(ctx, types.SqliteStoreEngine, dir, nil, false)
+	require.NoError(t, err)
+	sqlStore, ok := store.(*mgmtStore.SqlStore)
+	require.True(t, ok)
+
+	exports, err := flowExports.NewStore(sqlStore.GetGormDB(), testEncryptionKey)
+	require.NoError(t, err)
+	_, err = exports.Save(ctx, flowExports.SaveInput{
+		Name:    "archive",
+		Type:    flowExports.TypeGCS,
+		Enabled: true,
+		GCS: &flowExports.GCSDestConfig{
+			Bucket:          "bucket-from-console",
+			Prefix:          "flows",
+			Format:          "parquet",
+			CredentialsJSON: `{"type":"service_account"}`,
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.Close(ctx))
+
+	cfg, source, found, err := archiveConfigFromIntegrations(ctx)
+	require.NoError(t, err)
+	require.True(t, found, "a configured archive must be found")
+	require.Equal(t, "gcs", cfg.Provider)
+	require.Equal(t, "bucket-from-console", cfg.Bucket)
+	require.Equal(t, "flows", cfg.Prefix)
+	require.Equal(t, `{"type":"service_account"}`, string(cfg.CredentialsJSON),
+		"the credential must come with it; that is the whole reason for reading the row")
+	require.Contains(t, source, "flow_exports")
+}
+
+// Flags still win, so an operator can point the command at a copy of the
+// bucket without touching what the deployment is running on.
+func TestFlowArchiveCompactConfigFlagsWinOverIntegrations(t *testing.T) {
+	ctx := context.Background()
+	dir := writeMgmtConfig(t)
+
+	store, err := mgmtStore.NewStore(ctx, types.SqliteStoreEngine, dir, nil, false)
+	require.NoError(t, err)
+	sqlStore, _ := store.(*mgmtStore.SqlStore)
+	exports, err := flowExports.NewStore(sqlStore.GetGormDB(), testEncryptionKey)
+	require.NoError(t, err)
+	_, err = exports.Save(ctx, flowExports.SaveInput{
+		Name: "archive", Type: flowExports.TypeGCS, Enabled: true,
+		GCS: &flowExports.GCSDestConfig{
+			Bucket: "bucket-from-console", Prefix: "flows", Format: "parquet",
+		},
+	})
+	require.NoError(t, err)
+	require.NoError(t, store.Close(ctx))
+
+	opts := &flowArchiveCompactOptions{concurrency: 1}
+	cmd := newFlowArchiveCompactCommand(opts)
+	require.NoError(t, cmd.Flags().Set("bucket", "bucket-from-flag"))
+
+	cfg, err := flowArchiveCompactConfig(ctx, cmd, opts)
+	require.NoError(t, err)
+	require.Equal(t, "bucket-from-flag", cfg.Bucket)
+	require.Equal(t, "gcs", cfg.Provider, "the rest of the row still applies")
+}
+
+// A management config that exists but cannot be read is a real
+// misconfiguration and must be reported. Only its absence is treated as
+// "not running beside a management deployment".
+func TestArchiveConfigFromIntegrationsReportsABrokenConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "management.json")
+	require.NoError(t, os.WriteFile(path, []byte("{not json"), 0o600))
+	old := types.MgmtConfigPath
+	types.MgmtConfigPath = path
+	t.Cleanup(func() { types.MgmtConfigPath = old })
+
+	_, _, found, err := archiveConfigFromIntegrations(context.Background())
+	require.Error(t, err)
+	require.False(t, found)
+}

--- a/management/cmd/flow_archive_compact_test.go
+++ b/management/cmd/flow_archive_compact_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"github.com/openzro/openzro/management/server/types"
 	"os"
 	"testing"
 	"time"
@@ -172,7 +173,7 @@ func TestFlowArchiveCompactWorkerContinuesDryRunAfterDayError(t *testing.T) {
 
 func TestFlowArchiveCompactDoesNotCreateManifestWhenStoreConfigFails(t *testing.T) {
 	manifest := t.TempDir() + "/manifest.jsonl"
-	cmd := newFlowArchiveCompactCommand()
+	cmd := newFlowArchiveCompactCommand(&flowArchiveCompactOptions{concurrency: 1})
 	cmd.SetArgs([]string{
 		"--from", "2026-07-01",
 		"--to", "2026-07-01",
@@ -192,7 +193,7 @@ func TestFlowArchiveCompactDoesNotCreateManifestWhenDuckDBConfigFails(t *testing
 	t.Setenv("OPENZRO_FLOW_ARCHIVE_GCS_HMAC_KEY_ID", "")
 	t.Setenv("OPENZRO_FLOW_ARCHIVE_GCS_HMAC_SECRET", "")
 	manifest := t.TempDir() + "/manifest.jsonl"
-	cmd := newFlowArchiveCompactCommand()
+	cmd := newFlowArchiveCompactCommand(&flowArchiveCompactOptions{concurrency: 1})
 	cmd.SetArgs([]string{
 		"--from", "2026-07-01",
 		"--to", "2026-07-01",
@@ -265,5 +266,64 @@ func drainCompactResults(results <-chan flowArchiveCompactManifestEntry) []flowA
 		default:
 			return out
 		}
+	}
+}
+
+// Flags win over whatever was configured elsewhere, so an operator can
+// point the command at a copy of the bucket without touching the running
+// configuration.
+func TestFlowArchiveCompactConfigFlagsWinOverEnv(t *testing.T) {
+	t.Setenv("OPENZRO_FLOW_ARCHIVE_GCS_BUCKET", "from-env")
+	t.Setenv("OPENZRO_FLOW_ARCHIVE_GCS_PREFIX", "env-prefix")
+
+	opts := &flowArchiveCompactOptions{}
+	cmd := newFlowArchiveCompactCommand(opts)
+	require.NoError(t, cmd.Flags().Set("bucket", "from-flag"))
+	require.NoError(t, cmd.Flags().Set("prefix", "flag-prefix"))
+
+	cfg, err := flowArchiveCompactConfig(context.Background(), cmd, opts)
+	require.NoError(t, err)
+	require.Equal(t, "from-flag", cfg.Bucket)
+	require.Equal(t, "flag-prefix", cfg.Prefix)
+}
+
+// The environment is consulted before the dashboard, and finding a bucket
+// there means the command never opens the database. That matters for a
+// CronJob: an archive configured entirely through env should not need DB
+// credentials to compact.
+func TestFlowArchiveCompactConfigEnvSkipsTheDatabase(t *testing.T) {
+	t.Setenv("OPENZRO_FLOW_ARCHIVE_GCS_BUCKET", "from-env")
+	t.Setenv("OPENZRO_FLOW_ARCHIVE_GCS_HMAC_KEY_ID", "k")
+	t.Setenv("OPENZRO_FLOW_ARCHIVE_GCS_HMAC_SECRET", "s")
+	// A management config that exists and is unreadable: if Integrations
+	// were consulted, this would fail. An archive fully described by the
+	// environment must not need a database, which is what lets a CronJob
+	// run without database credentials.
+	broken := t.TempDir() + "/management.json"
+	require.NoError(t, os.WriteFile(broken, []byte("{not json"), 0o600))
+	old := types.MgmtConfigPath
+	types.MgmtConfigPath = broken
+	t.Cleanup(func() { types.MgmtConfigPath = old })
+
+	opts := &flowArchiveCompactOptions{}
+	cmd := newFlowArchiveCompactCommand(opts)
+
+	cfg, err := flowArchiveCompactConfig(context.Background(), cmd, opts)
+	require.NoError(t, err, "an env-configured archive must not require a database")
+	require.Equal(t, "from-env", cfg.Bucket)
+	require.Equal(t, "gcs", cfg.Provider)
+}
+
+// With nothing configured anywhere, the error has to name all three
+// places rather than only the environment -- an operator who set the
+// bucket in the dashboard and hit this needs to know the command looked
+// there.
+func TestFlowArchiveCompactConfigErrorNamesEverySource(t *testing.T) {
+	opts := &flowArchiveCompactOptions{}
+	cmd := newFlowArchiveCompactCommand(opts)
+	_, err := flowArchiveCompactConfig(context.Background(), cmd, opts)
+	require.Error(t, err)
+	for _, want := range []string{"Integrations", "OPENZRO_FLOW_ARCHIVE_", "--provider"} {
+		require.Contains(t, err.Error(), want)
 	}
 }


### PR DESCRIPTION
Reopened as a fresh PR: #192 was auto-closed when its base branch (#191) was deleted on merge, and GitHub will not retarget a closed PR. Same three commits, now rebased onto `main`. All review history is on #192.

## The problem

A deployment that configures its archive in the dashboard has **no** `OPENZRO_FLOW_ARCHIVE_*_BUCKET` set anywhere, and its credential exists only as an encrypted `flow_exports` row. The compaction command read neither, so running it meant handing a CronJob its own copy of the service-account key — which drifts from the console the first time somebody rotates one and not the other.

## Resolution order

| | |
| --- | --- |
| 1. `OPENZRO_FLOW_ARCHIVE_*` | explicit configuration comes first |
| 2. flags | override individual fields |
| 3. **short circuit** | if provider *and* bucket are both set by then, nothing else is read — no management config, no database |
| 4. Integrations | otherwise the dashboard row is the base, with the flags layered back on |

Step 3 makes the flags an **escape hatch** rather than a preference. This command deletes objects, so pointing it at a copy of the bucket — or working around a broken deployment — must not depend on the management config being readable or the database being up.

The environment is **all-or-nothing**: without a bucket it describes no archive, so exporting only a prefix does not override the dashboard. That is how the reader treats these variables everywhere; use a flag to change one field.

## The HMAC pair stays, and that is not an oversight

Reads go through DuckDB, whose GCS secret takes interoperability keys and **rejects service-account JSON**. No row carries them. Writes and deletes use the service account. **S3 needs no such split** — one key pair signs both halves.

## Three findings from review, all fixed

| finding | fix |
| --- | --- |
| flags applied *after* the lookup, so a broken `management.json` blocked the escape hatch | short circuit before touching config or DB |
| documented order said Integrations first while the code checked env first | help and comment now match the code |
| the config returned to the **writer** never passed through `ConfigWithRuntimeEnv`, so a flag-named bucket reached the SDK with no credential | fold it in on both paths |

The third was the worst, and it landed only on the escape-hatch path — which is the shape a SQLite deployment is forced to use, since it cannot read the row at all. The one configuration with no alternative was silently losing its credentials.

## Tests

The Integrations path runs against a real SQLite store with a real encrypted row. Every property is pinned by a mutation that fails without it:

| mutation | fails |
| --- | --- |
| never consult Integrations | `FlagsWinOverIntegrations` |
| consult it when the environment already answered | `EnvSkipsTheDatabase` |
| read Integrations despite complete flags | `FlagsSkipABrokenManagementConfig` |
| drop the flag overlay after reading the row | `PartialFlagsStillReadIntegrations` |
| skip `ConfigWithRuntimeEnv` on the short circuit | `FlagBucketKeepsEnvCredentials`, `FlagBucketKeepsS3Credentials` |

Chart side in corabank/platform-openzro#22.