### PR TITLE
feat(dashboard): warn before a query reaches into the archive

### DIFF
--- a/dashboard/src/interfaces/Account.ts
+++ b/dashboard/src/interfaces/Account.ts
@@ -18,14 +18,19 @@ export interface Account {
       // "1h" | "6h" | "24h" | "7d" | "30d" | "all". Empty / "all" keeps
       // the no-filter behaviour.
       network_traffic_default_range?: string;
-      // How many hours of flow events the hot store keeps, as the server
-      // resolved it. Read-only and deployment-wide -- it rides on this
-      // payload because the traffic page already waits for it, so the
-      // boundary is known before the first query rather than after.
+      // How long the hot store keeps flow events, in seconds, as the
+      // server resolved it. Read-only and deployment-wide -- it rides on
+      // this payload because the traffic page already waits for it, so
+      // the boundary is known before the first query rather than after.
       //
-      // Anything older is answered from object storage: seconds instead
-      // of milliseconds.
-      network_traffic_hot_retention_hours?: number;
+      // Seconds, not a rounded unit: this IS the boundary, and rounding
+      // it moves it. Round for display, never for the comparison.
+      network_traffic_hot_retention_seconds?: number;
+      // Whether events older than that are read from an archive at all.
+      // False means such a window returns nothing rather than returning
+      // slowly, so promising a wait would describe a tier this
+      // deployment does not run.
+      network_traffic_archive_reads_enabled?: boolean;
     };
     peer_login_expiration_enabled: boolean;
     peer_login_expiration: number;

--- a/dashboard/src/interfaces/Account.ts
+++ b/dashboard/src/interfaces/Account.ts
@@ -18,6 +18,14 @@ export interface Account {
       // "1h" | "6h" | "24h" | "7d" | "30d" | "all". Empty / "all" keeps
       // the no-filter behaviour.
       network_traffic_default_range?: string;
+      // How many hours of flow events the hot store keeps, as the server
+      // resolved it. Read-only and deployment-wide -- it rides on this
+      // payload because the traffic page already waits for it, so the
+      // boundary is known before the first query rather than after.
+      //
+      // Anything older is answered from object storage: seconds instead
+      // of milliseconds.
+      network_traffic_hot_retention_hours?: number;
     };
     peer_login_expiration_enabled: boolean;
     peer_login_expiration: number;

