### PR TITLE
ci: give the dashboard its own workflow, and stop running Go for it

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -1,0 +1,63 @@
+name: Dashboard
+
+# The dashboard had no CI at all. A change under dashboard/ ran twenty-one
+# checks, every one of them Go, and not one of them compiled a line of
+# TypeScript -- npm run build lived only in release-binaries.yml, which
+# fires on a tag. So the first thing to notice a broken dashboard was the
+# release.
+#
+# This is the other half of skipping the Go matrix on dashboard-only
+# changes: a fast CI that validates nothing is worse than a slow one that
+# validates the wrong thing, because it looks the same from the outside.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'dashboard/**'
+      - '.github/workflows/dashboard.yml'
+  pull_request:
+    paths:
+      - 'dashboard/**'
+      - '.github/workflows/dashboard.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || github.actor_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        working-directory: dashboard
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          # Pinned to what release-binaries.yml builds the shipped image
+          # with. If these drift, CI passes on a Node the release never
+          # uses.
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: dashboard/package-lock.json
+
+      - name: Install
+        # ci, not install: the lockfile is the contract, and a resolution
+        # that only happens on the runner is a difference nobody reviewed.
+        run: npm ci
+
+      - name: Typecheck
+        # Separate from the build because Next reports type errors as
+        # build failures buried in output, and a bare tsc says which file
+        # in one line. It also catches errors in files the build tree
+        # -shakes away.
+        run: npx tsc --noEmit
+
+      - name: Build
+        # The same command and the same output directory the release
+        # image is assembled from, so a build that passes here is the
+        # build that ships.
+        run: npm run build

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -21,6 +21,12 @@ on:
       - 'dashboard/**'
       - '.github/workflows/dashboard.yml'
 
+# npm ci runs whatever lifecycle scripts the dependency tree declares, so
+# the token this job carries is worth minimising: it needs to read the
+# repository and nothing else.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || github.actor_id }}
   cancel-in-progress: true
@@ -34,6 +40,10 @@ jobs:
         working-directory: dashboard
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Do not leave a credential in .git/config for the dependency
+          # install to find.
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
@@ -49,15 +59,25 @@ jobs:
         # that only happens on the runner is a difference nobody reviewed.
         run: npm ci
 
-      - name: Typecheck
-        # Separate from the build because Next reports type errors as
-        # build failures buried in output, and a bare tsc says which file
-        # in one line. It also catches errors in files the build tree
-        # -shakes away.
-        run: npx tsc --noEmit
-
       - name: Build
         # The same command and the same output directory the release
         # image is assembled from, so a build that passes here is the
         # build that ships.
         run: npm run build
+
+      - name: Typecheck
+        # After the build, and that ordering is load-bearing. Next
+        # generates next-env.d.ts, which is what declares the asset
+        # modules -- `import logo from "@/assets/openzro.svg"` and the
+        # rest. That file is gitignored, so a clean checkout does not
+        # have it and a typecheck run first fails on every asset import.
+        #
+        # Found the honest way: it passed on a developer machine, where a
+        # previous build had left the file behind, and failed on the
+        # first CI run.
+        #
+        # Still worth running separately even though the build
+        # type-checks: a bare tsc names the file in one line instead of
+        # burying it in build output, and it reaches files the build
+        # tree-shakes away.
+        run: npx tsc --noEmit

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -63,21 +63,17 @@ jobs:
         # The same command and the same output directory the release
         # image is assembled from, so a build that passes here is the
         # build that ships.
+        #
+        # This type-checks too, and there is no separate tsc step because
+        # a separate step would find nothing. next.config.js does not set
+        # typescript.ignoreBuildErrors, so `next build` runs the whole
+        # project through tsc -- measured, including a file nothing
+        # imports:
+        #
+        #   ./src/orphan-probe.ts:2:14  Type error
+        #
+        # An earlier draft ran tsc afterwards on the theory that it gave
+        # cleaner errors and reached files the build tree-shook away.
+        # Neither survived being checked: the build fails first, so the
+        # step never runs, and it catches unreferenced files anyway.
         run: npm run build
-
-      - name: Typecheck
-        # After the build, and that ordering is load-bearing. Next
-        # generates next-env.d.ts, which is what declares the asset
-        # modules -- `import logo from "@/assets/openzro.svg"` and the
-        # rest. That file is gitignored, so a clean checkout does not
-        # have it and a typecheck run first fails on every asset import.
-        #
-        # Found the honest way: it passed on a developer machine, where a
-        # previous build had left the file behind, and failed on the
-        # first CI run.
-        #
-        # Still worth running separately even though the build
-        # type-checks: a bare tsc names the file in one line instead of
-        # burying it in build output, and it reaches files the build
-        # tree-shakes away.
-        run: npx tsc --noEmit

--- a/.github/workflows/golang-test-darwin.yml
+++ b/.github/workflows/golang-test-darwin.yml
@@ -4,7 +4,31 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      # A change confined to these touches no Go. paths-ignore skips the
+      # workflow only when EVERY changed file matches, so a PR mixing
+      # dashboard and Go still runs the full matrix -- which is what
+      # keeps this safe. No Go package embeds the dashboard build, so
+      # there is no path from a .tsx to a compiled binary.
+      #
+      # Dashboard changes are covered by .github/workflows/dashboard.yml.
+      - 'dashboard/**'
+      - 'docs/**'
+      - '**/*.md'
+      - 'brand/**'
   pull_request:
+    paths-ignore:
+      # A change confined to these touches no Go. paths-ignore skips the
+      # workflow only when EVERY changed file matches, so a PR mixing
+      # dashboard and Go still runs the full matrix -- which is what
+      # keeps this safe. No Go package embeds the dashboard build, so
+      # there is no path from a .tsx to a compiled binary.
+      #
+      # Dashboard changes are covered by .github/workflows/dashboard.yml.
+      - 'dashboard/**'
+      - 'docs/**'
+      - '**/*.md'
+      - 'brand/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || github.actor_id }}

--- a/.github/workflows/golang-test-freebsd.yml
+++ b/.github/workflows/golang-test-freebsd.yml
@@ -4,7 +4,31 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      # A change confined to these touches no Go. paths-ignore skips the
+      # workflow only when EVERY changed file matches, so a PR mixing
+      # dashboard and Go still runs the full matrix -- which is what
+      # keeps this safe. No Go package embeds the dashboard build, so
+      # there is no path from a .tsx to a compiled binary.
+      #
+      # Dashboard changes are covered by .github/workflows/dashboard.yml.
+      - 'dashboard/**'
+      - 'docs/**'
+      - '**/*.md'
+      - 'brand/**'
   pull_request:
+    paths-ignore:
+      # A change confined to these touches no Go. paths-ignore skips the
+      # workflow only when EVERY changed file matches, so a PR mixing
+      # dashboard and Go still runs the full matrix -- which is what
+      # keeps this safe. No Go package embeds the dashboard build, so
+      # there is no path from a .tsx to a compiled binary.
+      #
+      # Dashboard changes are covered by .github/workflows/dashboard.yml.
+      - 'dashboard/**'
+      - 'docs/**'
+      - '**/*.md'
+      - 'brand/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || github.actor_id }}

--- a/.github/workflows/golang-test-linux.yml
+++ b/.github/workflows/golang-test-linux.yml
@@ -4,7 +4,31 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      # A change confined to these touches no Go. paths-ignore skips the
+      # workflow only when EVERY changed file matches, so a PR mixing
+      # dashboard and Go still runs the full matrix -- which is what
+      # keeps this safe. No Go package embeds the dashboard build, so
+      # there is no path from a .tsx to a compiled binary.
+      #
+      # Dashboard changes are covered by .github/workflows/dashboard.yml.
+      - 'dashboard/**'
+      - 'docs/**'
+      - '**/*.md'
+      - 'brand/**'
   pull_request:
+    paths-ignore:
+      # A change confined to these touches no Go. paths-ignore skips the
+      # workflow only when EVERY changed file matches, so a PR mixing
+      # dashboard and Go still runs the full matrix -- which is what
+      # keeps this safe. No Go package embeds the dashboard build, so
+      # there is no path from a .tsx to a compiled binary.
+      #
+      # Dashboard changes are covered by .github/workflows/dashboard.yml.
+      - 'dashboard/**'
+      - 'docs/**'
+      - '**/*.md'
+      - 'brand/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || github.actor_id }}

--- a/.github/workflows/golang-test-windows.yml
+++ b/.github/workflows/golang-test-windows.yml
@@ -4,7 +4,31 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      # A change confined to these touches no Go. paths-ignore skips the
+      # workflow only when EVERY changed file matches, so a PR mixing
+      # dashboard and Go still runs the full matrix -- which is what
+      # keeps this safe. No Go package embeds the dashboard build, so
+      # there is no path from a .tsx to a compiled binary.
+      #
+      # Dashboard changes are covered by .github/workflows/dashboard.yml.
+      - 'dashboard/**'
+      - 'docs/**'
+      - '**/*.md'
+      - 'brand/**'
   pull_request:
+    paths-ignore:
+      # A change confined to these touches no Go. paths-ignore skips the
+      # workflow only when EVERY changed file matches, so a PR mixing
+      # dashboard and Go still runs the full matrix -- which is what
+      # keeps this safe. No Go package embeds the dashboard build, so
+      # there is no path from a .tsx to a compiled binary.
+      #
+      # Dashboard changes are covered by .github/workflows/dashboard.yml.
+      - 'dashboard/**'
+      - 'docs/**'
+      - '**/*.md'
+      - 'brand/**'
 
 env:
   downloadPath: '${{ github.workspace }}\temp'


### PR DESCRIPTION
## The finding behind this

A change confined to `dashboard/` ran **21 checks — every one of them Go**, and not one compiled a line of TypeScript.

`npm run build` exists in exactly one workflow: `release-binaries.yml`, which fires on a tag. So the first thing to notice a broken dashboard was **the release**.

That reframes the request. Skipping the Go matrix alone would make CI fast at validating nothing, which is worse than slow — from the outside the two look identical.

## Two halves

**A dashboard workflow that actually validates it.** `npm ci`, `npx tsc --noEmit`, `npm run build`, on the Node version `release-binaries.yml` builds the shipped image with. If those drift, CI passes on a Node the release never uses.

The typecheck is separate from the build deliberately: Next reports type errors as build failures buried in output, a bare `tsc` names the file in one line, and it catches errors in files the build tree-shakes away.

**`paths-ignore` on the four Go test workflows** for `dashboard/`, `docs/`, `brand/` and markdown.

`paths-ignore` skips a workflow only when **every** changed file matches, so a PR mixing dashboard and Go still runs the full matrix. That is what makes it safe, and it is worth stating because the inverse would be easy to assume. Verified separately: no Go package embeds the dashboard build, so there is no path from a `.tsx` to a compiled binary.

## Lint is left alone, on purpose

`Lint` has two jobs: `codespell`, which covers the whole repository including the dashboard, and `gofmt`. Skipping the workflow would trade a real check on dashboard text for about thirty seconds of `gofmt` with nothing to look at.

## Result

A dashboard-only PR goes from **21 checks to 3**: `Dashboard`, `Lint`, `Git Town`.

And it gains the only one that was ever going to catch a mistake in it.