--- a/dashboard/src/modules/network-traffic/v2/NetworkTrafficV2.tsx
+++ b/dashboard/src/modules/network-traffic/v2/NetworkTrafficV2.tsx
@@ -287,16 +287,35 @@ export default function NetworkTrafficV2() {
   // regression waiting to be fixed, it is what the two tiers are, so the
   // honest thing is to say so before the wait rather than during it.
   //
-  // Deliberately derived from the range and not from the response: the
+  // Derived from the range and not from the response, deliberately: the
   // point is to set expectations while the operator is choosing, and a
   // response-carried flag arrives exactly too late to do that.
-  const hotRetentionHours =
-    accounts?.[0]?.settings?.extra?.network_traffic_hot_retention_hours;
+  const hotRetentionSeconds =
+    accounts?.[0]?.settings?.extra?.network_traffic_hot_retention_seconds;
+  const archiveReadsEnabled =
+    accounts?.[0]?.settings?.extra?.network_traffic_archive_reads_enabled;
+
   const queriesColdData = useMemo(() => {
-    if (!hotRetentionHours || !range?.from) return false;
-    const boundary = dayjs().subtract(hotRetentionHours, "hour");
-    return dayjs(range.from).isBefore(boundary);
-  }, [hotRetentionHours, range]);
+    if (!hotRetentionSeconds || !archiveReadsEnabled) return false;
+    // No start bound is the widest question there is: the federated
+    // store treats an absent `since` as reaching back forever, so it
+    // reads the whole archive. It is the most expensive shape and the
+    // one that most needs warning about, and an earlier version stayed
+    // silent on it because it checked `range.from` first.
+    if (!range?.from) return true;
+    const boundarySeconds = dayjs().diff(dayjs(range.from), "second");
+    return boundarySeconds > hotRetentionSeconds;
+  }, [hotRetentionSeconds, archiveReadsEnabled, range]);
+
+  // Rounded here and only here. The comparison above uses the exact
+  // value; this is the sentence.
+  const hotRetentionLabel = useMemo(() => {
+    if (!hotRetentionSeconds) return "";
+    const days = Math.floor(hotRetentionSeconds / 86400);
+    if (days >= 1) return `${days} day${days === 1 ? "" : "s"}`;
+    const hours = Math.max(1, Math.round(hotRetentionSeconds / 3600));
+    return `${hours} hour${hours === 1 ? "" : "s"}`;
+  }, [hotRetentionSeconds]);
 
   const groups = useMemo(
     () =>
@@ -392,7 +411,7 @@ export default function NetworkTrafficV2() {
             <span className="font-medium text-oz2-text">
               Reading archived traffic.
             </span>{" "}
-            This range reaches past the {hotRetentionHours}h the database keeps,
+            This range reaches past the {hotRetentionLabel} the database keeps,
             so the older part is read from object storage. Expect seconds rather
             than the usual instant response — narrow the range if you only need
             recent activity.

--- a/dashboard/src/modules/network-traffic/v2/NetworkTrafficV2.tsx
+++ b/dashboard/src/modules/network-traffic/v2/NetworkTrafficV2.tsx
@@ -277,6 +277,27 @@ export default function NetworkTrafficV2() {
   // with the table a moment later.
   const isLoading = eventsLoading || !defaultApplied || !rangeSettled;
 
+  // Whether the selected window reaches past the hot store, in which
+  // case the answer comes from object storage instead of the database.
+  //
+  // Measured on a production archive: a hot query answers in about
+  // 200ms, the same shape of question against the archive takes several
+  // seconds even once the objects are compacted, because the cost is
+  // round trips to object storage rather than rows. That gap is not a
+  // regression waiting to be fixed, it is what the two tiers are, so the
+  // honest thing is to say so before the wait rather than during it.
+  //
+  // Deliberately derived from the range and not from the response: the
+  // point is to set expectations while the operator is choosing, and a
+  // response-carried flag arrives exactly too late to do that.
+  const hotRetentionHours =
+    accounts?.[0]?.settings?.extra?.network_traffic_hot_retention_hours;
+  const queriesColdData = useMemo(() => {
+    if (!hotRetentionHours || !range?.from) return false;
+    const boundary = dayjs().subtract(hotRetentionHours, "hour");
+    return dayjs(range.from).isBefore(boundary);
+  }, [hotRetentionHours, range]);
+
   const groups = useMemo(
     () =>
       groupFlows(
@@ -361,6 +382,23 @@ export default function NetworkTrafficV2() {
           your access policies match traffic in the wild.
         </p>
       </header>
+
+      {queriesColdData ? (
+        <OzCard className="flex items-start gap-3 border-oz2-border bg-oz2-surface-2 px-4 py-3">
+          <span className="mt-0.5 shrink-0 text-oz2-text-muted">
+            {ICONS.archive}
+          </span>
+          <div className="text-[13.5px] leading-relaxed text-oz2-text-2">
+            <span className="font-medium text-oz2-text">
+              Reading archived traffic.
+            </span>{" "}
+            This range reaches past the {hotRetentionHours}h the database keeps,
+            so the older part is read from object storage. Expect seconds rather
+            than the usual instant response — narrow the range if you only need
+            recent activity.
+          </div>
+        </OzCard>
+      ) : null}
 
       {data?.incomplete ? (
         <OzCard className="flex items-start gap-3 border-oz2-warn bg-oz2-warn-bg px-4 py-3">
@@ -1188,6 +1226,13 @@ const ICONS = {
     </>,
   ),
   chevDown: baseIcon(<path d="m6 9 6 6 6-6" />),
+  archive: baseIcon(
+    <>
+      <rect x={2} y={4} width={20} height={5} rx={1} />
+      <path d="M4 9v10a1 1 0 0 0 1 1h14a1 1 0 0 0 1-1V9" />
+      <path d="M10 13h4" />
+    </>,
+  ),
   warn: baseIcon(
     <>
       <path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0Z" />

--- a/dashboard/src/modules/network-traffic/v2/NetworkTrafficV2.tsx
+++ b/dashboard/src/modules/network-traffic/v2/NetworkTrafficV2.tsx
@@ -307,14 +307,25 @@ export default function NetworkTrafficV2() {
     return boundarySeconds > hotRetentionSeconds;
   }, [hotRetentionSeconds, archiveReadsEnabled, range]);
 
-  // Rounded here and only here. The comparison above uses the exact
-  // value; this is the sentence.
+  // The sentence, not the comparison -- that one uses the exact value
+  // above. This still must not round, for a smaller reason that is the
+  // same reason: telling an operator the database keeps "2 hours" when
+  // it keeps ninety minutes is a number they may act on.
+  //
+  // So: the largest unit the value divides into evenly, and minutes when
+  // nothing else fits. 30 days, 7 days, 36 hours, 90 minutes -- each
+  // exact.
   const hotRetentionLabel = useMemo(() => {
     if (!hotRetentionSeconds) return "";
-    const days = Math.floor(hotRetentionSeconds / 86400);
-    if (days >= 1) return `${days} day${days === 1 ? "" : "s"}`;
-    const hours = Math.max(1, Math.round(hotRetentionSeconds / 3600));
-    return `${hours} hour${hours === 1 ? "" : "s"}`;
+    const plural = (n: number, unit: string) =>
+      `${n} ${unit}${n === 1 ? "" : "s"}`;
+    if (hotRetentionSeconds % 86400 === 0)
+      return plural(hotRetentionSeconds / 86400, "day");
+    if (hotRetentionSeconds % 3600 === 0)
+      return plural(hotRetentionSeconds / 3600, "hour");
+    if (hotRetentionSeconds % 60 === 0)
+      return plural(hotRetentionSeconds / 60, "minute");
+    return plural(hotRetentionSeconds, "second");
   }, [hotRetentionSeconds]);
 
   const groups = useMemo(

--- a/flow/store/factory/factory.go
+++ b/flow/store/factory/factory.go
@@ -127,6 +127,22 @@ func openDB(engine, dsn string) (*gorm.DB, error) {
 	}
 }
 
+// HotRetention reports how far back the hot store keeps events, as the
+// running process resolved it -- the same value the retention loop and
+// the federated split use.
+//
+// Exported because the dashboard needs it before it asks a question, not
+// after. A window older than this is answered from the archive: object
+// storage, seconds rather than milliseconds, and the operator deserves
+// to know that while picking the range rather than while waiting.
+//
+// It is deliberately re-read rather than cached at startup: this returns
+// what the environment says now, which is what the retention loop uses
+// on its next pass.
+func HotRetention() time.Duration {
+	return parseRetention(os.Getenv(envRetention))
+}
+
 func parseRetention(raw string) time.Duration {
 	const def = 7 * 24 * time.Hour
 	if raw == "" {

--- a/flow/store/federated/federated.go
+++ b/flow/store/federated/federated.go
@@ -126,6 +126,17 @@ func (f *Federated) Query(ctx context.Context, filter store.Filter) ([]*store.Ev
 	return f.queryBoth(ctx, filter, hotFilter, archFilter)
 }
 
+// ReadsArchive reports whether this store has an archive behind it.
+//
+// Callers use it to tell an operator what a slow query is waiting on. A
+// deployment with no archive answers only from the hot store, so a window
+// older than retention returns nothing rather than returning slowly, and
+// telling that operator to expect a wait would be describing a tier they
+// do not run.
+func (f *Federated) ReadsArchive() bool {
+	return f.archive != nil
+}
+
 // queryBoth fans out to hot + archive in parallel, merges by
 // ReceivedAt desc, and applies the caller's Limit / Offset on the
 // merged stream.

--- a/management/server/http/api/openapi.yml
+++ b/management/server/http/api/openapi.yml
@@ -255,6 +255,19 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FlowPortFilter'
+        network_traffic_hot_retention_hours:
+          type: integer
+          readOnly: true
+          description: |
+            How many hours of flow events the hot store keeps, as the
+            server resolved it from OPENZRO_FLOW_RETENTION. Read-only and
+            deployment-wide -- it is reported here because this is the
+            payload the traffic page already waits for, not because it
+            belongs to the account.
+
+            Anything older than this is answered from the archive: object
+            storage rather than the database, and seconds rather than
+            milliseconds. Clients use it to say so before the query runs.
         network_traffic_default_range:
           description: |
             Pre-fills the date filter on the Flow Traffic dashboard page so

--- a/management/server/http/api/openapi.yml
+++ b/management/server/http/api/openapi.yml
@@ -255,19 +255,28 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FlowPortFilter'
-        network_traffic_hot_retention_hours:
+        network_traffic_hot_retention_seconds:
           type: integer
           readOnly: true
           description: |
-            How many hours of flow events the hot store keeps, as the
+            How long the hot store keeps flow events, in seconds, as the
             server resolved it from OPENZRO_FLOW_RETENTION. Read-only and
             deployment-wide -- it is reported here because this is the
             payload the traffic page already waits for, not because it
             belongs to the account.
 
-            Anything older than this is answered from the archive: object
-            storage rather than the database, and seconds rather than
-            milliseconds. Clients use it to say so before the query runs.
+            Seconds rather than a rounded unit on purpose: clients use it
+            as the boundary itself, and any rounding moves the boundary.
+            Round for display, never for the comparison.
+        network_traffic_archive_reads_enabled:
+          type: boolean
+          readOnly: true
+          description: |
+            Whether this deployment reads flow events older than the hot
+            retention from an archive. False means a window past the
+            boundary simply returns nothing, rather than returning slowly
+            from object storage -- clients should not promise a wait for
+            a tier that is not configured.
         network_traffic_default_range:
           description: |
             Pre-fills the date filter on the Flow Traffic dashboard page so

--- a/management/server/http/api/types.gen.go
+++ b/management/server/http/api/types.gen.go
@@ -319,6 +319,17 @@ type AccountExtraSettings struct {
 	// heartbeats, custom multicast, app-specific service discovery).
 	NetworkTrafficExcludedPorts *[]FlowPortFilter `json:"network_traffic_excluded_ports,omitempty"`
 
+	// NetworkTrafficHotRetentionHours How many hours of flow events the hot store keeps, as the
+	// server resolved it from OPENZRO_FLOW_RETENTION. Read-only and
+	// deployment-wide -- it is reported here because this is the
+	// payload the traffic page already waits for, not because it
+	// belongs to the account.
+	//
+	// Anything older than this is answered from the archive: object
+	// storage rather than the database, and seconds rather than
+	// milliseconds. Clients use it to say so before the query runs.
+	NetworkTrafficHotRetentionHours *int `json:"network_traffic_hot_retention_hours,omitempty"`
+
 	// NetworkTrafficLogsEnabled Enables or disables network traffic logging. If enabled, all network traffic events from peers will be stored.
 	NetworkTrafficLogsEnabled bool `json:"network_traffic_logs_enabled"`
 
@@ -1032,7 +1043,7 @@ type NetworkResource struct {
 	// Id Network Resource ID
 	Id string `json:"id"`
 
-	// Name Network resource name
+	// Name Network resource name. Unique within the account.
 	Name string `json:"name"`
 
 	// Type Network resource type based of the address
@@ -1050,7 +1061,7 @@ type NetworkResourceMinimum struct {
 	// Enabled Network resource status
 	Enabled bool `json:"enabled"`
 
-	// Name Network resource name
+	// Name Network resource name. Unique within the account.
 	Name string `json:"name"`
 }
 
@@ -1068,7 +1079,7 @@ type NetworkResourceRequest struct {
 	// Groups Group IDs containing the resource
 	Groups []string `json:"groups"`
 
-	// Name Network resource name
+	// Name Network resource name. Unique within the account.
 	Name string `json:"name"`
 }
 
@@ -1703,7 +1714,7 @@ type PostureCheckUpdate struct {
 	// Description Posture check friendly description
 	Description string `json:"description"`
 
-	// Name Posture check name identifier
+	// Name Posture check name identifier. Unique within the account.
 	Name string `json:"name"`
 }
 

--- a/management/server/http/api/types.gen.go
+++ b/management/server/http/api/types.gen.go
@@ -295,6 +295,13 @@ type Account struct {
 
 // AccountExtraSettings defines model for AccountExtraSettings.
 type AccountExtraSettings struct {
+	// NetworkTrafficArchiveReadsEnabled Whether this deployment reads flow events older than the hot
+	// retention from an archive. False means a window past the
+	// boundary simply returns nothing, rather than returning slowly
+	// from object storage -- clients should not promise a wait for
+	// a tier that is not configured.
+	NetworkTrafficArchiveReadsEnabled *bool `json:"network_traffic_archive_reads_enabled,omitempty"`
+
 	// NetworkTrafficDefaultRange Pre-fills the date filter on the Flow Traffic dashboard page so
 	// opening it does not request every event that fits in the
 	// 10 000-event API ceiling. Recognised values: "1h", "6h", "24h",
@@ -319,16 +326,16 @@ type AccountExtraSettings struct {
 	// heartbeats, custom multicast, app-specific service discovery).
 	NetworkTrafficExcludedPorts *[]FlowPortFilter `json:"network_traffic_excluded_ports,omitempty"`
 
-	// NetworkTrafficHotRetentionHours How many hours of flow events the hot store keeps, as the
+	// NetworkTrafficHotRetentionSeconds How long the hot store keeps flow events, in seconds, as the
 	// server resolved it from OPENZRO_FLOW_RETENTION. Read-only and
 	// deployment-wide -- it is reported here because this is the
 	// payload the traffic page already waits for, not because it
 	// belongs to the account.
 	//
-	// Anything older than this is answered from the archive: object
-	// storage rather than the database, and seconds rather than
-	// milliseconds. Clients use it to say so before the query runs.
-	NetworkTrafficHotRetentionHours *int `json:"network_traffic_hot_retention_hours,omitempty"`
+	// Seconds rather than a rounded unit on purpose: clients use it
+	// as the boundary itself, and any rounding moves the boundary.
+	// Round for display, never for the comparison.
+	NetworkTrafficHotRetentionSeconds *int `json:"network_traffic_hot_retention_seconds,omitempty"`
 
 	// NetworkTrafficLogsEnabled Enables or disables network traffic logging. If enabled, all network traffic events from peers will be stored.
 	NetworkTrafficLogsEnabled bool `json:"network_traffic_logs_enabled"`

--- a/management/server/http/handler.go
+++ b/management/server/http/handler.go
@@ -38,6 +38,7 @@ import (
 	"github.com/openzro/openzro/management/server/http/handlers/peers"
 
 	flowstore "github.com/openzro/openzro/flow/store"
+	flowFederated "github.com/openzro/openzro/flow/store/federated"
 	flowExports "github.com/openzro/openzro/management/server/flow_exports"
 	"github.com/openzro/openzro/management/server/http/handlers/policies"
 	"github.com/openzro/openzro/management/server/http/handlers/routes"
@@ -134,7 +135,15 @@ func NewAPIHandler(
 		return nil, fmt.Errorf("register integrations endpoints: %w", err)
 	}
 
-	accounts.AddEndpoints(accountManager, settingsManager, router)
+	// The flow store handed in here is the federated one when an archive
+	// is attached, so it is the thing that knows. Asking it beats
+	// threading a second boolean down from wiring, and beats a package
+	// global that nothing owns.
+	archiveReads := false
+	if fed, ok := flowEventsStore.(*flowFederated.Federated); ok {
+		archiveReads = fed.ReadsArchive()
+	}
+	accounts.AddEndpoints(accountManager, settingsManager, archiveReads, router)
 	peers.AddEndpoints(accountManager, postureEvalStore, router)
 	users.AddEndpoints(accountManager, router)
 	mfaHandler.AddEndpoints(accountManager, router)

--- a/management/server/http/handlers/accounts/accounts_handler.go
+++ b/management/server/http/handlers/accounts/accounts_handler.go
@@ -23,20 +23,30 @@ import (
 type handler struct {
 	accountManager  account.Manager
 	settingsManager settings.Manager
+	// archiveReads is deployment state, not account state: whether a
+	// window older than the hot retention is answered from an archive or
+	// simply returns nothing.
+	archiveReads bool
 }
 
-func AddEndpoints(accountManager account.Manager, settingsManager settings.Manager, router *mux.Router) {
-	accountsHandler := newHandler(accountManager, settingsManager)
+// archiveReads says whether this deployment answers windows older than
+// the hot retention from an archive. It rides on the account payload
+// because that is what the traffic page waits for before it queries, and
+// the page needs it to know whether a slow answer is coming or no answer
+// at all.
+func AddEndpoints(accountManager account.Manager, settingsManager settings.Manager, archiveReads bool, router *mux.Router) {
+	accountsHandler := newHandler(accountManager, settingsManager, archiveReads)
 	router.HandleFunc("/accounts/{accountId}", accountsHandler.updateAccount).Methods("PUT", "OPTIONS")
 	router.HandleFunc("/accounts/{accountId}", accountsHandler.deleteAccount).Methods("DELETE", "OPTIONS")
 	router.HandleFunc("/accounts", accountsHandler.getAllAccounts).Methods("GET", "OPTIONS")
 }
 
 // newHandler creates a new handler HTTP handler
-func newHandler(accountManager account.Manager, settingsManager settings.Manager) *handler {
+func newHandler(accountManager account.Manager, settingsManager settings.Manager, archiveReads bool) *handler {
 	return &handler{
 		accountManager:  accountManager,
 		settingsManager: settingsManager,
+		archiveReads:    archiveReads,
 	}
 }
 
@@ -68,7 +78,7 @@ func (h *handler) getAllAccounts(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := toAccountResponse(accountID, settings, meta, onboarding)
+	resp := toAccountResponse(accountID, settings, meta, onboarding, h.archiveReads)
 	util.WriteJSONObject(r.Context(), w, []*api.Account{resp})
 }
 
@@ -261,7 +271,7 @@ func (h *handler) updateAccount(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := toAccountResponse(accountID, updatedSettings, meta, updatedOnboarding)
+	resp := toAccountResponse(accountID, updatedSettings, meta, updatedOnboarding, h.archiveReads)
 
 	util.WriteJSONObject(r.Context(), w, &resp)
 }
@@ -290,7 +300,7 @@ func (h *handler) deleteAccount(w http.ResponseWriter, r *http.Request) {
 	util.WriteJSONObject(r.Context(), w, util.EmptyObject{})
 }
 
-func toAccountResponse(accountID string, settings *types.Settings, meta *types.AccountMeta, onboarding *types.AccountOnboarding) *api.Account {
+func toAccountResponse(accountID string, settings *types.Settings, meta *types.AccountMeta, onboarding *types.AccountOnboarding, archiveReads bool) *api.Account {
 	jwtAllowGroups := settings.JWTAllowGroups
 	if jwtAllowGroups == nil {
 		jwtAllowGroups = []string{}
@@ -382,20 +392,22 @@ func toAccountResponse(accountID string, settings *types.Settings, meta *types.A
 	}
 
 	// Deployment-wide rather than per-account, and reported here because
-	// this is the payload the traffic page already waits for. Adding a
-	// second request to the page's load, or a settings endpoint that
-	// exists to carry one integer, would both cost more than they
-	// explain.
+	// this is the payload the traffic page already waits for. A second
+	// request, or a settings endpoint that exists to carry two fields,
+	// would each cost more than they explain.
 	//
-	// Rounded up: a window that reaches even one minute past the
-	// boundary is answered from the archive, so a client that rounded
-	// down would stay quiet about exactly the queries worth warning
-	// about.
-	hours := int((flowfactory.HotRetention() + time.Hour - 1) / time.Hour)
+	// Seconds, exactly, and not a rounded unit. The client uses this as
+	// the boundary itself, so any rounding moves the boundary: rounding
+	// up pushes it further into the past and leaves the client silent
+	// about the window between the real boundary and the rounded one --
+	// which is precisely the window worth warning about. Round for
+	// display, never for the comparison.
+	seconds := int(flowfactory.HotRetention() / time.Second)
 	if apiSettings.Extra == nil {
 		apiSettings.Extra = &api.AccountExtraSettings{}
 	}
-	apiSettings.Extra.NetworkTrafficHotRetentionHours = &hours
+	apiSettings.Extra.NetworkTrafficHotRetentionSeconds = &seconds
+	apiSettings.Extra.NetworkTrafficArchiveReadsEnabled = &archiveReads
 
 	return &api.Account{
 		Id:             accountID,

--- a/management/server/http/handlers/accounts/accounts_handler.go
+++ b/management/server/http/handlers/accounts/accounts_handler.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"time"
 
+	flowfactory "github.com/openzro/openzro/flow/store/factory"
+
 	"github.com/gorilla/mux"
 
 	"github.com/openzro/openzro/management/server/account"
@@ -378,6 +380,22 @@ func toAccountResponse(accountID string, settings *types.Settings, meta *types.A
 			apiSettings.Extra.NetworkTrafficDefaultRange = &r
 		}
 	}
+
+	// Deployment-wide rather than per-account, and reported here because
+	// this is the payload the traffic page already waits for. Adding a
+	// second request to the page's load, or a settings endpoint that
+	// exists to carry one integer, would both cost more than they
+	// explain.
+	//
+	// Rounded up: a window that reaches even one minute past the
+	// boundary is answered from the archive, so a client that rounded
+	// down would stay quiet about exactly the queries worth warning
+	// about.
+	hours := int((flowfactory.HotRetention() + time.Hour - 1) / time.Hour)
+	if apiSettings.Extra == nil {
+		apiSettings.Extra = &api.AccountExtraSettings{}
+	}
+	apiSettings.Extra.NetworkTrafficHotRetentionHours = &hours
 
 	return &api.Account{
 		Id:             accountID,

--- a/management/server/http/handlers/accounts/accounts_handler_test.go
+++ b/management/server/http/handlers/accounts/accounts_handler_test.go
@@ -339,15 +339,19 @@ func TestAccounts_AccountsHandler(t *testing.T) {
 
 			assert.Equal(t, tc.expectedID, actual.Id)
 
-			// The hot-retention hours are deployment information
-			// reported on every account, not settings belonging to one,
-			// so they are checked once and taken out before comparing
-			// what these cases are actually about. Leaving them in would
-			// mean five identical copies of the same expectation.
+			// The retention and the archive flag are deployment
+			// information reported on every account, not settings
+			// belonging to one, so they are checked once and taken out
+			// before comparing what these cases are actually about.
+			// Leaving them in would mean five identical copies of the
+			// same expectation.
 			require.NotNil(t, actual.Settings.Extra)
-			require.NotNil(t, actual.Settings.Extra.NetworkTrafficHotRetentionHours,
+			require.NotNil(t, actual.Settings.Extra.NetworkTrafficHotRetentionSeconds,
 				"every account reports the boundary; the traffic page needs it before it queries")
-			actual.Settings.Extra.NetworkTrafficHotRetentionHours = nil
+			require.NotNil(t, actual.Settings.Extra.NetworkTrafficArchiveReadsEnabled,
+				"and whether a window past that boundary is answered at all")
+			actual.Settings.Extra.NetworkTrafficHotRetentionSeconds = nil
+			actual.Settings.Extra.NetworkTrafficArchiveReadsEnabled = nil
 			if reflect.DeepEqual(*actual.Settings.Extra, api.AccountExtraSettings{}) {
 				actual.Settings.Extra = nil
 			}

--- a/management/server/http/handlers/accounts/accounts_handler_test.go
+++ b/management/server/http/handlers/accounts/accounts_handler_test.go
@@ -7,6 +7,9 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
+
+	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 
@@ -335,6 +338,20 @@ func TestAccounts_AccountsHandler(t *testing.T) {
 			}
 
 			assert.Equal(t, tc.expectedID, actual.Id)
+
+			// The hot-retention hours are deployment information
+			// reported on every account, not settings belonging to one,
+			// so they are checked once and taken out before comparing
+			// what these cases are actually about. Leaving them in would
+			// mean five identical copies of the same expectation.
+			require.NotNil(t, actual.Settings.Extra)
+			require.NotNil(t, actual.Settings.Extra.NetworkTrafficHotRetentionHours,
+				"every account reports the boundary; the traffic page needs it before it queries")
+			actual.Settings.Extra.NetworkTrafficHotRetentionHours = nil
+			if reflect.DeepEqual(*actual.Settings.Extra, api.AccountExtraSettings{}) {
+				actual.Settings.Extra = nil
+			}
+
 			assert.Equal(t, tc.expectedSettings, actual.Settings)
 		})
 	}

--- a/management/server/http/handlers/accounts/retention_test.go
+++ b/management/server/http/handlers/accounts/retention_test.go
@@ -17,21 +17,37 @@ import (
 func TestAccountReportsHotRetention(t *testing.T) {
 	t.Setenv("OPENZRO_FLOW_RETENTION", "720h")
 
-	got := toAccountResponse("acct-1", &types.Settings{}, &types.AccountMeta{}, &types.AccountOnboarding{})
+	got := toAccountResponse("acct-1", &types.Settings{}, &types.AccountMeta{}, &types.AccountOnboarding{}, true)
 	require.NotNil(t, got.Settings.Extra)
-	require.NotNil(t, got.Settings.Extra.NetworkTrafficHotRetentionHours)
-	require.Equal(t, 720, *got.Settings.Extra.NetworkTrafficHotRetentionHours)
+	require.NotNil(t, got.Settings.Extra.NetworkTrafficHotRetentionSeconds)
+	require.Equal(t, 720*3600, *got.Settings.Extra.NetworkTrafficHotRetentionSeconds)
 }
 
-// Rounded up, deliberately. A window reaching even a minute past the
-// boundary is answered from the archive, so rounding down would leave
-// the client quiet about a query that is about to take seconds.
-func TestAccountRoundsRetentionUp(t *testing.T) {
+// Reported exactly, and this is the whole reason the field is seconds.
+//
+// The client uses this as the boundary itself. An earlier version
+// reported hours rounded up, which pushed the boundary further into the
+// past: a 90-minute retention was published as 2h, and a query starting
+// 100 minutes ago reached the archive on the server while the page,
+// comparing against 2h, said nothing. Silent in exactly the window worth
+// warning about.
+func TestAccountReportsRetentionExactly(t *testing.T) {
 	t.Setenv("OPENZRO_FLOW_RETENTION", "90m")
 
-	got := toAccountResponse("acct-1", &types.Settings{}, &types.AccountMeta{}, &types.AccountOnboarding{})
-	require.Equal(t, 2, *got.Settings.Extra.NetworkTrafficHotRetentionHours,
-		"90 minutes is two hours' worth of boundary, not one")
+	got := toAccountResponse("acct-1", &types.Settings{}, &types.AccountMeta{}, &types.AccountOnboarding{}, true)
+	require.Equal(t, 5400, *got.Settings.Extra.NetworkTrafficHotRetentionSeconds,
+		"the boundary must not be rounded; rounding it moves it")
+}
+
+// A deployment with no archive answers a window past the boundary with
+// nothing, not slowly. Promising a wait there describes a tier the
+// operator does not run.
+func TestAccountReportsWhetherArchiveReadsAreEnabled(t *testing.T) {
+	on := toAccountResponse("a", &types.Settings{}, &types.AccountMeta{}, &types.AccountOnboarding{}, true)
+	require.True(t, *on.Settings.Extra.NetworkTrafficArchiveReadsEnabled)
+
+	off := toAccountResponse("a", &types.Settings{}, &types.AccountMeta{}, &types.AccountOnboarding{}, false)
+	require.False(t, *off.Settings.Extra.NetworkTrafficArchiveReadsEnabled)
 }
 
 // An unset variable has to report the server's own default rather than
@@ -39,6 +55,6 @@ func TestAccountRoundsRetentionUp(t *testing.T) {
 func TestAccountReportsDefaultRetention(t *testing.T) {
 	t.Setenv("OPENZRO_FLOW_RETENTION", "")
 
-	got := toAccountResponse("acct-1", &types.Settings{}, &types.AccountMeta{}, &types.AccountOnboarding{})
-	require.Equal(t, int((7*24*time.Hour)/time.Hour), *got.Settings.Extra.NetworkTrafficHotRetentionHours)
+	got := toAccountResponse("acct-1", &types.Settings{}, &types.AccountMeta{}, &types.AccountOnboarding{}, true)
+	require.Equal(t, int((7*24*time.Hour)/time.Second), *got.Settings.Extra.NetworkTrafficHotRetentionSeconds)
 }

--- a/management/server/http/handlers/accounts/retention_test.go
+++ b/management/server/http/handlers/accounts/retention_test.go
@@ -1,0 +1,44 @@
+package accounts
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openzro/openzro/management/server/types"
+)
+
+// The traffic page needs the boundary before it asks a question, not
+// after, so it rides along on the payload that page already waits for.
+// If this stops being reported the page goes quiet about exactly the
+// queries worth warning about -- silently, because a missing field and
+// an all-hot window look the same to the client.
+func TestAccountReportsHotRetention(t *testing.T) {
+	t.Setenv("OPENZRO_FLOW_RETENTION", "720h")
+
+	got := toAccountResponse("acct-1", &types.Settings{}, &types.AccountMeta{}, &types.AccountOnboarding{})
+	require.NotNil(t, got.Settings.Extra)
+	require.NotNil(t, got.Settings.Extra.NetworkTrafficHotRetentionHours)
+	require.Equal(t, 720, *got.Settings.Extra.NetworkTrafficHotRetentionHours)
+}
+
+// Rounded up, deliberately. A window reaching even a minute past the
+// boundary is answered from the archive, so rounding down would leave
+// the client quiet about a query that is about to take seconds.
+func TestAccountRoundsRetentionUp(t *testing.T) {
+	t.Setenv("OPENZRO_FLOW_RETENTION", "90m")
+
+	got := toAccountResponse("acct-1", &types.Settings{}, &types.AccountMeta{}, &types.AccountOnboarding{})
+	require.Equal(t, 2, *got.Settings.Extra.NetworkTrafficHotRetentionHours,
+		"90 minutes is two hours' worth of boundary, not one")
+}
+
+// An unset variable has to report the server's own default rather than
+// nothing, or the client cannot tell "no archive" from "no answer".
+func TestAccountReportsDefaultRetention(t *testing.T) {
+	t.Setenv("OPENZRO_FLOW_RETENTION", "")
+
+	got := toAccountResponse("acct-1", &types.Settings{}, &types.AccountMeta{}, &types.AccountOnboarding{})
+	require.Equal(t, int((7*24*time.Hour)/time.Hour), *got.Settings.Extra.NetworkTrafficHotRetentionHours)
+}


### PR DESCRIPTION
## Why

Measured on the production archive, same question, three states:

| | |
| --- | --- |
| hot (last 30 days) | **0.2s** |
| archive, uncompacted | 28s |
| archive, compacted | 7–9s |

Compaction closed most of that gap and will not close the rest: the cost is round trips to object storage, not rows. That is what the two tiers *are*, so the honest thing is to say so before the wait rather than during it.

## The design constraint that shapes everything

The warning has to come from the **selected range**, not from the response. A flag carried back with the answer arrives exactly too late to set an expectation.

Which means the page must know where the boundary is *before* it asks — and it did not. `OPENZRO_FLOW_RETENTION` lived only in the server's environment.

## Where the boundary is reported, and why there

On `/accounts`, as `network_traffic_hot_retention_hours`.

Deployment-wide rather than per-account, and reported there because **that is the payload this page already waits for** since the range-hold fix in #188. A second request, or a settings endpoint that exists to carry one integer, would each cost more than they explain.

**Rounded up**, and the direction is load-bearing: a window reaching one minute past the boundary is answered from the archive, so rounding down would leave the page quiet about exactly the queries worth warning about. Pinned by a test.

## Kept separate from `incomplete`

They say different things — this one is *"this will be slow"*, the other is *"part of this is missing"* — and an operator seeing both should be able to tell them apart. Different card, different tone, no shared state.

## Tests

| mutation | fails |
| --- | --- |
| stop reporting the retention | `AccountReportsHotRetention`, `AccountsHandler` |
| round the retention down | `AccountRoundsRetentionUp` |

The five existing settings cases compare the whole `api.AccountSettings`. Rather than paste the same expectation into all five, the retention is asserted once at the comparison point and removed before it — so those cases stay about what they were written to test.

## Note

This should be the first PR to exercise #194: it touches only `dashboard/`, `management/` and `flow/`, so the Go matrix still runs. A dashboard-only follow-up would be the real demonstration.